### PR TITLE
Fix guardian packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "build/**/*"
   ],
   "dependencies": {
-    "@guardian/src-text-input": "^0.15.1",
     "regenerator-runtime": "^0.13.3",
     "timeago.js": "^4.0.2"
   },
@@ -41,8 +40,9 @@
     "@emotion/babel-preset-css-prop": "^10.0.14",
     "@emotion/core": "^10.0.27",
     "@guardian/src-button": "^0.8.0",
-    "@guardian/src-foundations": "^0.12.3",
+    "@guardian/src-foundations": "^0.15.1",
     "@guardian/src-svgs": "^0.1.0",
+    "@guardian/src-text-input": "^0.15.1",
     "@storybook/addon-viewport": "^5.3.13",
     "@storybook/react": "^5.3.13",
     "@testing-library/jest-dom": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1822,11 +1822,6 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-button/-/src-button-0.8.1.tgz#bf7835ec90256e418cd7c06f8ac38dd22c217b8c"
   integrity sha512-UQTLqNpzOc62RpTBJip7IBYkspd+aNoRxCoTt75pOzY1U7+bBsAZZarztK5c0lGSe/22Tlxo8zv+7RrVZXRSQg==
 
-"@guardian/src-foundations@^0.12.3":
-  version "0.12.4"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.12.4.tgz#a4c6ec8dbf86279702d78e048e2bd4eea1624c7d"
-  integrity sha512-6V/3TWL4wMxfzUHOj5MJQMQA7oRBxWlRav5m9dYGw13JAg59DFOpcfM8LWWFwWWlJ8e2nbnDHS9/sOPzGrJduw==
-
 "@guardian/src-foundations@^0.15.1":
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.15.1.tgz#9e621aa2efee0cdb368ebbee129cd2a7d7e5868e"


### PR DESCRIPTION
## What does this change?
update both `@guardian/src-foundations` and `@guardian/src-text-input` to be compatible with one another

## Why?
TS bug was raised

