### PR TITLE
http > https

### DIFF
--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -109,7 +109,7 @@ export const CommentContainer = ({
   const expand = (commentId: number) => {
     setLoading(true);
     fetch(
-      `http://discussion.theguardian.com/discussion-api/comment/${commentId}?displayThreaded=true&displayResponses=true`
+      `https://discussion.theguardian.com/discussion-api/comment/${commentId}?displayThreaded=true&displayResponses=true`
     )
       .then(response => response.json())
       .then(json => {


### PR DESCRIPTION
## What does this change?
Replaces `http` with `https`

## Why?
Because request will fail otherwise
