### PR TITLE
Make this repo public

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@guardian/discussion-rendering",
   "description": "This codebase started as a hack day project by @gtrufitt and @nicl. The purpose is parity of the existing discussion application on Frontend using the discussion API (search for Private Repo).",
   "version": "0.1.0",
-  "private": true,
   "author": "",
   "homepage": "https://github.com/guardian/discussion-rendering#readme",
   "license": "Apache",


### PR DESCRIPTION
## What does this change?
Removes the private flag from the `package.json` file

## Why?
So we can publish as a public package
