### PR TITLE
Hide div wrapper if badge is not displayed

### DIFF
--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -206,14 +206,16 @@ export const Comment = ({
                 </div>
               </Row>
               <Row>
-                <div className={iconWrapper}>
-                  {comment.userProfile.badge.filter(
-                    obj => obj["name"] === "Staff"
-                  ) && <GuardianStaff />}
-                </div>
-                {comment.status !== "blocked" ? (
+                {!!comment.userProfile.badge.filter(
+                  obj => obj["name"] === "Staff"
+                ) && (
                   <div className={iconWrapper}>
-                    {isHighlighted && <GuardianPick />}
+                    <GuardianStaff />
+                  </div>
+                )}
+                {comment.status !== "blocked" && isHighlighted ? (
+                  <div className={iconWrapper}>
+                    <GuardianPick />
                   </div>
                 ) : (
                   <></>


### PR DESCRIPTION
## What does this change?
We should hide the div wrapper used for badges

## Why?
avoid wrapper styles being applied if badge not being rendered

