### PR TITLE
Dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,6 @@
     "@guardian/src-button": "^0.8.0",
     "@guardian/src-foundations": "^0.12.3",
     "@guardian/src-svgs": "^0.1.0",
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^25.1.0",
     "@types/node": "^13.5.0",
@@ -62,6 +60,8 @@
   "devDependencies": {
     "@storybook/addon-viewport": "^5.3.13",
     "@storybook/react": "^5.3.13",
+    "@testing-library/jest-dom": "^5.1.1",
+    "@testing-library/react": "^10.0.1",
     "eslint-plugin-react-hooks": "^2.3.0",
     "husky": "^4.2.3",
     "prettier": "^1.19.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged && yarn lint && yarn tsc && yarn test --watchAll=false"
+      "pre-push": "pretty-quick --staged && yarn lint && yarn tsc && yarn test --watchAll=false"
     }
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged && yarn lint && yarn tsc"
+      "pre-commit": "pretty-quick --staged && yarn lint && yarn tsc && yarn test --watchAll=false"
     }
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "io-ts-types": "^0.5.5",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
+    "react-focus-lock": "^2.2.1",
     "react-scripts": "3.3.0",
     "timeago.js": "^4.0.2",
     "typescript": "^3.7.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { css, cx } from "emotion";
+import { css } from "emotion";
 
 import { Button } from "@guardian/src-button";
 import { neutral } from "@guardian/src-foundations/palette";

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { css } from "emotion";
 
-import { palette } from "@guardian/src-foundations";
-
 import { DropdownLinkType } from "../../types";
 import { Dropdown } from "./Dropdown";
 
@@ -11,7 +9,6 @@ const Header = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
     className={css`
       height: 300px;
       width: 100%;
-      background-color: ${palette.brand.main};
     `}
   >
     {children}
@@ -39,12 +36,12 @@ const Nav = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
 const links: DropdownLinkType[] = [
   {
     value: "collapsed",
-    title: "Collapsed"
+    title: "Collapsed",
+    isActive: true
   },
   {
     value: "expanded",
-    title: "Expanded",
-    isActive: true
+    title: "Expanded"
   },
   {
     value: "unthreaded",
@@ -58,8 +55,7 @@ const linksWithNoneActive = [
     isActive: false
   },
   { ...links[1] },
-  { ...links[2] },
-  { ...links[3] }
+  { ...links[2] }
 ];
 
 /* tslint:disable */

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -56,6 +56,7 @@ export const DropdownActive = () => (
         console.log("clicked: ", value);
       }}
     />
+    <p>Hi, I'm some other content we want to overlay</p>
   </Container>
 );
 DropdownActive.story = { name: "Dropdown with first item active" };

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { css } from "emotion";
+
+import { palette } from "@guardian/src-foundations";
+
+import { Dropdown } from "./Dropdown";
+
+const Header = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+  <div
+    className={css`
+      height: 300px;
+      width: 100%;
+      background-color: ${palette.brand.main};
+    `}
+  >
+    {children}
+  </div>
+);
+
+const Nav = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+  <div
+    className={css`
+      height: 20px;
+      position: absolute;
+      top: 10px;
+      display: block;
+      right: 258px;
+      width: 197px;
+      z-index: 1072;
+      transform: translateX(100%);
+      padding-top: 7px;
+    `}
+  >
+    {children}
+  </div>
+);
+
+const links = [
+  {
+    url: "/preference/edition/uk",
+    title: "UK edition",
+    dataLinkName: "linkname-UK"
+  },
+  {
+    url: "/preference/edition/us",
+    title: "US edition",
+    isActive: true,
+    dataLinkName: "linkname-US"
+  },
+  {
+    url: "/preference/edition/au",
+    title: "Australian edition",
+    dataLinkName: "linkname-AU"
+  },
+  {
+    url: "/preference/edition/int",
+    title: "International edition",
+    dataLinkName: "linkname-INT"
+  }
+];
+
+const linksWithNoneActive = [
+  {
+    ...links[0],
+    isActive: false
+  },
+  { ...links[1] },
+  { ...links[2] },
+  { ...links[3] }
+];
+
+/* tslint:disable */
+export default {
+  component: Dropdown,
+  title: "Dropdown"
+};
+/* tslint:enable */
+
+export const DropdownActive = () => (
+  <Header>
+    <Nav>
+      <Dropdown
+        id="d1"
+        label="UK edition"
+        links={links}
+        dataLinkName="linkname1"
+      />
+    </Nav>
+  </Header>
+);
+DropdownActive.story = { name: "Dropdown with first item active" };
+
+export const DropdownNoActive = () => (
+  <Header>
+    <Nav>
+      <Dropdown
+        id="d2"
+        label="UK edition"
+        links={linksWithNoneActive}
+        dataLinkName="linkname2"
+      />
+    </Nav>
+  </Header>
+);
+DropdownNoActive.story = { name: "Dropdown with nothing active" };

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -38,21 +38,17 @@ const Nav = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
 
 const links: DropdownLinkType[] = [
   {
-    url: "/preference/edition/uk",
-    title: "UK edition"
+    value: "collapsed",
+    title: "Collapsed"
   },
   {
-    url: "/preference/edition/us",
-    title: "US edition",
+    value: "expanded",
+    title: "Expanded",
     isActive: true
   },
   {
-    url: "/preference/edition/au",
-    title: "Australian edition"
-  },
-  {
-    url: "/preference/edition/int",
-    title: "International edition"
+    value: "unthreaded",
+    title: "Unthreaded"
   }
 ];
 
