### PR TITLE
Externalise prop types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@guardian/discussion-rendering",
   "description": "This codebase started as a hack day project by @gtrufitt and @nicl. The purpose is parity of the existing discussion application on Frontend using the discussion API (search for Private Repo).",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": "",
   "homepage": "https://github.com/guardian/discussion-rendering#readme",
   "license": "Apache",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,7 +25,8 @@ module.exports = {
     "@guardian/src-foundations/accessibility",
     "@guardian/src-foundations/palette",
     "@guardian/src-foundations/themes",
-    "@guardian/src-foundations/typography"
+    "@guardian/src-foundations/typography",
+    "prop-types"
   ],
   plugins: [babel({ extensions }), resolve({ extensions }), commonjs()]
 };


### PR DESCRIPTION
## What does this change?
Adds `prop-types` to the externals property in the rollup config

## Why?
Because we were getting errors during `yarn build` without this

## Link to supporting Trello card
https://trello.com/c/zFdwXYhK/1316-external-prop-types