### PR TITLE
Periodically update when the comment was made

### DIFF
--- a/src/components/Timestamp/Timestamp.tsx
+++ b/src/components/Timestamp/Timestamp.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { css } from "emotion";
 
 import { textSans } from "@guardian/src-foundations/typography";
@@ -6,6 +6,7 @@ import { palette } from "@guardian/src-foundations";
 import { DateFromISOStringC } from "io-ts-types/lib/DateFromISOString";
 
 import { dateFormatter } from "../../lib/dateFormatter";
+import { useInterval } from "../../lib/useInterval";
 
 type Props = {
   isoDateTime: DateFromISOStringC;
@@ -26,12 +27,17 @@ const timeStyles = css`
   margin-right: 0.3125rem;
 `;
 
-// TODO: on hover + link
 export const Timestamp = ({ isoDateTime, linkTo }: Props) => {
+  let [timeAgo, setTimeAgo] = useState(dateFormatter(isoDateTime));
+
+  useInterval(() => {
+    setTimeAgo(dateFormatter(isoDateTime));
+  }, 15000);
+
   return (
     <a href={linkTo} className={linkStyles}>
       <time dateTime={isoDateTime.toString()} className={timeStyles}>
-        {dateFormatter(isoDateTime)}
+        {timeAgo}
       </time>
     </a>
   );

--- a/src/lib/useInterval.js
+++ b/src/lib/useInterval.js
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from "react";
+
+// Why do we have this custom hook?
+// https://overreacted.io/making-setinterval-declarative-with-react-hooks/
+export const useInterval = (callback, delay) => {
+  const savedCallback = useRef();
+
+  // Remember the latest callback.
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  // Set up the interval.
+  useEffect(() => {
+    function tick() {
+      savedCallback.current();
+    }
+    if (delay !== null) {
+      let id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+  }, [delay]);
+};


### PR DESCRIPTION
We don't want reader to have to refresh the page or list of comments to see an accurate time when each comment was made so here we add an interval to dynamically update this value

`useInterval`? Seems weird. Read [this](https://overreacted.io/making-setinterval-declarative-with-react-hooks/) for more information

![2020-02-25 14 42 01](https://user-images.githubusercontent.com/1336821/75257549-0a467500-57dd-11ea-8d2c-e5e91b37a653.gif)

We're using a 15 second interval. We could perhaps look at the optimisation of making this dynamic relative to how old the comment is