### PR TITLE
Enhance pagination to always show the last page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,7 +83,7 @@ export const App = ({ shortUrl, user }: Props) => {
   );
   const [commentCount, setCommentCount] = useState<number>(0);
   const [loading, setLoading] = useState<boolean>(true);
-  const [pages, setPages] = useState<number>(0);
+  const [totalPages, setTotalPages] = useState<number>(0);
 
   const simulateNewComment = (
     commentId: number,
@@ -130,7 +130,7 @@ export const App = ({ shortUrl, user }: Props) => {
     getDiscussion(shortUrl, filters).then(json => {
       setLoading(false);
       setComments(json?.discussion?.comments);
-      setPages(json?.pages);
+      setTotalPages(json?.pages);
     });
   }, [filters, shortUrl]);
 
@@ -156,7 +156,7 @@ export const App = ({ shortUrl, user }: Props) => {
       <Filters
         filters={filters}
         onFilterChange={onFilterChange}
-        pages={pages}
+        totalPages={totalPages}
         commentCount={commentCount}
       />
       {loading ? (
@@ -166,7 +166,7 @@ export const App = ({ shortUrl, user }: Props) => {
       )}
       <footer className={footerStyles}>
         <Pagination
-          pages={pages}
+          totalPages={totalPages}
           page={filters.page}
           setPage={(page: number) => {
             setFilters({

--- a/src/components/Filters/Filters.stories.tsx
+++ b/src/components/Filters/Filters.stories.tsx
@@ -16,8 +16,8 @@ export const Default = () => {
   return (
     <Filters
       filters={filters}
-      setFilters={setFilters}
-      pages={5}
+      onFilterChange={setFilters}
+      totalPages={5}
       commentCount={250}
     />
   );

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -11,7 +11,7 @@ import { FilterOptions, OrderByType, ThreadsType } from "../../types";
 type Props = {
   filters: FilterOptions;
   onFilterChange: (newFilterObject: FilterOptions) => void;
-  pages: number;
+  totalPages: number;
   commentCount: number;
 };
 
@@ -71,7 +71,7 @@ const filterWrapperStyles = css`
 export const Filters = ({
   filters,
   onFilterChange,
-  pages,
+  totalPages,
   commentCount
 }: Props) => (
   <div className={filterBar}>
@@ -152,9 +152,9 @@ export const Filters = ({
         </select>
       </div>
     </div>
-    {pages > 1 && (
+    {totalPages > 1 && (
       <Pagination
-        pages={pages}
+        totalPages={totalPages}
         page={filters.page}
         setPage={(page: number) => {
           onFilterChange({

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -1,21 +1,55 @@
 import React, { useState } from "react";
 import { Pagination } from "./Pagination";
 
+import { FilterOptions } from "../../types";
+
 export default { component: Pagination, title: "Pagination" };
+
+const DEFAULT_FILTERS: FilterOptions = {
+  orderBy: "newest",
+  pageSize: 25,
+  threads: "collapsed",
+  page: 1
+};
 
 export const Default = () => {
   const [page, setPage] = useState(1);
-  return <Pagination pages={9} page={page} setPage={setPage} />;
+  return (
+    <Pagination
+      pages={9}
+      page={page}
+      setPage={setPage}
+      filters={DEFAULT_FILTERS}
+      commentCount={200}
+    />
+  );
 };
 Default.story = { name: "default" };
 
 export const NoPages = () => {
-  return <Pagination pages={0} page={0} setPage={() => {}} />;
+  const [page, setPage] = useState(1);
+  return (
+    <Pagination
+      pages={2}
+      page={page}
+      setPage={setPage}
+      filters={DEFAULT_FILTERS}
+      commentCount={56}
+    />
+  );
 };
-NoPages.story = { name: "with zero pages" };
+NoPages.story = { name: "with two pages" };
 
 export const LotsOfPages = () => {
   const [page, setPage] = useState(1);
-  return <Pagination pages={187} page={page} setPage={setPage} />;
+  return (
+    <Pagination
+      pages={187}
+      page={page}
+      setPage={setPage}
+      filters={DEFAULT_FILTERS}
+      commentCount={490000}
+    />
+  );
 };
 LotsOfPages.story = { name: "with many pages" };

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -16,7 +16,7 @@ export const Default = () => {
   const [page, setPage] = useState(1);
   return (
     <Pagination
-      pages={9}
+      totalPages={9}
       page={page}
       setPage={setPage}
       filters={DEFAULT_FILTERS}
@@ -30,7 +30,7 @@ export const NoPages = () => {
   const [page, setPage] = useState(1);
   return (
     <Pagination
-      pages={2}
+      totalPages={2}
       page={page}
       setPage={setPage}
       filters={DEFAULT_FILTERS}
@@ -44,7 +44,7 @@ export const LotsOfPages = () => {
   const [page, setPage] = useState(1);
   return (
     <Pagination
-      pages={187}
+      totalPages={187}
       page={page}
       setPage={setPage}
       filters={DEFAULT_FILTERS}

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -178,7 +178,9 @@ export const Pagination = ({
   const secondPage = decideSecondPage({ page, pages });
   const thirdPage = decideThirdPage({ page, pages });
   const forthPage = decideForthPage({ page, pages });
-  const showLastPage = page === pages - 2;
+  const showThirdPage = pages > 2;
+  const showForthPage = pages > 3;
+  const showLastPage = page < pages - 1;
   const lastPage = pages;
   const showSecondElipsis = pages > 4 && page < pages - 2;
   const showForwardButton = pages > 4 && page !== pages;
@@ -201,16 +203,21 @@ export const Pagination = ({
           setPage={setPage}
           selected={page === secondPage}
         />
-        <PageButton
-          page={thirdPage}
-          setPage={setPage}
-          selected={page === thirdPage}
-        />
-        <PageButton
-          page={forthPage}
-          setPage={setPage}
-          selected={page === forthPage}
-        />
+        {showThirdPage && (
+          <PageButton
+            page={thirdPage}
+            setPage={setPage}
+            selected={page === thirdPage}
+          />
+        )}
+        {showForthPage && (
+          <PageButton
+            page={forthPage}
+            setPage={setPage}
+            selected={page === forthPage}
+          />
+        )}
+        {showSecondElipsis && <div className={elipsisStyles}>...</div>}
         {showLastPage && (
           <PageButton
             page={lastPage}
@@ -218,7 +225,6 @@ export const Pagination = ({
             selected={page === lastPage}
           />
         )}
-        {showSecondElipsis && <div className={elipsisStyles}>...</div>}
         {showForwardButton && <Forward page={page} setPage={setPage} />}
       </div>
       {commentCount && (

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -15,7 +15,7 @@ type Props = {
   filters: FilterOptions;
 };
 
-const buttonStyles = (selected: boolean) => css`
+const buttonStyles = (isSelected: boolean) => css`
   cursor: pointer;
   ${textSans.small({ fontWeight: "bold" })}
 
@@ -23,8 +23,8 @@ const buttonStyles = (selected: boolean) => css`
   border-radius: 62.5rem;
   box-sizing: border-box;
 
-  color: ${selected ? palette.neutral[100] : palette.neutral[46]};
-  background-color: ${selected ? palette.neutral[46] : palette.neutral[100]};
+  color: ${isSelected ? palette.neutral[100] : palette.neutral[46]};
+  background-color: ${isSelected ? palette.neutral[46] : palette.neutral[100]};
   border: none;
   :hover {
     border-width: 0.0625rem;
@@ -43,13 +43,13 @@ const buttonStyles = (selected: boolean) => css`
   text-overflow: ellipsis;
 `;
 
-const chevronStyles = (selected: boolean) => css`
+const chevronStyles = (isSelected: boolean) => css`
   cursor: pointer;
   border-radius: 62.5rem;
   border-width: 0.0625rem;
   border-style: solid;
   box-sizing: border-box;
-  background-color: ${selected ? palette.neutral[46] : palette.neutral[100]};
+  background-color: ${isSelected ? palette.neutral[46] : palette.neutral[100]};
   border-color: ${palette.neutral[86]};
   :hover {
     border-color: ${palette.neutral[60]};
@@ -59,7 +59,7 @@ const chevronStyles = (selected: boolean) => css`
   margin-left: 5px;
 
   > svg {
-    fill: ${selected ? palette.neutral[100] : palette.neutral[46]};
+    fill: ${isSelected ? palette.neutral[100] : palette.neutral[46]};
   }
 `;
 
@@ -132,15 +132,15 @@ const Back = ({ page, setPage }: { page: number; setPage: Function }) => (
 const PageButton = ({
   page,
   setPage,
-  selected
+  isSelected
 }: {
   page: number;
   setPage: Function;
-  selected: boolean;
+  isSelected: boolean;
 }) => (
   <button
     key={page}
-    className={buttonStyles(selected)}
+    className={buttonStyles(isSelected)}
     onClick={() => setPage(page)}
   >
     {page}
@@ -214,25 +214,25 @@ export const Pagination = ({
     <div className={paginationWrapper}>
       <div className={paginationSelectors}>
         {showBackButton && <Back page={page} setPage={setPage} />}
-        <PageButton page={1} setPage={setPage} selected={page === 1} />
+        <PageButton page={1} setPage={setPage} isSelected={page === 1} />
         {showFirstElipsis && <div className={elipsisStyles}>&hellip;</div>}
         <PageButton
           page={secondPage}
           setPage={setPage}
-          selected={page === secondPage}
+          isSelected={page === secondPage}
         />
         {showThirdPage && (
           <PageButton
             page={thirdPage}
             setPage={setPage}
-            selected={page === thirdPage}
+            isSelected={page === thirdPage}
           />
         )}
         {showForthPage && (
           <PageButton
             page={forthPage}
             setPage={setPage}
-            selected={page === forthPage}
+            isSelected={page === forthPage}
           />
         )}
         {showSecondElipsis && <div className={elipsisStyles}>&hellip;</div>}
@@ -240,7 +240,7 @@ export const Pagination = ({
           <PageButton
             page={lastPage}
             setPage={setPage}
-            selected={page === lastPage}
+            isSelected={page === lastPage}
           />
         )}
         {showForwardButton && <Forward page={page} setPage={setPage} />}

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -8,7 +8,7 @@ import { until } from "@guardian/src-foundations/mq";
 import { FilterOptions } from "../../types";
 
 type Props = {
-  pages: number;
+  totalPages: number;
   page: number;
   setPage: Function;
   commentCount: number;
@@ -147,43 +147,61 @@ const PageButton = ({
   </button>
 );
 
-const decideSecondPage = ({ page, pages }: { page: number; pages: number }) => {
+const decideSecondPage = ({
+  page,
+  totalPages
+}: {
+  page: number;
+  totalPages: number;
+}) => {
   if (page < 4) return 2;
-  if (page > pages - 2) return pages - 2;
+  if (page > totalPages - 2) return totalPages - 2;
   return page - 1;
 };
 
-const decideThirdPage = ({ page, pages }: { page: number; pages: number }) => {
+const decideThirdPage = ({
+  page,
+  totalPages
+}: {
+  page: number;
+  totalPages: number;
+}) => {
   if (page < 4) return 3;
-  if (page > pages - 2) return pages - 1;
+  if (page > totalPages - 2) return totalPages - 1;
   return page;
 };
 
-const decideForthPage = ({ page, pages }: { page: number; pages: number }) => {
+const decideForthPage = ({
+  page,
+  totalPages
+}: {
+  page: number;
+  totalPages: number;
+}) => {
   if (page < 4) return 4;
-  if (page > pages - 2) return pages;
+  if (page > totalPages - 2) return totalPages;
   return page + 1;
 };
 
 export const Pagination = ({
-  pages,
+  totalPages,
   page,
   setPage,
   commentCount,
   filters
 }: Props) => {
   // Make decisions aobut which pagination elements to show
-  const showBackButton = pages > 4 && page > 1;
-  const showFirstElipsis = pages > 4 && page > 3;
-  const secondPage = decideSecondPage({ page, pages });
-  const thirdPage = decideThirdPage({ page, pages });
-  const forthPage = decideForthPage({ page, pages });
-  const showThirdPage = pages > 2;
-  const showForthPage = pages > 3;
-  const showLastPage = page < pages - 1;
-  const lastPage = pages;
-  const showSecondElipsis = pages > 4 && page < pages - 2;
-  const showForwardButton = pages > 4 && page !== pages;
+  const showBackButton = totalPages > 4 && page > 1;
+  const showFirstElipsis = totalPages > 4 && page > 3;
+  const secondPage = decideSecondPage({ page, totalPages });
+  const thirdPage = decideThirdPage({ page, totalPages });
+  const forthPage = decideForthPage({ page, totalPages });
+  const showThirdPage = totalPages > 2;
+  const showForthPage = totalPages > 3;
+  const showLastPage = page < totalPages - 1;
+  const lastPage = totalPages;
+  const showSecondElipsis = totalPages > 4 && page < totalPages - 2;
+  const showForwardButton = totalPages > 4 && page !== totalPages;
 
   // Pagination Text
   const startIndex = filters.pageSize * (filters.page - 1);

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -197,7 +197,7 @@ export const Pagination = ({
       <div className={paginationSelectors}>
         {showBackButton && <Back page={page} setPage={setPage} />}
         <PageButton page={1} setPage={setPage} selected={page === 1} />
-        {showFirstElipsis && <div className={elipsisStyles}>...</div>}
+        {showFirstElipsis && <div className={elipsisStyles}>&hellip;</div>}
         <PageButton
           page={secondPage}
           setPage={setPage}
@@ -217,7 +217,7 @@ export const Pagination = ({
             selected={page === forthPage}
           />
         )}
-        {showSecondElipsis && <div className={elipsisStyles}>...</div>}
+        {showSecondElipsis && <div className={elipsisStyles}>&hellip;</div>}
         {showLastPage && (
           <PageButton
             page={lastPage}

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -9,8 +9,8 @@ import { FilterOptions } from "../../types";
 
 type Props = {
   totalPages: number;
-  page: number;
-  setPage: Function;
+  currentPage: number;
+  setCurrentPage: Function;
   commentCount: number;
   filters: FilterOptions;
 };
@@ -109,99 +109,111 @@ const ChevronBack = () => (
   </svg>
 );
 
-const Forward = ({ page, setPage }: { page: number; setPage: Function }) => (
+const Forward = ({
+  currentPage,
+  setCurrentPage
+}: {
+  currentPage: number;
+  setCurrentPage: Function;
+}) => (
   <button
     key={"last"}
     className={cx(chevronStyles(false), rotateSvg)}
-    onClick={() => setPage(page + 1)}
+    onClick={() => setCurrentPage(currentPage + 1)}
   >
     <ChevronBack />
   </button>
 );
 
-const Back = ({ page, setPage }: { page: number; setPage: Function }) => (
+const Back = ({
+  currentPage,
+  setCurrentPage
+}: {
+  currentPage: number;
+  setCurrentPage: Function;
+}) => (
   <button
     key={"last"}
     className={chevronStyles(false)}
-    onClick={() => setPage(page - 1 < 0 ? 0 : page - 1)}
+    onClick={() => setCurrentPage(currentPage - 1 < 0 ? 0 : currentPage - 1)}
   >
     <ChevronBack />
   </button>
 );
 
 const PageButton = ({
-  page,
-  setPage,
+  currentPage,
+  setCurrentPage,
   isSelected
 }: {
-  page: number;
-  setPage: Function;
+  currentPage: number;
+  setCurrentPage: Function;
   isSelected: boolean;
 }) => (
   <button
-    key={page}
+    key={currentPage}
     className={buttonStyles(isSelected)}
-    onClick={() => setPage(page)}
+    onClick={() => setCurrentPage(currentPage)}
   >
-    {page}
+    {currentPage}
   </button>
 );
 
 const decideSecondPage = ({
-  page,
+  currentPage,
   totalPages
 }: {
-  page: number;
+  currentPage: number;
   totalPages: number;
 }) => {
-  if (page < 4) return 2;
-  if (page > totalPages - 2) return totalPages - 2;
-  return page - 1;
+  if (currentPage < 4) return 2;
+  if (currentPage > totalPages - 2) return totalPages - 2;
+  return currentPage - 1;
 };
 
 const decideThirdPage = ({
-  page,
+  currentPage,
   totalPages
 }: {
-  page: number;
+  currentPage: number;
   totalPages: number;
 }) => {
-  if (page < 4) return 3;
-  if (page > totalPages - 2) return totalPages - 1;
-  return page;
+  if (currentPage < 4) return 3;
+  if (currentPage > totalPages - 2) return totalPages - 1;
+  return currentPage;
 };
 
 const decideForthPage = ({
-  page,
+  currentPage,
   totalPages
 }: {
-  page: number;
+  currentPage: number;
   totalPages: number;
 }) => {
-  if (page < 4) return 4;
-  if (page > totalPages - 2) return totalPages;
-  return page + 1;
+  if (currentPage < 4) return 4;
+  if (currentPage > totalPages - 2) return totalPages;
+  return currentPage + 1;
 };
 
 export const Pagination = ({
   totalPages,
-  page,
-  setPage,
+  currentPage,
+  setCurrentPage,
   commentCount,
   filters
 }: Props) => {
   // Make decisions aobut which pagination elements to show
-  const showBackButton = totalPages > 4 && page > 1;
-  const showFirstElipsis = totalPages > 4 && page > 3;
-  const secondPage = decideSecondPage({ page, totalPages });
-  const thirdPage = decideThirdPage({ page, totalPages });
-  const forthPage = decideForthPage({ page, totalPages });
+  const showBackButton = totalPages > 4 && currentPage > 1;
+  const showFirstElipsis = totalPages > 4 && currentPage > 3;
+  const secondPage = decideSecondPage({ currentPage, totalPages });
+  const thirdPage = decideThirdPage({ currentPage, totalPages });
+  const forthPage = decideForthPage({ currentPage, totalPages });
   const showThirdPage = totalPages > 2;
   const showForthPage = totalPages > 3;
-  const showLastPage = page < totalPages - 1;
+  const showLastPage = currentPage < totalPages - 1;
   const lastPage = totalPages;
-  const showSecondElipsis = totalPages > 4 && page < totalPages - 2;
-  const showForwardButton = totalPages > 4 && page !== totalPages;
+  const showSecondElipsis = totalPages > 4 && currentPage < totalPages - 2;
+  const showForwardButton = totalPages > 4 && currentPage !== totalPages;
 
   // Pagination Text
   const startIndex = filters.pageSize * (filters.page - 1);
@@ -213,37 +225,45 @@ export const Pagination = ({
   return (
     <div className={paginationWrapper}>
       <div className={paginationSelectors}>
-        {showBackButton && <Back page={page} setPage={setPage} />}
-        <PageButton page={1} setPage={setPage} isSelected={page === 1} />
+        {showBackButton && (
+          <Back currentPage={currentPage} setCurrentPage={setCurrentPage} />
+        )}
+        <PageButton
+          currentPage={1}
+          setCurrentPage={setCurrentPage}
+          isSelected={currentPage === 1}
+        />
         {showFirstElipsis && <div className={elipsisStyles}>&hellip;</div>}
         <PageButton
-          page={secondPage}
-          setPage={setPage}
-          isSelected={page === secondPage}
+          currentPage={secondPage}
+          setCurrentPage={setCurrentPage}
+          isSelected={currentPage === secondPage}
         />
         {showThirdPage && (
           <PageButton
-            page={thirdPage}
-            setPage={setPage}
-            isSelected={page === thirdPage}
+            currentPage={thirdPage}
+            setCurrentPage={setCurrentPage}
+            isSelected={currentPage === thirdPage}
           />
         )}
         {showForthPage && (
           <PageButton
-            page={forthPage}
-            setPage={setPage}
-            isSelected={page === forthPage}
+            currentPage={forthPage}
+            setCurrentPage={setCurrentPage}
+            isSelected={currentPage === forthPage}
           />
         )}
         {showSecondElipsis && <div className={elipsisStyles}>&hellip;</div>}
         {showLastPage && (
           <PageButton
-            page={lastPage}
-            setPage={setPage}
-            isSelected={page === lastPage}
+            currentPage={lastPage}
+            setCurrentPage={setCurrentPage}
+            isSelected={currentPage === lastPage}
           />
         )}
-        {showForwardButton && <Forward page={page} setPage={setPage} />}
+        {showForwardButton && (
+          <Forward currentPage={currentPage} setCurrentPage={setCurrentPage} />
+        )}
       </div>
       {commentCount && (
         <div className={paginationText}>


### PR DESCRIPTION
This one goes out to @paperboyo 

### What
Always show the last page in the pagination control

![Screenshot 2020-02-27 at 13 55 01](https://user-images.githubusercontent.com/1336821/75451987-558d8e80-5969-11ea-9934-8c1d9e7c1b3b.jpg)


### Why?
We already have in context the total number of pages so there's no extra cost to doing this and it helps the reader manage their expectations when navigating

### Why not?
There's an argument to say giving an indication of how many pages lie ahead could put people off?