### PR TITLE
More consistent text sizes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { css } from "emotion";
 import "regenerator-runtime/runtime";
 
 import { Button } from "@guardian/src-button";
-import { neutral } from "@guardian/src-foundations/palette";
+import { neutral, space } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
 
 import {
@@ -58,7 +58,6 @@ const picksWrapper = css`
 const viewMoreButtonContentStyles = css`
   display: flex;
   flex-direction: row;
-  ${textSans.medium({ fontWeight: "bold" })};
   fill: ${neutral[86]};
 `;
 
@@ -266,7 +265,8 @@ export const App = ({ baseUrl, shortUrl, user, additionalHeaders }: Props) => {
             </div>
             <div
               className={css`
-                padding-left: 10px;
+                ${textSans.small({ fontWeight: "bold" })}
+                padding-left: ${space[1]}px;
               `}
             >
               View more comments

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -85,8 +85,7 @@ const avatarMargin = css`
 const commentProfileName = (pillar: Pillar) => css`
   margin-top: 0;
   color: ${palette[pillar][400]};
-  ${textSans.small()};
-  font-weight: bold;
+  ${textSans.small({ fontWeight: "bold" })}
 `;
 
 const commentDetails = css`
@@ -250,17 +249,19 @@ export const Comment = ({
                 {!!comment.userProfile.badge.filter(
                   obj => obj["name"] === "Staff"
                 ).length ? (
-                    <div className={iconWrapper}>
-                      <GuardianStaff />
-                    </div>
-                  ) : <></>}
+                  <div className={iconWrapper}>
+                    <GuardianStaff />
+                  </div>
+                ) : (
+                  <></>
+                )}
                 {comment.status !== "blocked" && isHighlighted ? (
                   <div className={iconWrapper}>
                     <GuardianPick />
                   </div>
                 ) : (
-                    <></>
-                  )}
+                  <></>
+                )}
               </Row>
             </Column>
             {comment.status !== "blocked" && (
@@ -310,11 +311,11 @@ export const Comment = ({
               </div>
             </>
           ) : (
-              <p
-                className={cx(blockedCommentStyles, commentLinkStyling)}
-                dangerouslySetInnerHTML={{ __html: comment.body }}
-              />
-            )}
+            <p
+              className={cx(blockedCommentStyles, commentLinkStyling)}
+              dangerouslySetInnerHTML={{ __html: comment.body }}
+            />
+          )}
         </div>
       </div>
     </>

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -79,6 +79,10 @@ const buttonContainerStyles = css`
   }
 `;
 
+const buttonTextStyles = css`
+  ${textSans.small({ fontWeight: "bold" })}
+`;
+
 const headerTextStyles = css`
   margin: 0;
   ${textSans.xsmall()};
@@ -387,7 +391,7 @@ export const CommentForm = ({
         <div className={bottomContainer}>
           <div className={buttonContainerStyles}>
             <Button type="submit" size="small">
-              Post your comment
+              <div className={buttonTextStyles}>Post your comment</div>
             </Button>
             {(isActive || body) && (
               <>
@@ -396,10 +400,10 @@ export const CommentForm = ({
                   onClick={fetchShowPreview}
                   priority="secondary"
                 >
-                  Preview
+                  <div className={buttonTextStyles}>Preview</div>
                 </Button>
                 <Button size="small" onClick={resetForm} priority="tertiary">
-                  Cancel
+                  <div className={buttonTextStyles}>Cancel</div>
                 </Button>
               </>
             )}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -55,7 +55,7 @@ const ulExpanded = css`
 `;
 
 const linkStyles = css`
-  ${textSans.xsmall()};
+  ${textSans.small()};
   text-align: left;
   color: ${neutral[46]};
   position: relative;
@@ -102,6 +102,7 @@ const activeStyles = (pillar: Pillar) => css`
 `;
 
 const buttonStyles = css`
+${textSans.small({ fontWeight: "medium" })};
   display: block;
   cursor: pointer;
   background: none;
@@ -147,7 +148,7 @@ const expandedStyles = css`
 `;
 
 const labelStyles = css`
-  ${textSans.xsmall({ fontWeight: "bold" })};
+  ${textSans.small({ fontWeight: "bold" })};
   color: ${neutral[46]};
 `;
 

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -97,6 +97,7 @@ const paginationSelectors = css`
 `;
 
 const paginationText = css`
+  ${textSans.small()};
   margin-left: 5px;
   ${until.mobileLandscape} {
     padding-top: 10px;


### PR DESCRIPTION
## What does this change?
Ensure we're only using 2 text sizes everywhere. `textSans.small` and `textSans`xsmall`

## Why?
To bring us in line with the design system and reduce font size disparity

## Before
![Screenshot 2020-03-21 at 17 41 33](https://user-images.githubusercontent.com/1336821/77232878-81341b00-6b9b-11ea-8dd3-93a031cddbb2.jpg)


## After
![Screenshot 2020-03-21 at 17 41 02](https://user-images.githubusercontent.com/1336821/77232835-45995100-6b9b-11ea-9505-70c35faa278b.jpg)


## Link to supporting Trello card
https://trello.com/c/kINjHtFy/1321-consistent-text-sizing