### PR TITLE
Added joinUrl function

### DIFF
--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -1,3 +1,5 @@
+import { joinUrl } from "./joinUrl";
+
 import {
   FilterOptions,
   DiscussionResponse,
@@ -12,7 +14,9 @@ const baseURL = "https://discussion.theguardian.com/discussion-api";
 
 let additionalHeaders = {};
 
-export const setAdditionalHeaders = (newAdditionalHeader: AdditionalHeadersType) => additionalHeaders = newAdditionalHeader
+export const setAdditionalHeaders = (
+  newAdditionalHeader: AdditionalHeadersType
+) => (additionalHeaders = newAdditionalHeader);
 
 const objAsParams = (obj: any): string => {
   const params = Object.keys(obj)
@@ -37,7 +41,7 @@ export const getDiscussion = (
   };
   const params = objAsParams(apiOpts);
 
-  const url = baseURL + `/discussion/${shortUrl}` + params;
+  const url = joinUrl([baseURL, "discussion", shortUrl, params]);
 
   return fetch(url, {
     headers: {

--- a/src/lib/joinUrl.ts
+++ b/src/lib/joinUrl.ts
@@ -1,0 +1,17 @@
+export const joinUrl = (parts: string[]) => {
+  // Remove any leading or trailing slashes from all parts and then join cleanly on
+  // a single slash - prevents malformed urls
+  const trimmed = parts
+    .map(part => {
+      // Trim left
+      if (part.substr(0, 1) === "/") return part.slice(1);
+      return part;
+    })
+    .map(part => {
+      // Trim right
+      if (part.substr(part.length - 1, 1) === "/") return part.slice(0, -1);
+      return part;
+    });
+
+  return trimmed.join("/");
+};


### PR DESCRIPTION
## What does this change?
Adds a function to prevent double slashes when constructing urls.

## Why?
Because we have limited control over what strings get given to us and it's better safe, than sorry

## Link to supporting Trello card
https://trello.com/c/OWToydti/1296-joinurl
