### PR TITLE
Only show button when the response count is over 3

### DIFF
--- a/src/components/Comment/Comment.stories.tsx
+++ b/src/components/Comment/Comment.stories.tsx
@@ -80,11 +80,15 @@ const commentDataThreaded: CommentType = {
 };
 
 export const defaultStory = () => (
-  <Comment comment={commentData} pillar={"sport"} />
+  <Comment comment={commentData} pillar={"sport"} threads="collapsed" />
 );
 defaultStory.story = { name: "default" };
 
 export const threadedComment = () => (
-  <Comment comment={commentDataThreaded} pillar={"lifestyle"} />
+  <Comment
+    comment={commentDataThreaded}
+    pillar={"lifestyle"}
+    threads="expanded"
+  />
 );
 threadedComment.story = { name: "threaded" };

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -245,20 +245,25 @@ export const Comment = ({ comment, pillar, threads }: Props) => {
           {responses.map(comment => (
             <Comment comment={comment} pillar={pillar} threads={threads} />
           ))}
-          {!expanded && (
-            <button onClick={() => expand(comment.id)} className={buttonStyles}>
-              <Row>
-                <Plus />
-                <span
-                  className={css`
-                    margin-left: 4px;
-                  `}
-                >
-                  {loading ? "loading..." : decideShowMoreText()}
-                </span>
-              </Row>
-            </button>
-          )}
+          {!expanded &&
+            comment.metaData?.responseCount &&
+            comment.metaData?.responseCount > 3 && (
+              <button
+                onClick={() => expand(comment.id)}
+                className={buttonStyles}
+              >
+                <Row>
+                  <Plus />
+                  <span
+                    className={css`
+                      margin-left: 4px;
+                    `}
+                  >
+                    {loading ? "loading..." : decideShowMoreText()}
+                  </span>
+                </Row>
+              </button>
+            )}
         </ul>
       )}
     </li>


### PR DESCRIPTION
We were showing the 'more replies' button when a comment had less than three replies which led to incorrect behaviour.

This PR adds a check to only let the button render when the count of replies is above 3.

It also fixes the stories to include a missing prop