@@ -76,7 +72,14 @@ export default {
 export const DropdownActive = () => (
   <Header>
     <Nav>
-      <Dropdown id="d1" label="UK edition" links={links} />
+      <Dropdown
+        id="d1"
+        label="UK edition"
+        links={links}
+        onFilterClick={(value: string) => {
+          console.log("clicked: ", value);
+        }}
+      />
     </Nav>
   </Header>
 );
@@ -85,7 +88,14 @@ DropdownActive.story = { name: "Dropdown with first item active" };
 export const DropdownNoActive = () => (
   <Header>
     <Nav>
-      <Dropdown id="d2" label="UK edition" links={linksWithNoneActive} />
+      <Dropdown
+        id="d2"
+        label="UK edition"
+        links={linksWithNoneActive}
+        onFilterClick={(value: string) => {
+          console.log("clicked: ", value);
+        }}
+      />
     </Nav>
   </Header>
 );

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -40,7 +40,7 @@ const DropdownParent = () => {
       label="Page Size"
       pillar="culture"
       links={pageSizeLinks}
-      onFilterClick={(value: string) => {
+      onSelect={(value: string) => {
         setSelected(value);
       }}
     />
@@ -86,7 +86,7 @@ export const DropdownActive = () => (
       pillar="lifestyle"
       label="Threads"
       links={threadLinks}
-      onFilterClick={(value: string) => {
+      onSelect={(value: string) => {
         console.log("clicked: ", value);
       }}
     />
@@ -102,7 +102,7 @@ export const DropdownNoActive = () => (
       label="Threads"
       pillar="news"
       links={linksWithNoneActive}
-      onFilterClick={(value: string) => {
+      onSelect={(value: string) => {
         console.log("clicked: ", value);
       }}
     />

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { css } from "emotion";
 
 import { DropdownLinkType } from "../../types";
@@ -13,6 +13,38 @@ const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
     {children}
   </div>
 );
+
+const DropdownParent = () => {
+  const [selected, setSelected] = useState<string>();
+  const pageSizeLinks: DropdownLinkType[] = [
+    {
+      value: "25",
+      title: "25",
+      isActive: selected === "25"
+    },
+    {
+      value: "50",
+      title: "50",
+      isActive: selected === "50"
+    },
+    {
+      value: "100",
+      title: "100",
+      isActive: selected === "100"
+    }
+  ];
+
+  return (
+    <Dropdown
+      id="d3"
+      label="Threads"
+      links={pageSizeLinks}
+      onFilterClick={(value: string) => {
+        setSelected(value);
+      }}
+    />
+  );
+};
 
 const threadLinks: DropdownLinkType[] = [
   {
@@ -74,3 +106,10 @@ export const DropdownNoActive = () => (
   </Container>
 );
 DropdownNoActive.story = { name: "Dropdown with nothing active" };
+
+export const DropdownWithState = () => (
+  <Container>
+    <DropdownParent />
+  </Container>
+);
+DropdownWithState.story = { name: "Dropdown with working selection" };

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -37,7 +37,7 @@ const DropdownParent = () => {
   return (
     <Dropdown
       id="d3"
-      label="Threads"
+      label="Page Size"
       links={pageSizeLinks}
       onFilterClick={(value: string) => {
         setSelected(value);

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -38,24 +38,20 @@ const Nav = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
 const links = [
   {
     url: "/preference/edition/uk",
-    title: "UK edition",
-    dataLinkName: "linkname-UK"
+    title: "UK edition"
   },
   {
     url: "/preference/edition/us",
     title: "US edition",
-    isActive: true,
-    dataLinkName: "linkname-US"
+    isActive: true
   },
   {
     url: "/preference/edition/au",
-    title: "Australian edition",
-    dataLinkName: "linkname-AU"
+    title: "Australian edition"
   },
   {
     url: "/preference/edition/int",
-    title: "International edition",
-    dataLinkName: "linkname-INT"
+    title: "International edition"
   }
 ];
 
@@ -79,12 +75,7 @@ export default {
 export const DropdownActive = () => (
   <Header>
     <Nav>
-      <Dropdown
-        id="d1"
-        label="UK edition"
-        links={links}
-        dataLinkName="linkname1"
-      />
+      <Dropdown id="d1" label="UK edition" links={links} />
     </Nav>
   </Header>
 );
@@ -93,12 +84,7 @@ DropdownActive.story = { name: "Dropdown with first item active" };
 export const DropdownNoActive = () => (
   <Header>
     <Nav>
-      <Dropdown
-        id="d2"
-        label="UK edition"
-        links={linksWithNoneActive}
-        dataLinkName="linkname2"
-      />
+      <Dropdown id="d2" label="UK edition" links={linksWithNoneActive} />
     </Nav>
   </Header>
 );

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { css } from "emotion";
 
-import { DropdownLinkType } from "../../types";
+import { DropdownOptionType } from "../../types";
 import { Dropdown } from "./Dropdown";
 
 const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
@@ -16,7 +16,7 @@ const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
 
 const DropdownParent = () => {
   const [selected, setSelected] = useState<string>();
-  const pageSizeLinks: DropdownLinkType[] = [
+  const pageSizeOptions: DropdownOptionType[] = [
     {
       value: "25",
       title: "25",
@@ -39,7 +39,7 @@ const DropdownParent = () => {
       id="d3"
       label="Page Size"
       pillar="culture"
-      links={pageSizeLinks}
+      options={pageSizeOptions}
       onSelect={(value: string) => {
         setSelected(value);
       }}
@@ -47,7 +47,7 @@ const DropdownParent = () => {
   );
 };
 
-const threadLinks: DropdownLinkType[] = [
+const threadOptions: DropdownOptionType[] = [
   {
     value: "collapsed",
     title: "Collapsed",
@@ -63,13 +63,13 @@ const threadLinks: DropdownLinkType[] = [
   }
 ];
 
-const linksWithNoneActive = [
+const optionsWithNoneActive = [
   {
-    ...threadLinks[0],
+    ...threadOptions[0],
     isActive: false
   },
-  { ...threadLinks[1] },
-  { ...threadLinks[2] }
+  { ...threadOptions[1] },
+  { ...threadOptions[2] }
 ];
 
 /* tslint:disable */
@@ -85,7 +85,7 @@ export const DropdownActive = () => (
       id="d1"
       pillar="lifestyle"
       label="Threads"
-      links={threadLinks}
+      options={threadOptions}
       onSelect={(value: string) => {
         console.log("clicked: ", value);
       }}
@@ -101,7 +101,7 @@ export const DropdownNoActive = () => (
       id="d2"
       label="Threads"
       pillar="news"
-      links={linksWithNoneActive}
+      options={optionsWithNoneActive}
       onSelect={(value: string) => {
         console.log("clicked: ", value);
       }}

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -38,6 +38,7 @@ const DropdownParent = () => {
     <Dropdown
       id="d3"
       label="Page Size"
+      pillar="culture"
       links={pageSizeLinks}
       onFilterClick={(value: string) => {
         setSelected(value);
@@ -82,6 +83,7 @@ export const DropdownActive = () => (
   <Container>
     <Dropdown
       id="d1"
+      pillar="lifestyle"
       label="Threads"
       links={threadLinks}
       onFilterClick={(value: string) => {
@@ -98,6 +100,7 @@ export const DropdownNoActive = () => (
     <Dropdown
       id="d2"
       label="Threads"
+      pillar="news"
       links={linksWithNoneActive}
       onFilterClick={(value: string) => {
         console.log("clicked: ", value);

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -4,36 +4,17 @@ import { css } from "emotion";
 import { DropdownLinkType } from "../../types";
 import { Dropdown } from "./Dropdown";
 
-const Header = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
   <div
     className={css`
-      height: 300px;
-      width: 100%;
+      padding: 10px;
     `}
   >
     {children}
   </div>
 );
 
-const Nav = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
-  <div
-    className={css`
-      height: 20px;
-      position: absolute;
-      top: 10px;
-      display: block;
-      right: 258px;
-      width: 197px;
-      z-index: 1072;
-      transform: translateX(100%);
-      padding-top: 7px;
-    `}
-  >
-    {children}
-  </div>
-);
-
-const links: DropdownLinkType[] = [
+const threadLinks: DropdownLinkType[] = [
   {
     value: "collapsed",
     title: "Collapsed",
@@ -51,11 +32,11 @@ const links: DropdownLinkType[] = [
 
 const linksWithNoneActive = [
   {
-    ...links[0],
+    ...threadLinks[0],
     isActive: false
   },
-  { ...links[1] },
-  { ...links[2] }
+  { ...threadLinks[1] },
+  { ...threadLinks[2] }
 ];
 
 /* tslint:disable */
@@ -66,33 +47,29 @@ export default {
 /* tslint:enable */
 
 export const DropdownActive = () => (
-  <Header>
-    <Nav>
-      <Dropdown
-        id="d1"
-        label="UK edition"
-        links={links}
-        onFilterClick={(value: string) => {
-          console.log("clicked: ", value);
-        }}
-      />
-    </Nav>
-  </Header>
+  <Container>
+    <Dropdown
+      id="d1"
+      label="Threads"
+      links={threadLinks}
+      onFilterClick={(value: string) => {
+        console.log("clicked: ", value);
+      }}
+    />
+  </Container>
 );
 DropdownActive.story = { name: "Dropdown with first item active" };
 
 export const DropdownNoActive = () => (
-  <Header>
-    <Nav>
-      <Dropdown
-        id="d2"
-        label="UK edition"
-        links={linksWithNoneActive}
-        onFilterClick={(value: string) => {
-          console.log("clicked: ", value);
-        }}
-      />
-    </Nav>
-  </Header>
+  <Container>
+    <Dropdown
+      id="d2"
+      label="Threads"
+      links={linksWithNoneActive}
+      onFilterClick={(value: string) => {
+        console.log("clicked: ", value);
+      }}
+    />
+  </Container>
 );
 DropdownNoActive.story = { name: "Dropdown with nothing active" };

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -3,6 +3,7 @@ import { css } from "emotion";
 
 import { palette } from "@guardian/src-foundations";
 
+import { DropdownLinkType } from "../../types";
 import { Dropdown } from "./Dropdown";
 
 const Header = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
@@ -35,7 +36,7 @@ const Nav = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
   </div>
 );
 
-const links = [
+const links: DropdownLinkType[] = [
   {
     url: "/preference/edition/uk",
     title: "UK edition"

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -1,0 +1,151 @@
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+
+import { render, fireEvent } from "@testing-library/react";
+
+import { DropdownOptionType } from "../../types";
+import { Dropdown } from "./Dropdown";
+
+const threadOptions: DropdownOptionType[] = [
+  {
+    value: "collapsed",
+    title: "Collapsed",
+    isActive: true
+  },
+  {
+    value: "expanded",
+    title: "Expanded"
+  },
+  {
+    value: "unthreaded",
+    title: "Unthreaded"
+  }
+];
+
+const noActiveOptions: DropdownOptionType[] = threadOptions.map(option => ({
+  ...option,
+  isActive: false
+}));
+
+describe("Dropdown", () => {
+  it("should display the given label", () => {
+    const label = "I should show";
+    const { getByText } = render(
+      <Dropdown
+        id="abc"
+        pillar="news"
+        label={label}
+        options={threadOptions}
+        onSelect={() => {}}
+      />
+    );
+
+    expect(getByText(label)).toBeInTheDocument();
+  });
+
+  it("should display option titles", () => {
+    const { getByText } = render(
+      <Dropdown
+        id="abc"
+        pillar="news"
+        label={"The label"}
+        options={noActiveOptions}
+        onSelect={() => {}}
+      />
+    );
+
+    expect(getByText(threadOptions[0].title)).toBeInTheDocument();
+    expect(getByText(threadOptions[1].title)).toBeInTheDocument();
+    expect(getByText(threadOptions[2].title)).toBeInTheDocument();
+  });
+
+  it("should render the correct number of options", () => {
+    const { container } = render(
+      <Dropdown
+        id="abc"
+        pillar="news"
+        label={"The label"}
+        options={threadOptions}
+        onSelect={() => {}}
+      />
+    );
+
+    const listItems = container.querySelectorAll("li");
+    expect(listItems.length).toEqual(threadOptions.length);
+  });
+
+  it("should expand the menu when the label is clicked", () => {
+    const { container, getByRole } = render(
+      <Dropdown
+        id="abc"
+        pillar="news"
+        label={"The label"}
+        options={threadOptions}
+        onSelect={() => {}}
+      />
+    );
+
+    const ulElement = container.querySelector("ul");
+    expect(ulElement).toHaveStyle("display: none");
+    fireEvent.click(getByRole("button"));
+    expect(ulElement).toHaveStyle("display: block");
+  });
+
+  it("should close the expanded menu when readers click away", () => {
+    const { container, getByRole } = render(
+      <Dropdown
+        id="abc"
+        pillar="news"
+        label={"The label"}
+        options={threadOptions}
+        onSelect={() => {}}
+      />
+    );
+
+    const ulElement = container.querySelector("ul");
+    fireEvent.click(getByRole("button"));
+    expect(ulElement).toHaveStyle("display: block");
+    container.click();
+    expect(ulElement).toHaveStyle("display: none");
+  });
+
+  it("should close the expanded menu when blurred", () => {
+    const { container, getByRole } = render(
+      <Dropdown
+        id="abc"
+        pillar="news"
+        label={"The label"}
+        options={threadOptions}
+        onSelect={() => {}}
+      />
+    );
+
+    const ulElement = container.querySelector("ul");
+    fireEvent.click(getByRole("button"));
+    expect(ulElement).toHaveStyle("display: block");
+    fireEvent.keyDown(container, { key: "Escape", code: "Escape" });
+    expect(ulElement).toHaveStyle("display: none");
+  });
+});
+
+it("should trigger the correct onSelect callbacks when an option is clicked", () => {
+  const mockCallback = jest.fn();
+  const { getByRole, getByText } = render(
+    <Dropdown
+      id="abc"
+      pillar="news"
+      label={"The label"}
+      options={threadOptions}
+      onSelect={mockCallback}
+    />
+  );
+
+  fireEvent.click(getByRole("button"));
+  fireEvent.click(getByText(threadOptions[2].title));
+  expect(mockCallback).toHaveBeenCalled();
+  expect(mockCallback.mock.calls[0][0]).toBe("unthreaded");
+  fireEvent.click(getByRole("button"));
+  fireEvent.click(getByText(threadOptions[1].title));
+  expect(mockCallback).toHaveBeenCalled();
+  expect(mockCallback.mock.calls[1][0]).toBe("expanded");
+});

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -87,8 +87,8 @@ const linkActive = css`
 `;
 
 const button = css`
-  ${textSans.xsmall()};
-  display: block;
+  display: inline;
+  font-weight: bold;
   cursor: pointer;
   background: none;
   border: none;
@@ -132,6 +132,10 @@ const buttonExpanded = css`
   }
 `;
 
+const labelStyles = css`
+  ${textSans.xsmall()};
+`;
+
 export const Dropdown = ({ id, label, links, onFilterClick }: Props) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -168,19 +172,24 @@ export const Dropdown = ({ id, label, links, onFilterClick }: Props) => {
   // this should be unique because JS is single-threaded
   const dropdownID = `dropbox-id-${id}`;
 
+  const activeLink = links.find(link => link.isActive);
+
   return (
     <>
-      <button
-        onClick={handleToggle}
-        className={cx({
-          [button]: true,
-          [buttonExpanded]: isExpanded
-        })}
-        aria-controls={dropdownID}
-        aria-expanded={isExpanded ? "true" : "false"}
-      >
+      <div className={labelStyles}>
         {label}
-      </button>
+        <button
+          onClick={handleToggle}
+          className={cx({
+            [button]: true,
+            [buttonExpanded]: isExpanded
+          })}
+          aria-controls={dropdownID}
+          aria-expanded={isExpanded ? "true" : "false"}
+        >
+          {activeLink && activeLink.title}
+        </button>
+      </div>
 
       <ul
         id={dropdownID}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -2,7 +2,12 @@ import React, { useState, useEffect } from "react";
 import { css, cx } from "emotion";
 
 import { palette } from "@guardian/src-foundations";
-import { neutral, border, brandAlt } from "@guardian/src-foundations/palette";
+import {
+  neutral,
+  border,
+  brandAlt,
+  background
+} from "@guardian/src-foundations/palette";
 import { textSans } from "@guardian/src-foundations/typography";
 import { from, until } from "@guardian/src-foundations/mq";
 
@@ -20,9 +25,11 @@ const ul = css`
   list-style: none;
   border: 1px solid ${border.secondary};
   margin-left: -8px;
-  padding: 0;
+  padding: 0px;
   display: none;
-  width: 150px;
+  background-color: ${background.primary};
+
+  position: absolute;
 
   ${until.tablet} {
     margin-top: 4px;
@@ -47,7 +54,10 @@ const link = css`
   position: relative;
   text-decoration: none;
   margin-top: 1px;
-  padding: 8px 8px;
+  padding-top: 8px;
+  padding-right: 30px;
+  padding-bottom: 8px;
+  padding-left: 8px;
   width: 100%;
   cursor: pointer;
   background-color: white;

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -18,7 +18,7 @@ type Props = {
   label: string;
   links: DropdownLinkType[];
   pillar: Pillar;
-  onFilterClick: (value: string) => void;
+  onSelect: (value: string) => void;
 };
 
 const ulStyles = css`
@@ -145,13 +145,7 @@ const labelStyles = css`
   color: ${neutral[46]};
 `;
 
-export const Dropdown = ({
-  id,
-  label,
-  links,
-  pillar,
-  onFilterClick
-}: Props) => {
+export const Dropdown = ({ id, label, links, pillar, onSelect }: Props) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
   useEffect(() => {
@@ -205,7 +199,7 @@ export const Dropdown = ({
         {links.map((l, index) => (
           <li key={l.title}>
             <button
-              onClick={() => onFilterClick(l.value)}
+              onClick={() => onSelect(l.value)}
               className={cx(
                 linkStyles,
                 l.isActive && activeStyles(pillar),

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -12,11 +12,7 @@ import { textSans } from "@guardian/src-foundations/typography";
 import { from, until } from "@guardian/src-foundations/mq";
 import { visuallyHidden } from "@guardian/src-foundations/accessibility";
 
-export interface DropdownLinkType {
-  url: string;
-  title: string;
-  isActive?: boolean;
-}
+import { DropdownLinkType } from "../../types";
 
 interface Props {
   id: string;

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,0 +1,274 @@
+import React, { useState, useEffect } from "react";
+import { css, cx } from "emotion";
+
+import { palette } from "@guardian/src-foundations";
+import {
+  neutral,
+  border,
+  brandText,
+  brandAlt
+} from "@guardian/src-foundations/palette";
+import { textSans } from "@guardian/src-foundations/typography";
+import { from, until } from "@guardian/src-foundations/mq";
+import { visuallyHidden } from "@guardian/src-foundations/accessibility";
+
+export interface DropdownLinkType {
+  url: string;
+  title: string;
+  isActive?: boolean;
+  dataLinkName: string;
+}
+
+interface Props {
+  id: string;
+  label: string;
+  links: DropdownLinkType[];
+  dataLinkName: string;
+}
+
+const input = css`
+  ${visuallyHidden};
+  :checked + ul {
+    display: block;
+  }
+`;
+
+const ul = css`
+  z-index: 1072;
+  list-style: none;
+  background-color: white;
+  padding: 6px 0;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+  display: none;
+
+  ${until.tablet} {
+    position: fixed;
+    border-radius: 0;
+    top: 32px;
+    left: 0;
+    right: 0;
+    width: auto;
+    max-height: calc(100% - 50px);
+    overflow: auto;
+  }
+
+  ${from.tablet} {
+    position: absolute;
+    right: 0;
+    width: 200px;
+    border-radius: 3px;
+  }
+`;
+
+const ulExpanded = css`
+  display: block;
+`;
+
+const link = css`
+  ${textSans.small()};
+  color: ${palette.neutral[7]};
+  position: relative;
+  transition: color 80ms ease-out;
+  margin: -1px 0 0 0;
+  text-decoration: none;
+  display: block;
+  padding: 10px 18px 15px 30px;
+
+  :hover {
+    background-color: ${neutral[93]};
+    text-decoration: none;
+  }
+
+  :focus {
+    text-decoration: underline;
+  }
+
+  :before {
+    content: "";
+    border-top: 1px solid ${border.secondary};
+    display: block;
+    position: absolute;
+    top: 0px;
+    left: 30px;
+    right: 0px;
+  }
+`;
+
+const linkActive = css`
+  font-weight: bold;
+
+  :after {
+    content: "";
+    border: 2px solid ${palette.news.main};
+    border-top: 0px;
+    border-right: 0px;
+    position: absolute;
+    top: 19px;
+    left: 12px;
+    width: 10px;
+    height: 4px;
+    transform: rotate(-45deg);
+  }
+`;
+
+const linkFirst = css`
+  :before {
+    content: none;
+  }
+`;
+
+const button = css`
+  ${textSans.medium()};
+  display: block;
+  cursor: pointer;
+  background: none;
+  border: none;
+  /* Design System: The buttons should be components that handle their own layout using primitives  */
+  line-height: 1.2;
+  color: ${brandText.primary};
+  transition: color 80ms ease-out;
+  padding: 0px 10px 6px 5px;
+  margin: 1px 0 0;
+  text-decoration: none;
+
+  :hover {
+    color: ${brandAlt[400]};
+
+    :after {
+      transform: translateY(0) rotate(45deg);
+    }
+  }
+
+  :after {
+    content: "";
+    display: inline-block;
+    width: 5px;
+    height: 5px;
+    transform: translateY(-2px) rotate(45deg);
+    border: 1px solid currentColor;
+    border-left: transparent;
+    border-top: transparent;
+    margin-left: 5px;
+    vertical-align: middle;
+    transition: transform 250ms ease-out;
+  }
+`;
+
+const buttonExpanded = css`
+  :hover:after {
+    transform: translateY(-1px) rotate(-135deg);
+  }
+  :after {
+    transform: translateY(1px) rotate(-135deg);
+  }
+`;
+
+export const Dropdown = ({ id, label, links, dataLinkName }: Props) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [noJS, setNoJS] = useState(true);
+
+  useEffect(() => {
+    // If hook runs we know client-side JS is enabled
+    setNoJS(false);
+  }, []);
+
+  useEffect(() => {
+    const dismissOnEsc = (event: KeyboardEvent) => {
+      if (isExpanded && event.code === "Escape") {
+        setIsExpanded(false);
+      }
+    };
+
+    document.addEventListener("keydown", dismissOnEsc, false);
+
+    // Remove listener on unmount
+    return () => document.removeEventListener("keydown", dismissOnEsc);
+  }, [isExpanded]);
+
+  useEffect(() => {
+    const dismissOnClick = (event: MouseEvent) => {
+      if (isExpanded) {
+        event.stopPropagation();
+        setIsExpanded(false);
+      }
+    };
+
+    document.addEventListener("click", dismissOnClick, false);
+
+    // Remove listener on unmount
+    return () => document.removeEventListener("click", dismissOnClick);
+  }, [isExpanded]);
+
+  const handleToggle = () => setIsExpanded(!isExpanded);
+
+  // needs to be unique to allow multiple dropdowns on same page
+  // this should be unique because JS is single-threaded
+  const dropdownID = `dropbox-id-${id}`;
+  const checkboxID = `checkbox-id-${id}`;
+
+  return (
+    <>
+      {noJS ? (
+        <label
+          htmlFor={checkboxID}
+          className={cx({
+            [button]: true,
+            [buttonExpanded]: isExpanded
+          })}
+          aria-controls={dropdownID}
+          aria-expanded={isExpanded ? "true" : "false"}
+          role="button"
+        >
+          <input
+            className={input}
+            type="checkbox"
+            id={checkboxID}
+            aria-controls={dropdownID}
+            aria-checked="false"
+            tabIndex={-1}
+            key="OpenMainMenuCheckbox"
+            role="menuitemcheckbox"
+          />
+          {label}
+        </label>
+      ) : (
+        <button
+          onClick={handleToggle}
+          className={cx({
+            [button]: true,
+            [buttonExpanded]: isExpanded
+          })}
+          aria-controls={dropdownID}
+          aria-expanded={isExpanded ? "true" : "false"}
+          data-link-name={dataLinkName}
+        >
+          {label}
+        </button>
+      )}
+
+      <ul
+        id={dropdownID}
+        className={cx({
+          [ul]: true,
+          [ulExpanded]: isExpanded
+        })}
+      >
+        {links.map((l, index) => (
+          <li key={l.title}>
+            <a
+              href={l.url}
+              className={cx({
+                [link]: true,
+                [linkActive]: !!l.isActive,
+                [linkFirst]: index === 0
+              })}
+              data-link-name={l.dataLinkName}
+            >
+              {l.title}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+};

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -21,28 +21,21 @@ type Props = {
 };
 
 const ul = css`
-  z-index: 1072;
+  z-index: 2;
   list-style: none;
-  background-color: white;
-  padding: 6px 0;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+  border: 1px solid ${palette.neutral[93]};
+  padding: 0;
   display: none;
-
   ${until.tablet} {
-    position: fixed;
+    margin-top: 4px;
     border-radius: 0;
-    top: 32px;
-    left: 0;
-    right: 0;
-    width: auto;
-    max-height: calc(100% - 50px);
+    width: 120px;
     overflow: auto;
   }
 
   ${from.tablet} {
-    position: absolute;
-    right: 0;
-    width: 200px;
+    margin-top: 12px;
+    width: 120px;
     border-radius: 3px;
   }
 `;
@@ -52,33 +45,28 @@ const ulExpanded = css`
 `;
 
 const link = css`
-  ${textSans.small()};
-  color: ${palette.neutral[7]};
+  ${textSans.xsmall()};
   position: relative;
-  transition: color 80ms ease-out;
-  margin: -1px 0 0 0;
   text-decoration: none;
-  display: block;
-  padding: 10px 18px 15px 30px;
+  margin-top: 1px;
+  padding: 8px 4px;
+  width: 100%;
+  cursor: pointer;
+  background-color: white;
+  border: none;
 
   :hover {
     background-color: ${neutral[93]};
-    text-decoration: none;
+    text-decoration: underline;
   }
 
   :focus {
     text-decoration: underline;
   }
+`;
 
-  :before {
-    content: "";
-    border-top: 1px solid ${border.secondary};
-    display: block;
-    position: absolute;
-    top: 0px;
-    left: 30px;
-    right: 0px;
-  }
+const linkFirst = css`
+  margin-top: 0;
 `;
 
 const linkActive = css`
@@ -90,36 +78,30 @@ const linkActive = css`
     border-top: 0px;
     border-right: 0px;
     position: absolute;
-    top: 19px;
+    top: 14px;
     left: 12px;
-    width: 10px;
+    width: 8px;
     height: 4px;
     transform: rotate(-45deg);
   }
 `;
 
-const linkFirst = css`
-  :before {
-    content: none;
-  }
-`;
-
 const button = css`
-  ${textSans.medium()};
+  ${textSans.xsmall()};
   display: block;
   cursor: pointer;
   background: none;
   border: none;
   /* Design System: The buttons should be components that handle their own layout using primitives  */
   line-height: 1.2;
-  color: ${brandText.primary};
+  /* color: ${brandText.primary}; */
   transition: color 80ms ease-out;
   padding: 0px 10px 6px 5px;
   margin: 1px 0 0;
   text-decoration: none;
 
   :hover {
-    color: ${brandAlt[400]};
+    /* color: ${brandAlt[400]}; */
 
     :after {
       transform: translateY(0) rotate(45deg);
@@ -213,7 +195,7 @@ export const Dropdown = ({ id, label, links, onFilterClick }: Props) => {
               onClick={() => onFilterClick(l.value)}
               className={cx({
                 [link]: true,
-                [linkActive]: !!l.isActive,
+                [linkActive]: l.isActive,
                 [linkFirst]: index === 0
               })}
             >

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -209,6 +209,7 @@ export const Dropdown = ({ id, label, links, onFilterClick }: Props) => {
                 [linkActive]: l.isActive,
                 [linkFirst]: index === 0
               })}
+              disabled={l.isActive}
             >
               {l.title}
             </button>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -2,12 +2,7 @@ import React, { useState, useEffect } from "react";
 import { css, cx } from "emotion";
 
 import { palette } from "@guardian/src-foundations";
-import {
-  neutral,
-  border,
-  brandText,
-  brandAlt
-} from "@guardian/src-foundations/palette";
+import { neutral, border, brandAlt } from "@guardian/src-foundations/palette";
 import { textSans } from "@guardian/src-foundations/typography";
 import { from, until } from "@guardian/src-foundations/mq";
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -14,11 +14,11 @@ import { visuallyHidden } from "@guardian/src-foundations/accessibility";
 
 import { DropdownLinkType } from "../../types";
 
-interface Props {
+type Props = {
   id: string;
   label: string;
   links: DropdownLinkType[];
-}
+};
 
 const input = css`
   ${visuallyHidden};

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -11,12 +11,13 @@ import {
 import { textSans } from "@guardian/src-foundations/typography";
 import { from, until } from "@guardian/src-foundations/mq";
 
-import { DropdownLinkType } from "../../types";
+import { DropdownLinkType, Pillar } from "../../types";
 
 type Props = {
   id: string;
   label: string;
   links: DropdownLinkType[];
+  pillar: Pillar;
   onFilterClick: (value: string) => void;
 };
 
@@ -77,12 +78,12 @@ const firstStyles = css`
   margin-top: 0;
 `;
 
-const activeStyles = css`
+const activeStyles = (pillar: Pillar) => css`
   font-weight: bold;
 
   :after {
     content: "";
-    border: 2px solid ${palette.news.main};
+    border: 2px solid ${palette[pillar].main};
     border-top: 0px;
     border-right: 0px;
     position: absolute;
@@ -144,7 +145,13 @@ const labelStyles = css`
   color: ${neutral[46]};
 `;
 
-export const Dropdown = ({ id, label, links, onFilterClick }: Props) => {
+export const Dropdown = ({
+  id,
+  label,
+  links,
+  pillar,
+  onFilterClick
+}: Props) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
   useEffect(() => {
@@ -201,7 +208,7 @@ export const Dropdown = ({ id, label, links, onFilterClick }: Props) => {
               onClick={() => onFilterClick(l.value)}
               className={cx(
                 linkStyles,
-                l.isActive && activeStyles,
+                l.isActive && activeStyles(pillar),
                 index === 0 && firstStyles
               )}
               disabled={l.isActive}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -16,14 +16,12 @@ export interface DropdownLinkType {
   url: string;
   title: string;
   isActive?: boolean;
-  dataLinkName: string;
 }
 
 interface Props {
   id: string;
   label: string;
   links: DropdownLinkType[];
-  dataLinkName: string;
 }
 
 const input = css`
@@ -163,7 +161,7 @@ const buttonExpanded = css`
   }
 `;
 
-export const Dropdown = ({ id, label, links, dataLinkName }: Props) => {
+export const Dropdown = ({ id, label, links }: Props) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [noJS, setNoJS] = useState(true);
 
@@ -240,7 +238,6 @@ export const Dropdown = ({ id, label, links, dataLinkName }: Props) => {
           })}
           aria-controls={dropdownID}
           aria-expanded={isExpanded ? "true" : "false"}
-          data-link-name={dataLinkName}
         >
           {label}
         </button>
@@ -262,7 +259,6 @@ export const Dropdown = ({ id, label, links, dataLinkName }: Props) => {
                 [linkActive]: !!l.isActive,
                 [linkFirst]: index === 0
               })}
-              data-link-name={l.dataLinkName}
             >
               {l.title}
             </a>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -195,7 +195,7 @@ export const Dropdown = ({ id, label, links, onFilterClick }: Props) => {
           aria-controls={dropdownID}
           aria-expanded={isExpanded ? "true" : "false"}
         >
-          {activeLink && activeLink.title}
+          {activeLink ? activeLink.title : "Please select"}
         </button>
       </div>
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -159,12 +159,6 @@ const buttonExpanded = css`
 
 export const Dropdown = ({ id, label, links }: Props) => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const [noJS, setNoJS] = useState(true);
-
-  useEffect(() => {
-    // If hook runs we know client-side JS is enabled
-    setNoJS(false);
-  }, []);
 
   useEffect(() => {
     const dismissOnEsc = (event: KeyboardEvent) => {
@@ -198,46 +192,20 @@ export const Dropdown = ({ id, label, links }: Props) => {
   // needs to be unique to allow multiple dropdowns on same page
   // this should be unique because JS is single-threaded
   const dropdownID = `dropbox-id-${id}`;
-  const checkboxID = `checkbox-id-${id}`;
 
   return (
     <>
-      {noJS ? (
-        <label
-          htmlFor={checkboxID}
-          className={cx({
-            [button]: true,
-            [buttonExpanded]: isExpanded
-          })}
-          aria-controls={dropdownID}
-          aria-expanded={isExpanded ? "true" : "false"}
-          role="button"
-        >
-          <input
-            className={input}
-            type="checkbox"
-            id={checkboxID}
-            aria-controls={dropdownID}
-            aria-checked="false"
-            tabIndex={-1}
-            key="OpenMainMenuCheckbox"
-            role="menuitemcheckbox"
-          />
-          {label}
-        </label>
-      ) : (
-        <button
-          onClick={handleToggle}
-          className={cx({
-            [button]: true,
-            [buttonExpanded]: isExpanded
-          })}
-          aria-controls={dropdownID}
-          aria-expanded={isExpanded ? "true" : "false"}
-        >
-          {label}
-        </button>
-      )}
+      <button
+        onClick={handleToggle}
+        className={cx({
+          [button]: true,
+          [buttonExpanded]: isExpanded
+        })}
+        aria-controls={dropdownID}
+        aria-expanded={isExpanded ? "true" : "false"}
+      >
+        {label}
+      </button>
 
       <ul
         id={dropdownID}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -27,6 +27,8 @@ const ul = css`
   margin-left: -8px;
   padding: 0;
   display: none;
+  width: 150px;
+
   ${until.tablet} {
     margin-top: 4px;
     border-radius: 0;

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -10,7 +10,6 @@ import {
 } from "@guardian/src-foundations/palette";
 import { textSans } from "@guardian/src-foundations/typography";
 import { from, until } from "@guardian/src-foundations/mq";
-import { visuallyHidden } from "@guardian/src-foundations/accessibility";
 
 import { DropdownLinkType } from "../../types";
 
@@ -18,14 +17,8 @@ type Props = {
   id: string;
   label: string;
   links: DropdownLinkType[];
+  onFilterClick: (value: string) => void;
 };
-
-const input = css`
-  ${visuallyHidden};
-  :checked + ul {
-    display: block;
-  }
-`;
 
 const ul = css`
   z-index: 1072;
@@ -157,7 +150,7 @@ const buttonExpanded = css`
   }
 `;
 
-export const Dropdown = ({ id, label, links }: Props) => {
+export const Dropdown = ({ id, label, links, onFilterClick }: Props) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
   useEffect(() => {
@@ -216,8 +209,8 @@ export const Dropdown = ({ id, label, links }: Props) => {
       >
         {links.map((l, index) => (
           <li key={l.title}>
-            <a
-              href={l.url}
+            <button
+              onClick={() => onFilterClick(l.value)}
               className={cx({
                 [link]: true,
                 [linkActive]: !!l.isActive,
@@ -225,7 +218,7 @@ export const Dropdown = ({ id, label, links }: Props) => {
               })}
             >
               {l.title}
-            </a>
+            </button>
           </li>
         ))}
       </ul>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -20,7 +20,7 @@ type Props = {
   onFilterClick: (value: string) => void;
 };
 
-const ul = css`
+const ulStyles = css`
   z-index: 2;
   list-style: none;
   border: 1px solid ${border.secondary};
@@ -47,7 +47,7 @@ const ulExpanded = css`
   display: block;
 `;
 
-const link = css`
+const linkStyles = css`
   ${textSans.xsmall()};
   text-align: left;
   color: ${neutral[46]};
@@ -73,11 +73,11 @@ const link = css`
   }
 `;
 
-const linkFirst = css`
+const firstStyles = css`
   margin-top: 0;
 `;
 
-const linkActive = css`
+const activeStyles = css`
   font-weight: bold;
 
   :after {
@@ -94,7 +94,7 @@ const linkActive = css`
   }
 `;
 
-const button = css`
+const buttonStyles = css`
   display: block;
   cursor: pointer;
   background: none;
@@ -130,7 +130,7 @@ const button = css`
   }
 `;
 
-const buttonExpanded = css`
+const expandedStyles = css`
   :hover:after {
     transform: translateY(-1px) rotate(-135deg);
   }
@@ -188,10 +188,7 @@ export const Dropdown = ({ id, label, links, onFilterClick }: Props) => {
         {label}
         <button
           onClick={handleToggle}
-          className={cx({
-            [button]: true,
-            [buttonExpanded]: isExpanded
-          })}
+          className={cx(buttonStyles, isExpanded && expandedStyles)}
           aria-controls={dropdownID}
           aria-expanded={isExpanded ? "true" : "false"}
         >
@@ -199,22 +196,16 @@ export const Dropdown = ({ id, label, links, onFilterClick }: Props) => {
         </button>
       </div>
 
-      <ul
-        id={dropdownID}
-        className={cx({
-          [ul]: true,
-          [ulExpanded]: isExpanded
-        })}
-      >
+      <ul id={dropdownID} className={cx(ulStyles, isExpanded && ulExpanded)}>
         {links.map((l, index) => (
           <li key={l.title}>
             <button
               onClick={() => onFilterClick(l.value)}
-              className={cx({
-                [link]: true,
-                [linkActive]: l.isActive,
-                [linkFirst]: index === 0
-              })}
+              className={cx(
+                linkStyles,
+                l.isActive && activeStyles,
+                index === 0 && firstStyles
+              )}
               disabled={l.isActive}
             >
               {l.title}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -95,8 +95,7 @@ const linkActive = css`
 `;
 
 const button = css`
-  display: inline;
-  font-weight: bold;
+  display: block;
   cursor: pointer;
   background: none;
   border: none;
@@ -104,7 +103,7 @@ const button = css`
   line-height: 1.2;
   color: ${neutral[46]};
   transition: color 80ms ease-out;
-  padding: 0px 10px 6px 5px;
+  padding: 0px 10px 6px 0px;
   margin: 1px 0 0;
   text-decoration: none;
 
@@ -141,7 +140,7 @@ const buttonExpanded = css`
 `;
 
 const labelStyles = css`
-  ${textSans.xsmall()};
+  ${textSans.xsmall({ fontWeight: "bold" })};
   color: ${neutral[46]};
 `;
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -174,8 +174,6 @@ export const Dropdown = ({ id, label, links, onFilterClick }: Props) => {
     return () => document.removeEventListener("click", dismissOnClick);
   }, [isExpanded]);
 
-  const handleToggle = () => setIsExpanded(!isExpanded);
-
   // needs to be unique to allow multiple dropdowns on same page
   // this should be unique because JS is single-threaded
   const dropdownID = `dropbox-id-${id}`;
@@ -187,7 +185,7 @@ export const Dropdown = ({ id, label, links, onFilterClick }: Props) => {
       <div className={labelStyles}>
         {label}
         <button
-          onClick={handleToggle}
+          onClick={() => setIsExpanded(!isExpanded)}
           className={cx(buttonStyles, isExpanded && expandedStyles)}
           aria-controls={dropdownID}
           aria-expanded={isExpanded ? "true" : "false"}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from "react";
 import { css, cx } from "emotion";
 
+import FocusLock from "react-focus-lock";
+
 import { palette } from "@guardian/src-foundations";
 import {
   neutral,
@@ -194,24 +196,25 @@ export const Dropdown = ({ id, label, options, pillar, onSelect }: Props) => {
           {activeLink ? activeLink.title : "Please select"}
         </button>
       </div>
-
-      <ul id={dropdownID} className={cx(ulStyles, isExpanded && ulExpanded)}>
-        {options.map((option, index) => (
-          <li key={option.title}>
-            <button
-              onClick={() => onSelect(option.value)}
-              className={cx(
-                linkStyles,
-                option.isActive && activeStyles(pillar),
-                index === 0 && firstStyles
-              )}
-              disabled={option.isActive}
-            >
-              {option.title}
-            </button>
-          </li>
-        ))}
-      </ul>
+      <FocusLock>
+        <ul id={dropdownID} className={cx(ulStyles, isExpanded && ulExpanded)}>
+          {options.map((option, index) => (
+            <li key={option.title}>
+              <button
+                onClick={() => onSelect(option.value)}
+                className={cx(
+                  linkStyles,
+                  option.isActive && activeStyles(pillar),
+                  index === 0 && firstStyles
+                )}
+                disabled={option.isActive}
+              >
+                {option.title}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </FocusLock>
     </>
   );
 };

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -24,18 +24,17 @@ const ul = css`
   z-index: 2;
   list-style: none;
   border: 1px solid ${border.secondary};
+  margin-left: -8px;
   padding: 0;
   display: none;
   ${until.tablet} {
     margin-top: 4px;
     border-radius: 0;
-    width: 120px;
     overflow: auto;
   }
 
   ${from.tablet} {
     margin-top: 12px;
-    width: 120px;
     border-radius: 3px;
   }
 `;
@@ -46,11 +45,12 @@ const ulExpanded = css`
 
 const link = css`
   ${textSans.xsmall()};
+  text-align: left;
   color: ${neutral[46]};
   position: relative;
   text-decoration: none;
   margin-top: 1px;
-  padding: 8px 4px;
+  padding: 8px 8px;
   width: 100%;
   cursor: pointer;
   background-color: white;
@@ -79,8 +79,8 @@ const linkActive = css`
     border-top: 0px;
     border-right: 0px;
     position: absolute;
-    top: 14px;
-    left: 12px;
+    top: 12px;
+    right: 12px;
     width: 8px;
     height: 4px;
     transform: rotate(-45deg);

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -11,12 +11,12 @@ import {
 import { textSans } from "@guardian/src-foundations/typography";
 import { from, until } from "@guardian/src-foundations/mq";
 
-import { DropdownLinkType, Pillar } from "../../types";
+import { DropdownOptionType, Pillar } from "../../types";
 
 type Props = {
   id: string;
   label: string;
-  links: DropdownLinkType[];
+  options: DropdownOptionType[];
   pillar: Pillar;
   onSelect: (value: string) => void;
 };
@@ -145,7 +145,7 @@ const labelStyles = css`
   color: ${neutral[46]};
 `;
 
-export const Dropdown = ({ id, label, links, pillar, onSelect }: Props) => {
+export const Dropdown = ({ id, label, options, pillar, onSelect }: Props) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
   useEffect(() => {
@@ -179,7 +179,7 @@ export const Dropdown = ({ id, label, links, pillar, onSelect }: Props) => {
   // this should be unique because JS is single-threaded
   const dropdownID = `dropbox-id-${id}`;
 
-  const activeLink = links.find(link => link.isActive);
+  const activeLink = options.find(option => option.isActive);
 
   return (
     <>
@@ -196,18 +196,18 @@ export const Dropdown = ({ id, label, links, pillar, onSelect }: Props) => {
       </div>
 
       <ul id={dropdownID} className={cx(ulStyles, isExpanded && ulExpanded)}>
-        {links.map((l, index) => (
-          <li key={l.title}>
+        {options.map((option, index) => (
+          <li key={option.title}>
             <button
-              onClick={() => onSelect(l.value)}
+              onClick={() => onSelect(option.value)}
               className={cx(
                 linkStyles,
-                l.isActive && activeStyles(pillar),
+                option.isActive && activeStyles(pillar),
                 index === 0 && firstStyles
               )}
-              disabled={l.isActive}
+              disabled={option.isActive}
             >
-              {l.title}
+              {option.title}
             </button>
           </li>
         ))}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -23,7 +23,7 @@ type Props = {
 const ul = css`
   z-index: 2;
   list-style: none;
-  border: 1px solid ${palette.neutral[93]};
+  border: 1px solid ${border.secondary};
   padding: 0;
   display: none;
   ${until.tablet} {
@@ -46,6 +46,7 @@ const ulExpanded = css`
 
 const link = css`
   ${textSans.xsmall()};
+  color: ${neutral[46]};
   position: relative;
   text-decoration: none;
   margin-top: 1px;
@@ -94,7 +95,7 @@ const button = css`
   border: none;
   /* Design System: The buttons should be components that handle their own layout using primitives  */
   line-height: 1.2;
-  /* color: ${brandText.primary}; */
+  color: ${neutral[46]};
   transition: color 80ms ease-out;
   padding: 0px 10px 6px 5px;
   margin: 1px 0 0;
@@ -134,6 +135,7 @@ const buttonExpanded = css`
 
 const labelStyles = css`
   ${textSans.xsmall()};
+  color: ${neutral[46]};
 `;
 
 export const Dropdown = ({ id, label, links, onFilterClick }: Props) => {

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -5,8 +5,6 @@ import { space, neutral } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
 import { until } from "@guardian/src-foundations/mq";
 
-import { Dropdown } from "../Dropdown/Dropdown";
-
 import { FilterOptions, OrderByType, ThreadsType } from "../../types";
 
 type Props = {

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -5,6 +5,8 @@ import { space, neutral } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
 import { until } from "@guardian/src-foundations/mq";
 
+import { Dropdown } from "../Dropdown/Dropdown";
+
 import { FilterOptions, OrderByType, ThreadsType } from "../../types";
 
 type Props = {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -94,7 +94,7 @@ export interface DiscussionOptions {
   page: number;
 }
 
-export type DropdownLinkType = {
+export type DropdownOptionType = {
   value: string;
   title: string;
   isActive?: boolean;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -93,3 +93,9 @@ export interface DiscussionOptions {
   maxResponses: number;
   page: number;
 }
+
+export type DropdownLinkType = {
+  url: string;
+  title: string;
+  isActive?: boolean;
+};

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -95,7 +95,7 @@ export interface DiscussionOptions {
 }
 
 export type DropdownLinkType = {
-  url: string;
+  value: string;
   title: string;
   isActive?: boolean;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,12 +1043,19 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6":
+"@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.3.tgz#0811944f73a6c926bb2ad35e918dcc1bfab279f1"
   integrity sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==
   dependencies:
     regenerator-runtime "^0.13.2"
+
+"@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+  version "7.8.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.7.tgz#8fefce9802db54881ba59f90bb28719b4996324d"
+  integrity sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
 
 "@babel/template@^7.4.0", "@babel/template@^7.7.4":
   version "7.7.4"
@@ -1478,11 +1485,6 @@
     invariant "^2.2.3"
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
-
-"@sheerun/mutationobserver-shim@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
-  integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
 
 "@storybook/addon-viewport@^5.3.13":
   version "5.3.13"
@@ -1923,41 +1925,41 @@
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
 
-"@testing-library/dom@^6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.11.0.tgz#962a38f1a721fdb7c9e35e7579e33ff13a00eda4"
-  integrity sha512-Pkx9LMIGshyNbfmecjt18rrAp/ayMqGH674jYER0SXj0iG9xZc+zWRjk2Pg9JgPBDvwI//xGrI/oOQkAi4YEew==
+"@testing-library/dom@^7.0.2":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.0.4.tgz#89909046b4a2818d423dd2c786faee4ddbe32838"
+  integrity sha512-+vrLcGDvopLPsBB7JgJhf8ZoOhBSeCsI44PKJL9YoKrP2AvCkqrTg+z77wEEZJ4tSNdxV0kymil7hSvsQQ7jMQ==
   dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@sheerun/mutationobserver-shim" "^0.3.2"
-    "@types/testing-library__dom" "^6.0.0"
-    aria-query "3.0.0"
-    pretty-format "^24.9.0"
-    wait-for-expect "^3.0.0"
+    "@babel/runtime" "^7.8.4"
+    "@types/testing-library__dom" "^6.12.1"
+    aria-query "^4.0.2"
+    dom-accessibility-api "^0.3.0"
+    pretty-format "^25.1.0"
 
-"@testing-library/jest-dom@^4.2.4":
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-4.2.4.tgz#00dfa0cbdd837d9a3c2a7f3f0a248ea6e7b89742"
-  integrity sha512-j31Bn0rQo12fhCWOUWy9fl7wtqkp7In/YP2p5ZFyRuiiB9Qs3g+hS4gAmDWONbAHcRmVooNJ5eOHQDCOmUFXHg==
+"@testing-library/jest-dom@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.1.1.tgz#e88a5c08f9b9f36b384f948a0532eae2abbc8204"
+  integrity sha512-7xnmBFcUmmUVAUhFiZ/u3CxFh1e46THAwra4SiiKNCW4By26RedCRwEk0rtleFPZG0wlTSNOKDvJjWYy93dp0w==
   dependencies:
-    "@babel/runtime" "^7.5.1"
-    chalk "^2.4.1"
-    css "^2.2.3"
+    "@babel/runtime" "^7.8.3"
+    "@types/testing-library__jest-dom" "^5.0.0"
+    chalk "^3.0.0"
+    css "^2.2.4"
     css.escape "^1.5.1"
-    jest-diff "^24.0.0"
-    jest-matcher-utils "^24.0.0"
-    lodash "^4.17.11"
-    pretty-format "^24.0.0"
+    jest-diff "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    lodash "^4.17.15"
+    pretty-format "^25.1.0"
     redent "^3.0.0"
 
-"@testing-library/react@^9.3.2":
-  version "9.4.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-9.4.0.tgz#b021ac8cb987c8dc54c6841875f745bf9b2e88e5"
-  integrity sha512-XdhDWkI4GktUPsz0AYyeQ8M9qS/JFie06kcSnUVcpgOwFjAu9vhwR83qBl+lw9yZWkbECjL8Hd+n5hH6C0oWqg==
+"@testing-library/react@^10.0.1":
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-10.0.1.tgz#4f5e2a8836257c5bd3df640b21d7bea5a0d83ead"
+  integrity sha512-sMHWud2dcymOzq2AhEniICSijEwKeTiBX+K0y36FYNY7wH2t0SIP1o732Bf5dDY0jYoMC2hj2UJSVpZC/rDsWg==
   dependencies:
-    "@babel/runtime" "^7.7.6"
-    "@testing-library/dom" "^6.11.0"
-    "@types/testing-library__react" "^9.1.2"
+    "@babel/runtime" "^7.8.7"
+    "@testing-library/dom" "^7.0.2"
+    "@types/testing-library__react" "^9.1.3"
 
 "@testing-library/user-event@^7.1.2":
   version "7.2.1"
@@ -2051,6 +2053,14 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@*":
+  version "25.1.4"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.1.4.tgz#9e9f1e59dda86d3fd56afce71d1ea1b331f6f760"
+  integrity sha512-QDDY2uNAhCV7TMCITrxz+MRk1EizcsevzfeS6LykIlq2V1E5oO4wXG8V2ZEd9w7Snxeeagk46YbMgZ8ESHx3sw==
+  dependencies:
+    jest-diff "^25.1.0"
+    pretty-format "^25.1.0"
+
 "@types/jest@^25.1.0":
   version "25.1.0"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.1.0.tgz#b3955aa0be6057c65c0bfb11ac2ef1e078598d76"
@@ -2140,20 +2150,28 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/testing-library__dom@*", "@types/testing-library__dom@^6.0.0":
-  version "6.11.1"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-6.11.1.tgz#6058a6ac391db679f7c60dbb27b81f0620de2dd9"
-  integrity sha512-ImChHtQqmjwraRLqBC2sgSQFtczeFvBmBcfhTYZn/3KwXbyD07LQykEQ0xJo7QHc1GbVvf7pRyGaIe6PkCdxEw==
+"@types/testing-library__dom@*", "@types/testing-library__dom@^6.12.1":
+  version "6.14.0"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-6.14.0.tgz#1aede831cb4ed4a398448df5a2c54b54a365644e"
+  integrity sha512-sMl7OSv0AvMOqn1UJ6j1unPMIHRXen0Ita1ujnMX912rrOcawe4f7wu0Zt9GIQhBhJvH2BaibqFgQ3lP+Pj2hA==
   dependencies:
     pretty-format "^24.3.0"
 
-"@types/testing-library__react@^9.1.2":
-  version "9.1.2"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__react/-/testing-library__react-9.1.2.tgz#e33af9124c60a010fc03a34eff8f8a34a75c4351"
-  integrity sha512-CYaMqrswQ+cJACy268jsLAw355DZtPZGt3Jwmmotlcu8O/tkoXBI6AeZ84oZBJsIsesozPKzWzmv/0TIU+1E9Q==
+"@types/testing-library__jest-dom@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.0.2.tgz#89b782e0f187fe1e80d6375133da74182ba02065"
+  integrity sha512-dZP+/WHndgCSmdaImITy0KhjGAa9c0hlGGkzefbtrPFpnGEPZECDA0zyvfSp8RKhHECJJSKHFExjOwzo0rHyIA==
+  dependencies:
+    "@types/jest" "*"
+
+"@types/testing-library__react@^9.1.3":
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react/-/testing-library__react-9.1.3.tgz#35eca61cc6ea923543796f16034882a1603d7302"
+  integrity sha512-iCdNPKU3IsYwRK9JieSYAiX0+aYDXOGAmrC/3/M7AqqSDKnWWVv07X+Zk1uFSL7cMTUYzv4lQRfohucEocn5/w==
   dependencies:
     "@types/react-dom" "*"
     "@types/testing-library__dom" "*"
+    pretty-format "^25.1.0"
 
 "@types/use-persisted-state@^0.3.0":
   version "0.3.0"
@@ -2622,13 +2640,21 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@3.0.0, aria-query@^3.0.0:
+aria-query@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
   integrity sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=
   dependencies:
     ast-types-flow "0.0.7"
     commander "^2.11.0"
+
+aria-query@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.0.2.tgz#250687b4ccde1ab86d127da0432ae3552fc7b145"
+  integrity sha512-S1G1V790fTaigUSM/Gd0NngzEfiMy9uTUfMyHhKhVyy4cH5O/eTuR01ydhGL0z4Za1PXFTRGH3qL8VhUQuEO5w==
+  dependencies:
+    "@babel/runtime" "^7.7.4"
+    "@babel/runtime-corejs3" "^7.7.4"
 
 arity-n@^1.0.4:
   version "1.0.4"
@@ -4463,7 +4489,7 @@ css.escape@^1.5.1:
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
 
-css@^2.0.0, css@^2.2.3:
+css@^2.0.0, css@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
   integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
@@ -4854,6 +4880,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz#511e5993dd673b97c87ea47dba0e3892f7e0c983"
+  integrity sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -7383,7 +7414,7 @@ jest-config@^24.9.0:
     pretty-format "^24.9.0"
     realpath-native "^1.1.0"
 
-jest-diff@^24.0.0, jest-diff@^24.9.0:
+jest-diff@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
   integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
@@ -7512,7 +7543,7 @@ jest-leak-detector@^24.9.0:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
 
-jest-matcher-utils@^24.0.0, jest-matcher-utils@^24.9.0:
+jest-matcher-utils@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz#f5b3661d5e628dffe6dd65251dfdae0e87c3a073"
   integrity sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
@@ -7521,6 +7552,16 @@ jest-matcher-utils@^24.0.0, jest-matcher-utils@^24.9.0:
     jest-diff "^24.9.0"
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
+
+jest-matcher-utils@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-25.1.0.tgz#fa5996c45c7193a3c24e73066fc14acdee020220"
+  integrity sha512-KGOAFcSFbclXIFE7bS4C53iYobKI20ZWleAdAFun4W1Wz1Kkej8Ng6RRbhL8leaEvIOjGXhGf/a1JjO8bkxIWQ==
+  dependencies:
+    chalk "^3.0.0"
+    jest-diff "^25.1.0"
+    jest-get-type "^25.1.0"
+    pretty-format "^25.1.0"
 
 jest-message-util@^24.9.0:
   version "24.9.0"
@@ -10243,7 +10284,7 @@ pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
-pretty-format@^24.0.0, pretty-format@^24.3.0, pretty-format@^24.9.0:
+pretty-format@^24.3.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -10963,6 +11004,11 @@ regenerator-runtime@^0.13.2, regenerator-runtime@^0.13.3:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
+regenerator-runtime@^0.13.4:
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
+  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
 
 regenerator-transform@^0.14.0:
   version "0.14.1"
@@ -12861,11 +12907,6 @@ w3c-xmlserializer@^1.1.2:
     domexception "^1.0.1"
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
-
-wait-for-expect@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.1.tgz#ec204a76b0038f17711e575720aaf28505ac7185"
-  integrity sha512-3Ha7lu+zshEG/CeHdcpmQsZnnZpPj/UsG3DuKO8FskjuDbkx3jE3845H+CuwZjA2YWYDfKMU2KhnCaXMLd3wVw==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10711,7 +10711,7 @@ react-fast-compare@^2.0.4:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
-react-focus-lock@^2.1.0:
+react-focus-lock@^2.1.0, react-focus-lock@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.2.1.tgz#1d12887416925dc53481914b7cedd39494a3b24a"
   integrity sha512-47g0xYcCTZccdzKRGufepY8oZ3W1Qg+2hn6u9SHZ0zUB6uz/4K4xJe7yYFNZ1qT6m+2JDm82F6QgKeBTbjW4PQ==


### PR DESCRIPTION
## What does this change?
This adds a custom Dropdown component so we don't need to depend on browser based styling for select fields

```typescript
type DropdownLinkType = {
  value: string;
  title: string;
  isActive?: boolean;
};

type Props = {
  id: string;
  label: string;
  links: DropdownLinkType[];
  pillar: Pillar;
  onSelect: (value: string) => void;
};
```

### With first item selected
![Screenshot 2020-03-14 at 15 00 04](https://user-images.githubusercontent.com/1336821/76684534-92fa4900-6604-11ea-9886-8b50cf894ed5.jpg)


### With nothing selected
![Screenshot 2020-03-14 at 14 31 25](https://user-images.githubusercontent.com/1336821/76684052-9a1f5800-6600-11ea-9e9f-6aabfdcab300.jpg)

### With narrower content
![Screenshot 2020-03-14 at 14 59 54](https://user-images.githubusercontent.com/1336821/76684535-9392df80-6604-11ea-988e-c3f5237fecc5.jpg)



## Why?
There's an argument for keeping classic, simple select styles based on the OS/Browser but the [designs for the filters](https://www.figma.com/file/55MFs13FCdCIfkhcgId4bh/Comment-filter-pagination?node-id=1%3A7) need a more compact look

## Link to supporting Trello card
https://trello.com/c/7V2UJwGq/1231-style-filters
