### PR TITLE
Persist filters to local storage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,14 +24,63 @@ const footerStyles = css`
   justify-content: flex-end;
 `;
 
+const DEFAULT_FILTERS: FilterOptions = {
+  orderBy: "newest",
+  pageSize: 25,
+  threads: "collapsed",
+  page: 1
+};
+
+const rememberFilters = (filtersToRemember: FilterOptions) => {
+  try {
+    localStorage.setItem(
+      "gu.prefs.discussioni.threading",
+      JSON.stringify({ value: filtersToRemember.threads })
+    );
+    localStorage.setItem(
+      "gu.prefs.discussioni.pagesize",
+      JSON.stringify({ value: filtersToRemember.pageSize })
+    );
+    localStorage.setItem(
+      "gu.prefs.discussioni.order",
+      JSON.stringify({ value: filtersToRemember.orderBy })
+    );
+  } catch (error) {
+    // Sometimes it's not possible to access localStorage, we accept this and don't want to
+    // capture these errors
+  }
+};
+
+const readFiltersFromLocalStorage = (): FilterOptions => {
+  let threads;
+  let pageSize;
+  let orderBy;
+
+  try {
+    // Try to read from local storage
+    orderBy = localStorage.getItem("gu.prefs.discussioni.order");
+    threads = localStorage.getItem("gu.prefs.discussioni.threading");
+    pageSize = localStorage.getItem("gu.prefs.discussioni.pagesize");
+  } catch (error) {
+    // Sometimes it's not possible to access localStorage, we accept this and don't want to
+    // capture these errors
+    return DEFAULT_FILTERS;
+  }
+
+  // If we found something in LS, use it, otherwise return defaults
+  return {
+    orderBy: orderBy ? JSON.parse(orderBy).value : DEFAULT_FILTERS.orderBy,
+    threads: threads ? JSON.parse(threads).value : DEFAULT_FILTERS.threads,
+    pageSize: pageSize ? JSON.parse(pageSize).value : DEFAULT_FILTERS.pageSize,
+    page: DEFAULT_FILTERS.page
+  };
+};
+
 export const App = ({ shortUrl, user }: Props) => {
   const [comments, setComments] = useState<CommentType[]>([]);
-  const [filters, setFilters] = useState<FilterOptions>({
-    orderBy: "newest",
-    pageSize: 25,
-    threads: "unthreaded",
-    page: 1
-  });
+  const [filters, setFilters] = useState<FilterOptions>(
+    readFiltersFromLocalStorage()
+  );
   const [commentCount, setCommentCount] = useState<number>(0);
   const [loading, setLoading] = useState<boolean>(true);
   const [pages, setPages] = useState<number>(0);
@@ -80,8 +129,8 @@ export const App = ({ shortUrl, user }: Props) => {
     setLoading(true);
     getDiscussion(shortUrl, filters).then(json => {
       setLoading(false);
-      setComments(json.discussion.comments);
-      setPages(json.pages);
+      setComments(json?.discussion?.comments);
+      setPages(json?.pages);
     });
   }, [filters, shortUrl]);
 
@@ -89,9 +138,14 @@ export const App = ({ shortUrl, user }: Props) => {
     setLoading(true);
     getCommentCount(shortUrl).then(json => {
       setLoading(false);
-      setCommentCount(json.numberOfComments);
+      setCommentCount(json?.numberOfComments);
     });
   }, [shortUrl]);
+
+  const onFilterChange = (newFilterObject: FilterOptions) => {
+    rememberFilters(newFilterObject);
+    setFilters(newFilterObject);
+  };
 
   return (
     <div className={containerStyles}>
@@ -101,7 +155,7 @@ export const App = ({ shortUrl, user }: Props) => {
       <TopPicks shortUrl={shortUrl} />
       <Filters
         filters={filters}
-        setFilters={setFilters}
+        onFilterChange={onFilterChange}
         pages={pages}
         commentCount={commentCount}
       />

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -10,7 +10,7 @@ import { FilterOptions, OrderByType, ThreadsType } from "../../types";
 
 type Props = {
   filters: FilterOptions;
-  setFilters: (newFilterObject: FilterOptions) => void;
+  onFilterChange: (newFilterObject: FilterOptions) => void;
   pages: number;
   commentCount: number;
 };
@@ -70,7 +70,7 @@ const filterWrapperStyles = css`
 
 export const Filters = ({
   filters,
-  setFilters,
+  onFilterChange,
   pages,
   commentCount
 }: Props) => (
@@ -95,7 +95,7 @@ export const Filters = ({
           id="orderBy"
           className={filterStyle}
           onChange={e =>
-            setFilters({
+            onFilterChange({
               ...filters,
               orderBy: e.target.value as OrderByType
             })
@@ -117,7 +117,7 @@ export const Filters = ({
           id="pageSize"
           className={filterStyle}
           onChange={e =>
-            setFilters({
+            onFilterChange({
               ...filters,
               pageSize: Number(e.target.value) as number
             })
@@ -139,7 +139,7 @@ export const Filters = ({
           id="threads"
           className={filterStyle}
           onChange={e =>
-            setFilters({
+            onFilterChange({
               ...filters,
               threads: e.target.value as ThreadsType
             })
@@ -157,7 +157,7 @@ export const Filters = ({
         pages={pages}
         page={filters.page}
         setPage={(page: number) => {
-          setFilters({
+          onFilterChange({
             ...filters,
             page
           });


### PR DESCRIPTION
### What
This change ensures that the reader's filter settings are persisted to localStorage

### Why
So that next time they visit we will remember the settings they had before

### Trello
https://trello.com/c/1bes5LGl/1215-remember-filters