### PR TITLE
Refactor pagination

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -158,6 +158,8 @@ export const App = ({ shortUrl, user }: Props) => {
     setFilters(newFilterObject);
   };
 
+  const showPagination = totalPages > 1;
+
   return (
     <div className={containerStyles}>
       {user && (
@@ -172,8 +174,21 @@ export const App = ({ shortUrl, user }: Props) => {
         filters={filters}
         onFilterChange={onFilterChange}
         totalPages={totalPages}
-        commentCount={commentCount}
       />
+      {showPagination && (
+        <Pagination
+          totalPages={totalPages}
+          currentPage={filters.page}
+          setCurrentPage={(page: number) => {
+            onFilterChange({
+              ...filters,
+              page
+            });
+          }}
+          commentCount={commentCount}
+          filters={filters}
+        />
+      )}
       {loading ? (
         <p>TODO loading component goes here...</p>
       ) : !comments.length ? (
@@ -195,20 +210,22 @@ export const App = ({ shortUrl, user }: Props) => {
           ))}
         </ul>
       )}
-      <footer className={footerStyles}>
-        <Pagination
-          totalPages={totalPages}
-          currentPage={filters.page}
-          setCurrentPage={(page: number) => {
-            setFilters({
-              ...filters,
-              page: page
-            });
-          }}
-          commentCount={commentCount}
-          filters={filters}
-        />
-      </footer>
+      {showPagination && (
+        <footer className={footerStyles}>
+          <Pagination
+            totalPages={totalPages}
+            currentPage={filters.page}
+            setCurrentPage={(page: number) => {
+              setFilters({
+                ...filters,
+                page: page
+              });
+            }}
+            commentCount={commentCount}
+            filters={filters}
+          />
+        </footer>
+      )}
     </div>
   );
 };

--- a/src/components/Filters/Filters.stories.tsx
+++ b/src/components/Filters/Filters.stories.tsx
@@ -14,12 +14,7 @@ export const Default = () => {
     page: 1
   });
   return (
-    <Filters
-      filters={filters}
-      onFilterChange={setFilters}
-      totalPages={5}
-      commentCount={250}
-    />
+    <Filters filters={filters} onFilterChange={setFilters} totalPages={5} />
   );
 };
 Default.story = { name: "default" };

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -5,14 +5,12 @@ import { space, neutral } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
 import { until } from "@guardian/src-foundations/mq";
 
-import { Pagination } from "../Pagination/Pagination";
 import { FilterOptions, OrderByType, ThreadsType } from "../../types";
 
 type Props = {
   filters: FilterOptions;
   onFilterChange: (newFilterObject: FilterOptions) => void;
   totalPages: number;
-  commentCount: number;
 };
 
 const filterBar = css`
@@ -68,12 +66,7 @@ const filterWrapperStyles = css`
   flex-direction: column;
 `;
 
-export const Filters = ({
-  filters,
-  onFilterChange,
-  totalPages,
-  commentCount
-}: Props) => (
+export const Filters = ({ filters, onFilterChange, totalPages }: Props) => (
   <div className={filterBar}>
     <div className={filterContainer}>
       <div className={filterWrapperStyles}>
@@ -152,19 +145,5 @@ export const Filters = ({
         </select>
       </div>
     </div>
-    {totalPages > 1 && (
-      <Pagination
-        totalPages={totalPages}
-        currentPage={filters.page}
-        setCurrentPage={(page: number) => {
-          onFilterChange({
-            ...filters,
-            page
-          });
-        }}
-        commentCount={commentCount}
-        filters={filters}
-      />
-    )}
   </div>
 );

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -155,8 +155,8 @@ export const Filters = ({
     {totalPages > 1 && (
       <Pagination
         totalPages={totalPages}
-        page={filters.page}
-        setPage={(page: number) => {
+        currentPage={filters.page}
+        setCurrentPage={(page: number) => {
           onFilterChange({
             ...filters,
             page


### PR DESCRIPTION
## What does this change?
Refactors Filters/Pagination to keep pagination separate.

## Why?
After we visually moved the pagination control out of the Filters it makes more sense to not render one inside the other.

## Link to supporting Trello card
https://trello.com/c/7b6E3LAN/1233-refactor-pagination
