### PR TITLE
Reply button should have an arrow

### DIFF
--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -28,11 +28,14 @@ const commentControls = css`
 `;
 
 const commentControlsButton = (pillar: Pillar) => css`
-  font-weight: bold;
+  ${textSans.xsmall({ fontWeight: "bold" })}
   margin-right: ${space[2]}px;
   color: ${palette[pillar][400]};
   border: 0;
   cursor: pointer;
+  :hover {
+    text-decoration: underline
+  }
 `;
 
 const spaceBetween = css`
@@ -111,6 +114,15 @@ const linkStyles = css`
   }
 `;
 
+const flexRowStyles = css`
+  display: flex;
+  flex-direction: row;
+`;
+
+const removePaddingLeft = css`
+  padding-left: 0px;
+`;
+
 const Column = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
   <div
     className={css`
@@ -131,6 +143,18 @@ const Row = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
   >
     {children}
   </div>
+);
+
+const ReplyArrow = () => (
+  <svg
+    width="18"
+    height="18"
+    className={css`
+      fill: ${palette.neutral[46]};
+    `}
+  >
+    <path d="M10.1 5l.9-1 4 4.5v1L11 14l-.9-1 2.5-3H4L3 9V6.5h2V8h7.6l-2.5-3z"></path>
+  </svg>
 );
 
 export const Comment = ({
@@ -238,9 +262,15 @@ export const Comment = ({
                 <div className={commentControls}>
                   <button
                     onClick={() => setCommentBeingRepliedTo(comment)}
-                    className={commentControlsButtonStyles}
+                    className={cx(
+                      commentControlsButtonStyles,
+                      removePaddingLeft
+                    )}
                   >
-                    Reply
+                    <div className={flexRowStyles}>
+                      <ReplyArrow />
+                      Reply
+                    </div>
                   </button>
                   <button className={commentControlsButtonStyles}>Share</button>
                   {/* Only staff can pick, and they cannot pick thier own comment */}

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -150,7 +150,7 @@ const ReplyArrow = () => (
     width="18"
     height="18"
     className={css`
-      fill: ${palette.neutral[46]};
+      fill: ${neutral[46]};
     `}
   >
     <path d="M10.1 5l.9-1 4 4.5v1L11 14l-.9-1 2.5-3H4L3 9V6.5h2V8h7.6l-2.5-3z"></path>


### PR DESCRIPTION
## What does this change?
Add an arrow next to reply button

## Why?
Parity with frontent

## Link to supporting Trello card
https://trello.com/c/VwoGFeau/1266-add-arrow-next-to-reply-button

## Current UI
<img width="424" alt="Screenshot 2020-03-05 at 15 02 41" src="https://user-images.githubusercontent.com/8831403/75994127-62bef600-5ef2-11ea-850a-4883781f9369.png">
