### PR TITLE
Add response type for getMoreResponses api call

### DIFF
--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -268,7 +268,12 @@ export const unPickComment = (commentId: number): Promise<CommentResponse> => {
     .catch(error => console.error(`Error fetching ${url}`, error));
 };
 
-export const getMoreResponses = (commentId: number): Promise<any> => {
+export const getMoreResponses = (
+  commentId: number
+): Promise<{
+  status: "ok" | "error";
+  comment: CommentType;
+}> => {
   const url =
     joinUrl([options.baseUrl, "comment", commentId.toString()]) +
     "?displayThreaded=true&displayResponses=true";


### PR DESCRIPTION
## What does this change?
Replaces use of any with correct type

## Why?
Because any is bad and I only put it there for testing but then forgot

## Link to supporting Trello card
https://trello.com/c/kwdzIqgl/1317-type-show-more