### PR TITLE
CommentForm now handles different api responses

### DIFF
--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -3,7 +3,8 @@ import {
   DiscussionResponse,
   DiscussionOptions,
   UserProfile,
-  CommentType
+  CommentType,
+  CommentResponse
 } from "../types";
 
 const baseURL = "https://discussion.code.dev-theguardian.com/discussion-api";
@@ -63,7 +64,7 @@ const getProfile = (): Promise<UserProfile> => {
     .catch(error => console.error(`Error fetching ${url}`, error));
 };
 
-const comment = (shortUrl: string, body: string): Promise<string> => {
+const comment = (shortUrl: string, body: string): Promise<CommentResponse> => {
   const url = baseURL + `/discussion/${shortUrl}/comment`;
   const data = new URLSearchParams();
   data.append("body", body);
@@ -77,7 +78,7 @@ const comment = (shortUrl: string, body: string): Promise<string> => {
     credentials: "include"
   })
     .then(resp => resp.json())
-    .then(json => json.message);
+    .then(json => json);
 };
 
 const reply = (

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -32,6 +32,13 @@ export interface CommentType {
   };
 }
 
+export type CommentResponse = {
+  status: "ok" | "error";
+  statusCode: number;
+  message: string;
+  errorCode?: string;
+};
+
 export type OrderByType = "newest" | "oldest" | "mostrecommended";
 export type ThreadsType = "collapsed" | "expanded" | "unthreaded";
 


### PR DESCRIPTION
- Change response sent back for `comment()` to allow logic based on response type
- Added error handling to `CommentForm`
- Added `firstPost` state to `CommentForm` (still needs more integration to allow the state to be reset)