### PR TITLE
Show a message when a user is premoderated

### DIFF
--- a/src/components/CommentForm/CommentForm.stories.tsx
+++ b/src/components/CommentForm/CommentForm.stories.tsx
@@ -20,6 +20,37 @@ const aUser = {
   }
 };
 
+const aComment: CommentType = {
+  id: 25487686,
+  body:
+    "<p>Beau Jos pizza in Idaho Springs is a great place for mountain pizza pies. Order one with extra thick crust and drizzle it with honey. Y'all can try the Challenge if you fancy, and sketch on your napkins so your art can join their walls. This was 15 years ago, but I hope it's still there! As for music, anything from Boulder's own Big Head Todd &amp; the Monsters - 'Broken Hearted Savior' is a good start, with 'Bittersweet' a good road track. I'm jealous!!!</p>",
+  date: "26 July 2013 4:13pm",
+  isoDateTime: "2013-07-26T15:13:20Z",
+  status: "visible",
+  webUrl: "https://discussion.theguardian.com/comment-permalink/25487686",
+  apiUrl: "https://discussion.guardianapis.com/discussion-api/comment/25487686",
+  numRecommends: 0,
+  isHighlighted: false,
+  userProfile: {
+    userId: "2762428",
+    displayName: "FrankDeFord",
+    webUrl: "https://profile.theguardian.com/user/id/2762428",
+    apiUrl:
+      "https://discussion.guardianapis.com/discussion-api/profile/2762428",
+    avatar: "https://avatar.guim.co.uk/user/2762428",
+    secureAvatarUrl: "https://avatar.guim.co.uk/user/2762428",
+    badge: []
+  },
+  responses: [],
+  metaData: {
+    commentCount: 2,
+    staffCommenterCount: 1,
+    editorsPickCount: 0,
+    blockedCount: 0,
+    responseCount: 1
+  }
+};
+
 export const Default = () => (
   <CommentForm
     shortUrl={shortUrl}
@@ -27,5 +58,30 @@ export const Default = () => (
     onAddComment={(commentId, body, user) => {}}
   />
 );
-
 Default.story = { name: "default" };
+
+export const Active = () => (
+  <CommentForm
+    shortUrl={shortUrl}
+    user={aUser}
+    onAddComment={(commentId, body, user) => {}}
+    commentBeingRepliedTo={aComment}
+  />
+);
+Active.story = { name: "form is active" };
+
+export const Premoderated = () => (
+  <CommentForm
+    shortUrl={shortUrl}
+    user={{
+      ...aUser,
+      privateFields: {
+        ...aUser.privateFields,
+        isPremoderated: true
+      }
+    }}
+    onAddComment={(commentId, body, user) => {}}
+    commentBeingRepliedTo={aComment}
+  />
+);
+Premoderated.story = { name: "user is premoderated" };

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -332,6 +332,16 @@ export const CommentForm = ({
               Please keep comments respectful and abide by the{" "}
               <a href="/community-standards">community guidelines</a>.
             </p>
+
+            {user.privateFields && user.privateFields.isPremoderated && (
+              <p className={errorTextStyles}>
+                Your comments are currently being pre-moderated (
+                <a href="/community-faqs#311" target="_blank">
+                  why?
+                </a>
+                )
+              </p>
+            )}
           </div>
         )}
         <textarea


### PR DESCRIPTION
## What does this change?
Adds text to the comment form header when a user is marked as premoderated

![Screenshot 2020-03-06 at 11 21 35](https://user-images.githubusercontent.com/1336821/76080060-fe597080-5f9d-11ea-864c-d5bda3dc4edc.jpg)

I also added a drive by story to capture the active form state (even without this message)

## Why?
So they know

## Link to supporting Trello card
https://trello.com/c/tEU1taIV/1249-premoderated-comments
