### PR TITLE
Fix for firefox background color default

### DIFF
--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { css, cx } from "emotion";
 
 import { space, palette } from "@guardian/src-foundations";
-import { neutral } from "@guardian/src-foundations/";
+import { neutral } from "@guardian/src-foundations/palette";
 import { textSans } from "@guardian/src-foundations/typography";
 
 import { Pillar, CommentType, UserProfile } from "../../types";

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
 import { css, cx } from "emotion";
 
-import { neutral, space, palette } from "@guardian/src-foundations";
+import { space, palette } from "@guardian/src-foundations";
+import { neutral } from "@guardian/src-foundations/";
 import { textSans } from "@guardian/src-foundations/typography";
 
 import { Pillar, CommentType, UserProfile } from "../../types";
@@ -31,6 +32,7 @@ const commentControlsButton = (pillar: Pillar) => css`
   ${textSans.xsmall({ fontWeight: "bold" })}
   margin-right: ${space[2]}px;
   color: ${palette[pillar][400]};
+  background-color: ${neutral[100]};
   border: 0;
   cursor: pointer;
   :hover {

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { css, cx } from "emotion";
 
 import { space, palette } from "@guardian/src-foundations";
-import { neutral } from "@guardian/src-foundations/palette";
+import { neutral, background } from "@guardian/src-foundations/palette";
 import { textSans } from "@guardian/src-foundations/typography";
 
 import { Pillar, CommentType, UserProfile } from "../../types";
@@ -32,7 +32,7 @@ const commentControlsButton = (pillar: Pillar) => css`
   ${textSans.xsmall({ fontWeight: "bold" })}
   margin-right: ${space[2]}px;
   color: ${palette[pillar][400]};
-  background-color: ${neutral[100]};
+  background-color: ${background.primary};
   border: 0;
   cursor: pointer;
   :hover {


### PR DESCRIPTION
## What does this change?
Set the background of the comment action buttons 

## Why?
In firefox the background colour defaults to grey

## Before
<img width="356" alt="Screenshot 2020-03-06 at 13 32 53" src="https://user-images.githubusercontent.com/8831403/76088005-32895d00-5faf-11ea-8327-ec6fd66a80f1.png">

## After
<img width="389" alt="Screenshot 2020-03-06 at 13 32 41" src="https://user-images.githubusercontent.com/8831403/76088021-39b06b00-5faf-11ea-9287-55ffc5816fa0.png">

