### PR TITLE
Limit pick text

### DIFF
--- a/src/components/TopPick/TopPick.stories.tsx
+++ b/src/components/TopPick/TopPick.stories.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { css } from "emotion";
+import { TopPick } from "../TopPick/TopPick";
+import { CommentType } from "../../types";
+
+export default { component: TopPick, title: "TopPick" };
+
+const comment: CommentType = {
+  id: 25488498,
+  body:
+    "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sodales metus magna, et molestie diam gravida quis. Ut ligula libero, condimentum quis elit at, dignissim pulvinar enim. Phasellus mattis felis in mi facilisis, ut vulputate ipsum rhoncus. Proin elit sem, venenatis vitae molestie id, posuere non justo. Morbi ac felis quis diam elementum tempus. Suspendisse efficitur consectetur sapien eleifend rhoncus. Aenean tempor leo pharetra, venenatis elit non, porta arcu. Maecenas tempus tellus sit amet iaculis molestie. Praesent id lobortis dolor. Nullam et ipsum ut leo accumsan vehicula vitae a augue. Integer vitae massa a tellus porta tincidunt ac sed tellus. Etiam ac semper lectus. Quisque et dui libero. Maecenas et lobortis nulla. Ut elementum egestas hendrerit.</p>",
+  date: "26 July 2013 4:35pm",
+  isoDateTime: "2013-07-26T15:13:20Z",
+  status: "visible",
+  webUrl: "https://discussion.theguardian.com/comment-permalink/25488498",
+  apiUrl: "https://discussion.guardianapis.com/discussion-api/comment/25488498",
+  numRecommends: 0,
+  isHighlighted: false,
+  responseTo: {
+    displayName: "FrankDeFord",
+    commentApiUrl:
+      "https://discussion.guardianapis.com/discussion-api/comment/25487686",
+    isoDateTime: "2013-07-26T15:13:20Z",
+    date: "26 July 2013 4:13pm",
+    commentId: 25487686,
+    commentWebUrl:
+      "https://discussion.theguardian.com/comment-permalink/25487686"
+  },
+  userProfile: {
+    userId: "3150446",
+    displayName: "AndyPietrasik",
+    webUrl: "https://profile.theguardian.com/user/id/3150446",
+    apiUrl:
+      "https://discussion.guardianapis.com/discussion-api/profile/3150446",
+    avatar: "https://avatar.guim.co.uk/user/3150446",
+    secureAvatarUrl: "https://avatar.guim.co.uk/user/3150446",
+    badge: [
+      {
+        name: "Staff"
+      }
+    ]
+  }
+};
+
+const commentWithShortBody: CommentType = {
+  ...comment,
+  body: "<p>It's still there FrankDeFord - and thanks, I will pass that on</p>"
+};
+
+export const LongPick = () => (
+  <div
+    className={css`
+      width: 100%;
+      max-width: 300px;
+    `}
+  >
+    <TopPick
+      baseUrl="https://discussion.guardianapis.com/discussion-api"
+      comment={comment}
+    />
+  </div>
+);
+LongPick.story = { name: "Long" };
+
+export const ShortPick = () => (
+  <div
+    className={css`
+      width: 100%;
+      max-width: 300px;
+    `}
+  >
+    <TopPick
+      baseUrl="https://discussion.guardianapis.com/discussion-api"
+      comment={commentWithShortBody}
+    />
+  </div>
+);
+ShortPick.story = { name: "Short" };

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -80,6 +80,12 @@ const linkStyles = css`
   }
 `;
 
