### PR TITLE
Support different avatar sizes

### DIFF
--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -3,5 +3,34 @@ import { Avatar } from "./Avatar";
 
 export default { component: Avatar, title: "Avatar" };
 
-export const Default = () => <Avatar />;
-Default.story = { name: "default" };
+export const Sizes = () => {
+  return (
+    <>
+      <Avatar
+        imageUrl="https://avatar.guim.co.uk/no-user-image.gif"
+        size="small"
+        displayName=""
+      />
+      <Avatar
+        imageUrl="https://avatar.guim.co.uk/no-user-image.gif"
+        size="medium"
+        displayName=""
+      />
+      <Avatar
+        imageUrl="https://avatar.guim.co.uk/no-user-image.gif"
+        size="large"
+        displayName=""
+      />
+    </>
+  );
+};
+Sizes.story = { name: "different sizes" };
+
+export const NoImage = () => {
+  return (
+    <>
+      <Avatar size="medium" displayName="" />
+    </>
+  );
+};
+NoImage.story = { name: "with no image url given" };

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,18 +1,36 @@
 import React from "react";
 import { css } from "emotion";
-// import { textSans } from "@guardian/src-foundations/typography";
-// import { palette } from "@guardian/src-foundations";
 
 type Props = {
-  imageUrl: string;
-  size: "small" | "large";
+  imageUrl?: string;
+  displayName: string;
+  size: "small" | "medium" | "large";
 };
 
-const containerStyles = css`
-  display: flex;
-  flex-direction: row;
+const imageStyles = (size: number) => css`
+  border-radius: ${size + 10}px;
+  width: ${size}px;
+  height: ${size}px;
 `;
 
-export const Avatar = () => {
-  return <div className={containerStyles}>Avatar</div>;
+export const Avatar = ({
+  imageUrl = "https://avatar.guim.co.uk/no-user-image.gif",
+  displayName,
+  size
+}: Props) => {
+  switch (size) {
+    case "small":
+      return (
+        <img src={imageUrl} alt={displayName} className={imageStyles(36)} />
+      );
+    case "large":
+      return (
+        <img src={imageUrl} alt={displayName} className={imageStyles(60)} />
+      );
+    case "medium":
+    default:
+      return (
+        <img src={imageUrl} alt={displayName} className={imageStyles(48)} />
+      );
+  }
 };

--- a/src/components/Comment/Comment.stories.tsx
+++ b/src/components/Comment/Comment.stories.tsx
@@ -41,6 +41,7 @@ export const defaultStory = () => (
     comment={commentData}
     pillar={"sport"}
     setCommentBeingRepliedTo={() => {}}
+    isReply={false}
   />
 );
 defaultStory.story = { name: "default" };

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { css, cx } from "emotion";
+import { css } from "emotion";
 
 import { neutral, space, palette } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
@@ -9,11 +9,13 @@ import { GuardianStaff, GuardianPick } from "../Badges/Badges";
 import { RecommendationCount } from "../RecommendationCount/RecommendationCount";
 import { AbuseReportForm } from "../AbuseReportForm/AbuseReportForm";
 import { Timestamp } from "../Timestamp/Timestamp";
+import { Avatar } from "../Avatar/Avatar";
 
 type Props = {
   comment: CommentType;
   pillar: Pillar;
   setCommentBeingRepliedTo: (commentBeingRepliedTo?: CommentType) => void;
+  isReply: boolean;
 };
 
 const commentControls = css`
@@ -50,9 +52,7 @@ const commentWrapper = css`
   padding: ${space[2]}px 0;
 `;
 
-const commentAvatar = css`
-  min-width: 50px;
-  height: 50px;
+const avatarMargin = css`
   margin-right: ${space[2]}px;
 `;
 
@@ -93,12 +93,6 @@ const linkStyles = css`
   }
 `;
 
-export const avatar = (avatarSize: number): string => css`
-  border-radius: ${avatarSize + 10}px;
-  width: ${avatarSize}px;
-  height: ${avatarSize}px;
-`;
-
 const Column = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
   <div
     className={css`
@@ -124,17 +118,20 @@ const Row = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
 export const Comment = ({
   comment,
   pillar,
-  setCommentBeingRepliedTo
+  setCommentBeingRepliedTo,
+  isReply
 }: Props) => {
   const commentControlsButtonStyles = commentControlsButton(pillar);
   return (
     <li>
       <div className={commentWrapper}>
-        <img
-          src={comment.userProfile.avatar}
-          alt={comment.userProfile.displayName}
-          className={cx(avatar(50), commentAvatar)}
-        />
+        <div className={avatarMargin}>
+          <Avatar
+            imageUrl={comment.userProfile.avatar}
+            displayName={comment.userProfile.displayName}
+            size={isReply ? "small" : "medium"}
+          />
+        </div>
 
         <div className={commentDetails}>
           <header className={headerStyles}>

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -121,6 +121,7 @@ export const CommentContainer = ({
         comment={comment}
         pillar={pillar}
         setCommentBeingRepliedTo={setCommentBeingRepliedTo}
+        isReply={false}
       />
 
       <>
@@ -131,6 +132,7 @@ export const CommentContainer = ({
                 comment={responseComment}
                 pillar={pillar}
                 setCommentBeingRepliedTo={setCommentBeingRepliedTo}
+                isReply={true}
               />
             ))}
             {!expanded &&

--- a/src/components/TopPicks/TopPicks.tsx
+++ b/src/components/TopPicks/TopPicks.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from "react";
-import { css, cx } from "emotion";
+import { css } from "emotion";
 
 import { space, neutral, palette } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
 
 import { GuardianStaff } from "../Badges/Badges";
 import { CommentType } from "../../types";
-import { avatar } from "../Comment/Comment";
+import { Avatar } from "../Avatar/Avatar";
 import { getPicks } from "../../lib/api";
 import { RecommendationCount } from "../RecommendationCount/RecommendationCount";
 import { Timestamp } from "../Timestamp/Timestamp";
@@ -62,8 +62,8 @@ const userName = css`
   color: ${palette.news.main}; /* TODO USE PILLAR */
 `;
 
-const picksAvatar = css`
-  margin-right: ${space[3]}px;
+const avatarMargin = css`
+  margin-right: ${space[2]}px;
 `;
 
 const linkStyles = css`
@@ -92,11 +92,13 @@ const Pick = ({ comment }: { comment: CommentType }) => (
     </div>
     <div className={pickMetaWrapper}>
       <div className={userDetails}>
-        <img
-          src={comment.userProfile.avatar}
-          alt={""}
-          className={cx(avatar(50), comment.userProfile.avatar, picksAvatar)}
-        />
+        <div className={avatarMargin}>
+          <Avatar
+            imageUrl={comment.userProfile.avatar}
+            displayName={""}
+            size="medium"
+          />
+        </div>
         <div className="usermeta">
           <span className={userName}>
             <a


### PR DESCRIPTION
## What does this change?
We now use `Avatar` to render avatars. This component has a prop allowing 3 different sizes for an avatar

Avatar small (reply) should have

```
{
    width: 36px;
    height: 36px;
}
```

Avatar medium (comment) should have

```
{
    width: 48px;
    height: 48px;
}
```

Avatar large (signed in as) should have

```
{
    width: 60px;
    height: 60px;
}
```

## Why?
Because we want to group this shared code in one place and because we want to be able to have parity with FE in terms of avatar sizes

## Link to supporting Trello card
https://trello.com/c/RrEHcNpE/1229-avatar-is-smaller-when-replying