### PR TITLE
baseUrl

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@guardian/discussion-rendering",
   "description": "This codebase started as a hack day project by @gtrufitt and @nicl. The purpose is parity of the existing discussion application on Frontend using the discussion API (search for Private Repo).",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": "",
   "homepage": "https://github.com/guardian/discussion-rendering#readme",
   "license": "Apache",

--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -32,6 +32,7 @@ export const Default = () => (
   >
     <App
       shortUrl="p/39f5z"
+      baseUrl="https://discussion.theguardian.com/discussion-api"
       user={aUser}
       additionalHeaders={{
         "D2-X-UID": "testD2Header",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,7 +120,7 @@ const readFiltersFromLocalStorage = (): FilterOptions => {
   };
 };
 
-export const App = ({ shortUrl, user, additionalHeaders }: Props) => {
+export const App = ({ baseUrl, shortUrl, user, additionalHeaders }: Props) => {
   const [filters, setFilters] = useState<FilterOptions>(
     readFiltersFromLocalStorage()
   );
@@ -208,7 +208,7 @@ export const App = ({ shortUrl, user, additionalHeaders }: Props) => {
     setComments([simulateNewComment(commentId, body, user), ...comments]);
   };
 
-  initialiseApi({ additionalHeaders });
+  initialiseApi({ additionalHeaders, baseUrl });
 
   const showPagination = totalPages > 1;
 
@@ -224,7 +224,9 @@ export const App = ({ shortUrl, user, additionalHeaders }: Props) => {
         )}
         {picks && picks.length ? (
           <div className={picksWrapper}>
-            {!!picks.length && <TopPicks comments={picks.slice(0, 2)} />}
+            {!!picks.length && (
+              <TopPicks baseUrl={baseUrl} comments={picks.slice(0, 2)} />
+            )}
           </div>
         ) : (
           <>
@@ -237,6 +239,7 @@ export const App = ({ shortUrl, user, additionalHeaders }: Props) => {
                 {comments.slice(0, 2).map(comment => (
                   <li key={comment.id}>
                     <CommentContainer
+                      baseUrl={baseUrl}
                       comment={comment}
                       pillar="news"
                       shortUrl={shortUrl}
@@ -283,7 +286,7 @@ export const App = ({ shortUrl, user, additionalHeaders }: Props) => {
           user={user}
         />
       )}
-      {!!picks.length && <TopPicks comments={picks} />}
+      {!!picks.length && <TopPicks baseUrl={baseUrl} comments={picks} />}
       <Filters
         filters={filters}
         onFilterChange={onFilterChange}
@@ -312,6 +315,7 @@ export const App = ({ shortUrl, user, additionalHeaders }: Props) => {
           {comments.map(comment => (
             <li key={comment.id}>
               <CommentContainer
+                baseUrl={baseUrl}
                 comment={comment}
                 pillar="news"
                 shortUrl={shortUrl}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { Pagination } from "./components/Pagination/Pagination";
 
 type Props = {
   shortUrl: string;
+  baseUrl: string;
   user?: UserProfile;
   additionalHeaders: AdditionalHeadersType;
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import {
   getDiscussion,
   getCommentCount,
   getPicks,
-  setAdditionalHeaders
+  initialiseApi
 } from "./lib/api";
 import { CommentContainer } from "./components/CommentContainer/CommentContainer";
 import { TopPicks } from "./components/TopPicks/TopPicks";
@@ -208,7 +208,7 @@ export const App = ({ shortUrl, user, additionalHeaders }: Props) => {
     setComments([simulateNewComment(commentId, body, user), ...comments]);
   };
 
-  setAdditionalHeaders(additionalHeaders);
+  initialiseApi({ additionalHeaders });
 
   const showPagination = totalPages > 1;
 

--- a/src/components/Comment/Comment.stories.tsx
+++ b/src/components/Comment/Comment.stories.tsx
@@ -72,6 +72,7 @@ const staffUser = {
 
 export const Default = () => (
   <Comment
+    baseUrl="https://discussion.theguardian.com/discussion-api"
     comment={commentData}
     pillar={"sport"}
     setCommentBeingRepliedTo={() => {}}
@@ -82,6 +83,7 @@ Default.story = { name: "Default" };
 
 export const ReplyComment = () => (
   <Comment
+    baseUrl="https://discussion.theguardian.com/discussion-api"
     comment={commentData}
     pillar={"sport"}
     setCommentBeingRepliedTo={() => {}}
@@ -92,6 +94,7 @@ Default.story = { name: "Reply Default" };
 
 export const UnpickedComment = () => (
   <Comment
+    baseUrl="https://discussion.theguardian.com/discussion-api"
     comment={commentData}
     pillar={"sport"}
     setCommentBeingRepliedTo={() => {}}
@@ -102,6 +105,7 @@ UnpickedComment.story = { name: "Unpicked Comment" };
 
 export const PickedComment = () => (
   <Comment
+    baseUrl="https://discussion.theguardian.com/discussion-api"
     comment={{
       ...commentData,
       isHighlighted: true
@@ -115,6 +119,7 @@ PickedComment.story = { name: "Picked Comment" };
 
 export const StaffUserComment = () => (
   <Comment
+    baseUrl="https://discussion.theguardian.com/discussion-api"
     comment={commentStaffData}
     pillar={"sport"}
     setCommentBeingRepliedTo={() => {}}
@@ -125,6 +130,7 @@ StaffUserComment.story = { name: "Staff User Comment" };
 
 export const PickedStaffUserComment = () => (
   <Comment
+    baseUrl="https://discussion.theguardian.com/discussion-api"
     comment={{
       ...commentStaffData,
       isHighlighted: true
@@ -138,6 +144,7 @@ PickedStaffUserComment.story = { name: "Picked Staff User Comment" };
 
 export const LoggedInAsModerator = () => (
   <Comment
+    baseUrl="https://discussion.theguardian.com/discussion-api"
     comment={commentData}
     pillar={"sport"}
     setCommentBeingRepliedTo={() => {}}
@@ -149,6 +156,7 @@ LoggedInAsModerator.story = { name: "Logged in as moderator" };
 
 export const BlockedComment = () => (
   <Comment
+    baseUrl="https://discussion.theguardian.com/discussion-api"
     comment={blockedCommentData}
     pillar={"sport"}
     setCommentBeingRepliedTo={() => {}}

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -5,15 +5,18 @@ import { space, palette } from "@guardian/src-foundations";
 import { neutral, background } from "@guardian/src-foundations/palette";
 import { textSans } from "@guardian/src-foundations/typography";
 
-import { Pillar, CommentType, UserProfile } from "../../types";
 import { GuardianStaff, GuardianPick } from "../Badges/Badges";
 import { RecommendationCount } from "../RecommendationCount/RecommendationCount";
 import { AbuseReportForm } from "../AbuseReportForm/AbuseReportForm";
 import { Timestamp } from "../Timestamp/Timestamp";
-import { pickComment, unPickComment } from "../../lib/api";
 import { Avatar } from "../Avatar/Avatar";
 
+import { Pillar, CommentType, UserProfile } from "../../types";
+import { pickComment, unPickComment } from "../../lib/api";
+import { joinUrl } from "../../lib/joinUrl";
+
 type Props = {
+  baseUrl: string;
   user?: UserProfile;
   comment: CommentType;
   pillar: Pillar;
@@ -160,6 +163,7 @@ const ReplyArrow = () => (
 );
 
 export const Comment = ({
+  baseUrl,
   comment,
   pillar,
   setCommentBeingRepliedTo,
@@ -218,7 +222,10 @@ export const Comment = ({
               <Row>
                 <div className={commentProfileName(pillar)}>
                   <a
-                    href={`https://profile.theguardian.com/user/${comment.userProfile.userId}`}
+                    href={joinUrl([
+                      "https://profile.theguardian.com/user",
+                      comment.userProfile.userId
+                    ])}
                     className={linkStyles}
                   >
                     {comment.userProfile.displayName}
@@ -227,7 +234,15 @@ export const Comment = ({
                 <div className={timestampWrapperStyles}>
                   <Timestamp
                     isoDateTime={comment.isoDateTime}
-                    linkTo={`https://discussion.theguardian.com/comment-permalink/${comment.id}`}
+                    linkTo={joinUrl([
+                      // Remove the discussion-api path from the baseUrl
+                      baseUrl
+                        .split("/")
+                        .filter(path => path !== "discussion-api")
+                        .join("/"),
+                      "comment-permalink",
+                      comment.id.toString()
+                    ])}
                   />
                 </div>
               </Row>

--- a/src/components/CommentContainer/CommentContainer.stories.tsx
+++ b/src/components/CommentContainer/CommentContainer.stories.tsx
@@ -96,6 +96,7 @@ const commentDataThreaded: CommentType = {
 
 export const defaultStory = () => (
   <CommentContainer
+    baseUrl="https://discussion.theguardian.com/discussion-api"
     comment={commentData}
     pillar={"sport"}
     shortUrl="randomShortURL"
@@ -109,6 +110,7 @@ defaultStory.story = { name: "default" };
 
 export const threadedComment = () => (
   <CommentContainer
+    baseUrl="https://discussion.theguardian.com/discussion-api"
     comment={commentDataThreaded}
     pillar={"lifestyle"}
     shortUrl="randomShortURL"
@@ -122,6 +124,7 @@ threadedComment.story = { name: "threaded" };
 
 export const replyableComment = () => (
   <CommentContainer
+    baseUrl="https://discussion.theguardian.com/discussion-api"
     comment={commentDataThreaded}
     pillar="lifestyle"
     shortUrl="randomShortURL"

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -8,7 +8,10 @@ import { CommentForm } from "../CommentForm/CommentForm";
 import { Comment } from "../Comment/Comment";
 import { CommentReplyPreview } from "../CommentReplyPreview/CommentReplyPreview";
 
+import { joinUrl } from "../../lib/joinUrl";
+
 type Props = {
+  baseUrl: string;
   comment: CommentType;
   pillar: Pillar;
   shortUrl: string;
@@ -79,6 +82,7 @@ const Row = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
 );
 
 export const CommentContainer = ({
+  baseUrl,
   comment,
   pillar,
   onAddComment,
@@ -109,7 +113,8 @@ export const CommentContainer = ({
   const expand = (commentId: number) => {
     setLoading(true);
     fetch(
-      `https://discussion.theguardian.com/discussion-api/comment/${commentId}?displayThreaded=true&displayResponses=true`
+      joinUrl([baseUrl, "comment", commentId.toString()]) +
+        "?displayThreaded=true&displayResponses=true"
     )
       .then(response => response.json())
       .then(json => {
@@ -124,6 +129,7 @@ export const CommentContainer = ({
   return (
     <>
       <Comment
+        baseUrl={baseUrl}
         comment={comment}
         pillar={pillar}
         setCommentBeingRepliedTo={setCommentBeingRepliedTo}
@@ -138,6 +144,7 @@ export const CommentContainer = ({
               {responses.map(responseComment => (
                 <li key={responseComment.id}>
                   <Comment
+                    baseUrl={baseUrl}
                     comment={responseComment}
                     pillar={pillar}
                     setCommentBeingRepliedTo={setCommentBeingRepliedTo}

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -114,7 +114,6 @@ export const CommentContainer = ({
     setLoading(true);
     getMoreResponses(commentId)
       .then(json => {
-        console.log("json", json);
         setExpanded(true);
         setResponses(json.comment.responses);
       })

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -8,7 +8,7 @@ import { CommentForm } from "../CommentForm/CommentForm";
 import { Comment } from "../Comment/Comment";
 import { CommentReplyPreview } from "../CommentReplyPreview/CommentReplyPreview";
 
-import { joinUrl } from "../../lib/joinUrl";
+import { getMoreResponses } from "../../lib/api";
 
 type Props = {
   baseUrl: string;
@@ -112,12 +112,9 @@ export const CommentContainer = ({
 
   const expand = (commentId: number) => {
     setLoading(true);
-    fetch(
-      joinUrl([baseUrl, "comment", commentId.toString()]) +
-        "?displayThreaded=true&displayResponses=true"
-    )
-      .then(response => response.json())
+    getMoreResponses(commentId)
       .then(json => {
+        console.log("json", json);
         setExpanded(true);
         setResponses(json.comment.responses);
       })

--- a/src/components/TopPicks/TopPicks.stories.tsx
+++ b/src/components/TopPicks/TopPicks.stories.tsx
@@ -54,12 +54,16 @@ const commentWithShortBody: CommentType = {
 };
 
 export const SingleComment = () => (
-  <TopPicks comments={[commentWithShortBody]} />
+  <TopPicks
+    baseUrl="https://discussion.guardianapis.com/discussion-api"
+    comments={[commentWithShortBody]}
+  />
 );
 SingleComment.story = { name: "Single Comment" };
 
 export const MulitColumn = () => (
   <TopPicks
+    baseUrl="https://discussion.guardianapis.com/discussion-api"
     comments={[
       commentWithLongBody,
       commentWithShortBody,
@@ -72,6 +76,7 @@ MulitColumn.story = { name: "Mulitple Columns Comments" };
 
 export const SingleColumn = () => (
   <TopPicks
+    baseUrl="https://discussion.guardianapis.com/discussion-api"
     comments={[
       commentWithLongBody,
       commentWithShortBody,

--- a/src/components/TopPicks/TopPicks.tsx
+++ b/src/components/TopPicks/TopPicks.tsx
@@ -10,6 +10,9 @@ import { CommentType } from "../../types";
 import { Avatar } from "../Avatar/Avatar";
 import { RecommendationCount } from "../RecommendationCount/RecommendationCount";
 import { Timestamp } from "../Timestamp/Timestamp";
+import { joinUrl } from "../../lib/joinUrl";
+
+type Props = { baseUrl: string; comments: CommentType[] };
 
 const pickStyles = css`
   width: 100%;
@@ -111,7 +114,13 @@ const oneColCommentsStyles = css`
 `;
 
 // TODO: Check if there are other labels
-const TopPick = ({ comment }: { comment: CommentType }) => (
+const TopPick = ({
+  baseUrl,
+  comment
+}: {
+  baseUrl: string;
+  comment: CommentType;
+}) => (
   <div className={pickStyles}>
     <div className={pickComment}>
       <h3
@@ -145,7 +154,15 @@ const TopPick = ({ comment }: { comment: CommentType }) => (
           </span>
           <Timestamp
             isoDateTime={comment.isoDateTime}
-            linkTo={`https://discussion.theguardian.com/comment-permalink/${comment.id}`}
+            linkTo={joinUrl([
+              // Remove the discussion-api path from the baseUrl
+              baseUrl
+                .split("/")
+                .filter(path => path !== "discussion-api")
+                .join("/"),
+              "comment-permalink",
+              comment.id.toString()
+            ])}
           />
           {comment.userProfile.badge.filter(obj => obj["name"] === "Staff") && (
             <GuardianStaff />
@@ -163,7 +180,7 @@ const TopPick = ({ comment }: { comment: CommentType }) => (
   </div>
 );
 
-export const TopPicks = ({ comments }: { comments: CommentType[] }) => {
+export const TopPicks = ({ baseUrl, comments }: Props) => {
   const leftColComments: CommentType[] = [];
   const rightColComments: CommentType[] = [];
   comments.forEach((comment, index) =>
@@ -176,18 +193,18 @@ export const TopPicks = ({ comments }: { comments: CommentType[] }) => {
       <div className={twoColCommentsStyles}>
         <div className={cx(columWrapperStyles, paddingRight)}>
           {leftColComments.map(comment => (
-            <TopPick comment={comment} />
+            <TopPick baseUrl={baseUrl} comment={comment} />
           ))}
         </div>
         <div className={cx(columWrapperStyles, paddingLeft)}>
           {rightColComments.map(comment => (
-            <TopPick comment={comment} />
+            <TopPick baseUrl={baseUrl} comment={comment} />
           ))}
         </div>
       </div>
       <div className={oneColCommentsStyles}>
         {comments.map(comment => (
-          <TopPick comment={comment} />
+          <TopPick baseUrl={baseUrl} comment={comment} />
         ))}
       </div>
     </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import { App } from "./App";
 
 ReactDOM.render(
   <App
+    baseUrl="https://discussion.theguardian.com/discussion-api"
     shortUrl="/p/39f5z"
     additionalHeaders={{
       "D2-X-UID": "testD2Header",

--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -11,17 +11,22 @@ import {
   AdditionalHeadersType
 } from "../types";
 
-const baseURL = "https://discussion.theguardian.com/discussion-api";
-
 let options = {
+  // Defaults
+  baseUrl: "https://discussion.theguardian.com/discussion-api",
   headers: {}
 };
 
 export const initialiseApi = ({
+  baseUrl,
   additionalHeaders
 }: {
+  baseUrl: string;
   additionalHeaders: AdditionalHeadersType;
-}) => (options.headers = additionalHeaders);
+}) => {
+  options.baseUrl = baseUrl;
+  options.headers = additionalHeaders;
+};
 
 const objAsParams = (obj: any): string => {
   const params = Object.keys(obj)
@@ -46,7 +51,7 @@ export const getDiscussion = (
   };
   const params = objAsParams(apiOpts);
 
-  const url = joinUrl([baseURL, "discussion", shortUrl, params]);
+  const url = joinUrl([options.baseUrl, "discussion", shortUrl, params]);
 
   return fetch(url, {
     headers: {
@@ -58,7 +63,7 @@ export const getDiscussion = (
 };
 
 export const preview = (body: string): Promise<string> => {
-  const url = baseURL + "/comment/preview";
+  const url = options.baseUrl + "/comment/preview";
   const data = new URLSearchParams();
   data.append("body", body);
 
@@ -76,7 +81,7 @@ export const preview = (body: string): Promise<string> => {
 };
 
 export const getProfile = (): Promise<UserProfile> => {
-  const url = baseURL + "/profile/me";
+  const url = options.baseUrl + "/profile/me";
 
   return fetch(url, {
     credentials: "include",
@@ -92,7 +97,7 @@ export const comment = (
   shortUrl: string,
   body: string
 ): Promise<CommentResponse> => {
-  const url = baseURL + `/discussion/${shortUrl}/comment`;
+  const url = options.baseUrl + `/discussion/${shortUrl}/comment`;
   const data = new URLSearchParams();
   data.append("body", body);
 
@@ -113,7 +118,8 @@ export const reply = (
   parentCommentId: number
 ): Promise<CommentResponse> => {
   const url =
-    baseURL + `/discussion/${shortUrl}/comment/${parentCommentId}/reply`;
+    options.baseUrl +
+    `/discussion/${shortUrl}/comment/${parentCommentId}/reply`;
 
   const data = new URLSearchParams();
   data.append("body", body);
@@ -130,7 +136,7 @@ export const reply = (
 };
 
 export const getPicks = (shortUrl: string): Promise<CommentType[]> => {
-  const url = baseURL + `/discussion/${shortUrl}/topcomments`;
+  const url = options.baseUrl + `/discussion/${shortUrl}/topcomments`;
 
   return fetch(url, {
     headers: {
@@ -153,7 +159,7 @@ export const reportAbuse = ({
   reason?: string;
   email?: string;
 }) => {
-  const url = baseURL + `/comment/${commentId}/reportAbuse`;
+  const url = options.baseUrl + `/comment/${commentId}/reportAbuse`;
 
   const data = new URLSearchParams();
   data.append("categoryId", categoryId.toString());
@@ -171,7 +177,7 @@ export const reportAbuse = ({
 };
 
 export const recommend = (commentId: number): Promise<boolean> => {
-  const url = baseURL + `/comment/${commentId}/recommend`;
+  const url = options.baseUrl + `/comment/${commentId}/recommend`;
 
   return fetch(url, {
     method: "POST",
@@ -185,7 +191,7 @@ export const recommend = (commentId: number): Promise<boolean> => {
 export const getCommentCount = (
   shortUrl: string
 ): Promise<{ shortUrl: string; numberOfComments: number }> => {
-  const url = `${baseURL}/discussion/${shortUrl}/comments/count`;
+  const url = `${options.baseUrl}/discussion/${shortUrl}/comments/count`;
 
   return fetch(url, {
     headers: {
@@ -215,7 +221,7 @@ export const addUserName = (userName: string): Promise<UserNameResponse> => {
 };
 
 export const pickComment = (commentId: number): Promise<CommentResponse> => {
-  const url = `${baseURL}/comment/${commentId}/highlight`;
+  const url = `${options.baseUrl}/comment/${commentId}/highlight`;
 
   return fetch(url, {
     headers: {
@@ -227,7 +233,7 @@ export const pickComment = (commentId: number): Promise<CommentResponse> => {
 };
 
 export const unPickComment = (commentId: number): Promise<CommentResponse> => {
-  const url = `${baseURL}/comment/${commentId}/unhighlight`;
+  const url = `${options.baseUrl}/comment/${commentId}/unhighlight`;
 
   return fetch(url, {
     headers: {

--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -51,7 +51,7 @@ export const getDiscussion = (
   };
   const params = objAsParams(apiOpts);
 
-  const url = joinUrl([options.baseUrl, "discussion", shortUrl, params]);
+  const url = joinUrl([options.baseUrl, "discussion", shortUrl]) + params;
 
   return fetch(url, {
     headers: {

--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -243,3 +243,17 @@ export const unPickComment = (commentId: number): Promise<CommentResponse> => {
     .then(resp => resp.json())
     .catch(error => console.error(`Error fetching ${url}`, error));
 };
+
+export const getMoreResponses = (commentId: number): Promise<any> => {
+  const url =
+    joinUrl([options.baseUrl, "comment", commentId.toString()]) +
+    "?displayThreaded=true&displayResponses=true";
+
+  return fetch(url, {
+    headers: {
+      ...options.headers
+    }
+  })
+    .then(resp => resp.json())
+    .catch(error => console.error(`Error fetching ${url}`, error));
+};

--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -13,11 +13,15 @@ import {
 
 const baseURL = "https://discussion.theguardian.com/discussion-api";
 
-let additionalHeaders = {};
+let options = {
+  headers: {}
+};
 
-export const setAdditionalHeaders = (
-  newAdditionalHeader: AdditionalHeadersType
-) => (additionalHeaders = newAdditionalHeader);
+export const initialiseApi = ({
+  additionalHeaders
+}: {
+  additionalHeaders: AdditionalHeadersType;
+}) => (options.headers = additionalHeaders);
 
 const objAsParams = (obj: any): string => {
   const params = Object.keys(obj)
@@ -46,7 +50,7 @@ export const getDiscussion = (
 
   return fetch(url, {
     headers: {
-      ...additionalHeaders
+      ...options.headers
     }
   })
     .then(resp => resp.json())
@@ -63,7 +67,7 @@ export const preview = (body: string): Promise<string> => {
     body: data,
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
-      ...additionalHeaders
+      ...options.headers
     }
   })
     .then(resp => resp.json())
@@ -77,7 +81,7 @@ export const getProfile = (): Promise<UserProfile> => {
   return fetch(url, {
     credentials: "include",
     headers: {
-      ...additionalHeaders
+      ...options.headers
     }
   })
     .then(resp => resp.json())
@@ -97,7 +101,7 @@ export const comment = (
     body: data,
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
-      ...additionalHeaders
+      ...options.headers
     },
     credentials: "include"
   }).then(resp => resp.json());
@@ -119,7 +123,7 @@ export const reply = (
     body: data,
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
-      ...additionalHeaders
+      ...options.headers
     },
     credentials: "include"
   }).then(resp => resp.json());
@@ -130,7 +134,7 @@ export const getPicks = (shortUrl: string): Promise<CommentType[]> => {
 
   return fetch(url, {
     headers: {
-      ...additionalHeaders
+      ...options.headers
     }
   })
     .then(resp => resp.json())
@@ -161,7 +165,7 @@ export const reportAbuse = ({
     body: data,
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
-      ...additionalHeaders
+      ...options.headers
     }
   }).then(resp => resp.json());
 };
@@ -173,7 +177,7 @@ export const recommend = (commentId: number): Promise<boolean> => {
     method: "POST",
     credentials: "include",
     headers: {
-      ...additionalHeaders
+      ...options.headers
     }
   }).then(resp => resp.ok);
 };
@@ -185,7 +189,7 @@ export const getCommentCount = (
 
   return fetch(url, {
     headers: {
-      ...additionalHeaders
+      ...options.headers
     }
   })
     .then(resp => resp.json())
@@ -215,7 +219,7 @@ export const pickComment = (commentId: number): Promise<CommentResponse> => {
 
   return fetch(url, {
     headers: {
-      ...additionalHeaders
+      ...options.headers
     }
   })
     .then(resp => resp.json())
@@ -227,7 +231,7 @@ export const unPickComment = (commentId: number): Promise<CommentResponse> => {
 
   return fetch(url, {
     headers: {
-      ...additionalHeaders
+      ...options.headers
     }
   })
     .then(resp => resp.json())

--- a/src/lib/joinUrl.ts
+++ b/src/lib/joinUrl.ts
@@ -2,6 +2,7 @@ export const joinUrl = (parts: string[]) => {
   // Remove any leading or trailing slashes from all parts and then join cleanly on
   // a single slash - prevents malformed urls
   const trimmed = parts
+    .filter(part => part) // Filter any falsey parts
     .map(part => {
       // Trim left
       if (part.substr(0, 1) === "/") return part.slice(1);


### PR DESCRIPTION
## What does this change?
Adds support for passing in a `baseUrl` prop to `App` so that we accept the domain to make requests against dynamically

## Why?
So that we can easily test over CODE and production

## Link to supporting Trello card
https://trello.com/c/fNn0CFdy/1310-pass-in-a-baseurl-to-comments