+const truncateText = (input: string, limit: number) => {
+  // If input greater than limit trucate by limit and append an ellipsis
+  if (input.length > limit) return input.substr(0, limit) + "&#8230;";
+  return input;
+};
+
 export const TopPick = ({
   baseUrl,
   comment
@@ -98,7 +104,9 @@ export const TopPick = ({
       >
         Guardian Pick
       </h3>
-      <p dangerouslySetInnerHTML={{ __html: comment.body }}></p>
+      <p
+        dangerouslySetInnerHTML={{ __html: truncateText(comment.body, 450) }}
+      ></p>
     </div>
     <div className={pickMetaWrapper}>
       <div className={userDetails}>

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -38,7 +38,7 @@ const pickComment = css`
 
   :before {
     content: "";
-    margin-left: 24px;
+    margin-left: ${space[6]}px;
     position: absolute;
     border-right: ${arrowSize}px solid transparent;
     border-top: ${arrowSize}px solid ${bg};

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -1,0 +1,150 @@
+import React from "react";
+import { css } from "emotion";
+
+import { from } from "@guardian/src-foundations/mq";
+import { space, neutral, palette } from "@guardian/src-foundations";
+import { textSans } from "@guardian/src-foundations/typography";
+
+import { GuardianStaff } from "../Badges/Badges";
+import { CommentType } from "../../types";
+import { Avatar } from "../Avatar/Avatar";
+import { RecommendationCount } from "../RecommendationCount/RecommendationCount";
+import { Timestamp } from "../Timestamp/Timestamp";
+import { joinUrl } from "../../lib/joinUrl";
+
+type Props = { baseUrl: string; comments: CommentType[] };
+
+const pickStyles = css`
+  width: 100%;
+  min-width: 250px;
+  margin-bottom: ${space[5]}px;
+  flex: 0 0;
+  ${textSans.small()};
+`;
+
+const arrowSize = 25;
+const bg = neutral[93];
+
+const pickComment = css`
+  padding: ${space[3]}px;
+  background-color: ${bg};
+  border-radius: 15px;
+  margin-bottom: ${arrowSize + 5}px;
+  position: relative;
+
+  ${from.tablet} {
+    min-height: 150px;
+  }
+
+  :before {
+    content: "";
+    margin-left: 24px;
+    position: absolute;
+    border-right: ${arrowSize}px solid transparent;
+    border-top: ${arrowSize}px solid ${bg};
+    bottom: -${arrowSize - 1}px;
+  }
+`;
+
+const pickMetaWrapper = css`
+  display: flex;
+  justify-content: space-between;
+  padding-top: ${space[2]}px;
+`;
+
+const userDetails = css`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const userMetaStyles = css`
+  display: flex;
+  flex-direction: column;
+`;
+
+const userName = css`
+  font-weight: bold;
+  color: ${palette.news.main}; /* TODO USE PILLAR */
+`;
+
+const avatarMargin = css`
+  margin-right: ${space[2]}px;
+`;
+
+const linkStyles = css`
+  color: inherit;
+
+  text-decoration: none;
+  :hover {
+    text-decoration: underline;
+  }
+`;
+
+export const TopPick = ({
+  baseUrl,
+  comment
+}: {
+  baseUrl: string;
+  comment: CommentType;
+}) => (
+  <div className={pickStyles}>
+    <div className={pickComment}>
+      <h3
+        className={css`
+          ${textSans.small()};
+          font-weight: bold;
+          margin: 0px;
+        `}
+      >
+        Guardian Pick
+      </h3>
+      <p dangerouslySetInnerHTML={{ __html: comment.body }}></p>
+    </div>
+    <div className={pickMetaWrapper}>
+      <div className={userDetails}>
+        <div className={avatarMargin}>
+          <Avatar
+            imageUrl={comment.userProfile.avatar}
+            displayName={""}
+            size="medium"
+          />
+        </div>
+        <div className={userMetaStyles}>
+          <span className={userName}>
+            <a
+              href={`https://profile.theguardian.com/user/${comment.userProfile.userId}`}
+              className={linkStyles}
+            >
+              {comment.userProfile.displayName}
+            </a>
+          </span>
+          <Timestamp
+            isoDateTime={comment.isoDateTime}
+            linkTo={joinUrl([
+              // Remove the discussion-api path from the baseUrl
+              baseUrl
+                .split("/")
+                .filter(path => path !== "discussion-api")
+                .join("/"),
+              "comment-permalink",
+              comment.id.toString()
+            ])}
+          />
+          {!!comment.userProfile.badge.filter(obj => obj["name"] === "Staff")
+            .length ? (
+            <GuardianStaff />
+          ) : (
+            <></>
+          )}
+        </div>
+      </div>
+      <div>
+        <RecommendationCount
+          commentId={comment.id}
+          initialCount={comment.numRecommends}
+          alreadyRecommended={false}
+        />
+      </div>
+    </div>
+  </div>
+);

--- a/src/components/TopPicks/TopPicks.tsx
+++ b/src/components/TopPicks/TopPicks.tsx
@@ -2,83 +2,11 @@ import React from "react";
 import { css, cx } from "emotion";
 
 import { until, from } from "@guardian/src-foundations/mq";
-import { space, neutral, palette } from "@guardian/src-foundations";
-import { textSans } from "@guardian/src-foundations/typography";
 
-import { GuardianStaff } from "../Badges/Badges";
 import { CommentType } from "../../types";
-import { Avatar } from "../Avatar/Avatar";
-import { RecommendationCount } from "../RecommendationCount/RecommendationCount";
-import { Timestamp } from "../Timestamp/Timestamp";
-import { joinUrl } from "../../lib/joinUrl";
+import { TopPick } from "../TopPick/TopPick";
 
 type Props = { baseUrl: string; comments: CommentType[] };
-
-const pickStyles = css`
-  width: 100%;
-  min-width: 250px;
-  margin-bottom: ${space[5]}px;
-  flex: 0 0;
-  ${textSans.small()};
-`;
-
-const arrowSize = 25;
-const bg = neutral[93];
-
-const pickComment = css`
-  padding: ${space[3]}px;
-  background-color: ${bg};
-  border-radius: 15px;
-  margin-bottom: ${arrowSize + 5}px;
-  position: relative;
-
-  ${from.tablet} {
-    min-height: 150px;
-  }
-
-  :before {
-    content: "";
-    margin-left: 24px;
-    position: absolute;
-    border-right: ${arrowSize}px solid transparent;
-    border-top: ${arrowSize}px solid ${bg};
-    bottom: -${arrowSize - 1}px;
-  }
-`;
-
-const pickMetaWrapper = css`
-  display: flex;
-  justify-content: space-between;
-  padding-top: ${space[2]}px;
-`;
-
-const userDetails = css`
-  display: flex;
-  justify-content: space-between;
-`;
-
-const userMetaStyles = css`
-  display: flex;
-  flex-direction: column;
-`;
-
-const userName = css`
-  font-weight: bold;
-  color: ${palette.news.main}; /* TODO USE PILLAR */
-`;
-
-const avatarMargin = css`
-  margin-right: ${space[2]}px;
-`;
-
-const linkStyles = css`
-  color: inherit;
-
-  text-decoration: none;
-  :hover {
-    text-decoration: underline;
-  }
-`;
 
 const columWrapperStyles = css`
   width: 50%;
@@ -112,75 +40,6 @@ const oneColCommentsStyles = css`
     display: none;
   }
 `;
-
-// TODO: Check if there are other labels
-const TopPick = ({
-  baseUrl,
-  comment
-}: {
-  baseUrl: string;
-  comment: CommentType;
-}) => (
-    <div className={pickStyles}>
-      <div className={pickComment}>
-        <h3
-          className={css`
-          ${textSans.small()};
-          font-weight: bold;
-          margin: 0px;
-        `}
-        >
-          Guardian Pick
-      </h3>
-        <p dangerouslySetInnerHTML={{ __html: comment.body }}></p>
-      </div>
-      <div className={pickMetaWrapper}>
-        <div className={userDetails}>
-          <div className={avatarMargin}>
-            <Avatar
-              imageUrl={comment.userProfile.avatar}
-              displayName={""}
-              size="medium"
-            />
-          </div>
-          <div className={userMetaStyles}>
-            <span className={userName}>
-              <a
-                href={`https://profile.theguardian.com/user/${comment.userProfile.userId}`}
-                className={linkStyles}
-              >
-                {comment.userProfile.displayName}
-              </a>
-            </span>
-            <Timestamp
-              isoDateTime={comment.isoDateTime}
-              linkTo={joinUrl([
-                // Remove the discussion-api path from the baseUrl
-                baseUrl
-                  .split("/")
-                  .filter(path => path !== "discussion-api")
-                  .join("/"),
-                "comment-permalink",
-                comment.id.toString()
-              ])}
-            />
-            {!!comment.userProfile.badge.filter(
-              obj => obj["name"] === "Staff"
-            ).length ? (
-                <GuardianStaff />
-              ) : <></>}
-          </div>
-        </div>
-        <div>
-          <RecommendationCount
-            commentId={comment.id}
-            initialCount={comment.numRecommends}
-            alreadyRecommended={false}
-          />
-        </div>
-      </div>
-    </div>
-  );
 
 export const TopPicks = ({ baseUrl, comments }: Props) => {
   const leftColComments: CommentType[] = [];


### PR DESCRIPTION
## What does this change?
If the comment text of a pick is especially long we now only show the first 450 chars

## Before
![Screenshot 2020-03-21 at 20 10 07](https://user-images.githubusercontent.com/1336821/77235697-fc073100-6baf-11ea-85a8-215b3d93db88.jpg)

## After
![Screenshot 2020-03-21 at 20 08 42](https://user-images.githubusercontent.com/1336821/77235700-00cbe500-6bb0-11ea-8f89-ec75075ee702.jpg)

## Why?
Because sometimes they really are quite long and we don't want to push all the content down too far because of that

## Link to supporting Trello card
https://trello.com/c/49rX9wbP/1323-limit-pick-text
