### PR TITLE
initialPage

### DIFF
--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -42,3 +42,24 @@ export const Default = () => (
   </div>
 );
 Default.story = { name: "default" };
+
+export const InitialPage = () => (
+  <div
+    className={css`
+      width: 100%;
+      max-width: 620px;
+    `}
+  >
+    <App
+      shortUrl="p/39f5z"
+      initialPage={3}
+      baseUrl="https://discussion.theguardian.com/discussion-api"
+      user={aUser}
+      additionalHeaders={{
+        "D2-X-UID": "testD2Header",
+        "GU-Client": "testClientHeader"
+      }}
+    />
+  </div>
+);
+InitialPage.story = { name: "with initial page set to 3" };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import { Pagination } from "./components/Pagination/Pagination";
 type Props = {
   shortUrl: string;
   baseUrl: string;
+  initialPage?: number;
   user?: UserProfile;
   additionalHeaders: AdditionalHeadersType;
 };
@@ -65,8 +66,7 @@ const viewMoreButtonContentStyles = css`
 const DEFAULT_FILTERS: FilterOptions = {
   orderBy: "newest",
   pageSize: 25,
-  threads: "collapsed",
-  page: 1
+  threads: "collapsed"
 };
 
 const PlusSVG = () => (
@@ -115,18 +115,24 @@ const readFiltersFromLocalStorage = (): FilterOptions => {
   return {
     orderBy: orderBy ? JSON.parse(orderBy).value : DEFAULT_FILTERS.orderBy,
     threads: threads ? JSON.parse(threads).value : DEFAULT_FILTERS.threads,
-    pageSize: pageSize ? JSON.parse(pageSize).value : DEFAULT_FILTERS.pageSize,
-    page: DEFAULT_FILTERS.page
+    pageSize: pageSize ? JSON.parse(pageSize).value : DEFAULT_FILTERS.pageSize
   };
 };
 
-export const App = ({ baseUrl, shortUrl, user, additionalHeaders }: Props) => {
+export const App = ({
+  baseUrl,
+  shortUrl,
+  initialPage,
+  user,
+  additionalHeaders
+}: Props) => {
   const [filters, setFilters] = useState<FilterOptions>(
     readFiltersFromLocalStorage()
   );
   const [isPreview, setIsPreview] = useState<boolean>(true);
   const [loading, setLoading] = useState<boolean>(true);
   const [totalPages, setTotalPages] = useState<number>(0);
+  const [page, setPage] = useState<number>(initialPage || 1);
   const [picks, setPicks] = useState<CommentType[]>([]);
   const [commentBeingRepliedTo, setCommentBeingRepliedTo] = useState<
     CommentType
@@ -136,14 +142,14 @@ export const App = ({ baseUrl, shortUrl, user, additionalHeaders }: Props) => {
 
   useEffect(() => {
     setLoading(true);
-    getDiscussion(shortUrl, filters).then(json => {
+    getDiscussion(shortUrl, { ...filters, page }).then(json => {
       setLoading(false);
       if (json?.status !== "error") {
         setComments(json?.discussion?.comments);
       }
       setTotalPages(json?.pages);
     });
-  }, [filters, shortUrl]);
+  }, [filters, page, shortUrl]);
 
   useEffect(() => {
     setLoading(true);
@@ -166,6 +172,10 @@ export const App = ({ baseUrl, shortUrl, user, additionalHeaders }: Props) => {
   const onFilterChange = (newFilterObject: FilterOptions) => {
     rememberFilters(newFilterObject);
     setFilters(newFilterObject);
+  };
+
+  const onPageChange = (page: number) => {
+    setPage(page);
   };
 
   const onAddComment = (commentId: number, body: string, user: UserProfile) => {
@@ -295,12 +305,9 @@ export const App = ({ baseUrl, shortUrl, user, additionalHeaders }: Props) => {
       {showPagination && (
         <Pagination
           totalPages={totalPages}
-          currentPage={filters.page}
-          setCurrentPage={(page: number) => {
-            onFilterChange({
-              ...filters,
-              page
-            });
+          currentPage={page}
+          setCurrentPage={(newPage: number) => {
+            onPageChange(newPage);
           }}
           commentCount={commentCount}
           filters={filters}
@@ -333,12 +340,9 @@ export const App = ({ baseUrl, shortUrl, user, additionalHeaders }: Props) => {
         <footer className={footerStyles}>
           <Pagination
             totalPages={totalPages}
-            currentPage={filters.page}
-            setCurrentPage={(page: number) => {
-              setFilters({
-                ...filters,
-                page: page
-              });
+            currentPage={page}
+            setCurrentPage={(newPage: number) => {
+              onPageChange(newPage);
             }}
             commentCount={commentCount}
             filters={filters}

--- a/src/components/Filters/Filters.stories.tsx
+++ b/src/components/Filters/Filters.stories.tsx
@@ -10,8 +10,7 @@ export const Default = () => {
   const [filters, setFilters] = useState<FilterOptions>({
     orderBy: "newest",
     pageSize: 5,
-    threads: "collapsed",
-    page: 1
+    threads: "collapsed"
   });
   return (
     <Filters filters={filters} onFilterChange={setFilters} totalPages={5} />

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -8,8 +8,7 @@ export default { component: Pagination, title: "Pagination" };
 const DEFAULT_FILTERS: FilterOptions = {
   orderBy: "newest",
   pageSize: 25,
-  threads: "collapsed",
-  page: 1
+  threads: "collapsed"
 };
 
 export const Default = () => {

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -216,10 +216,10 @@ export const Pagination = ({
   const showForwardButton = totalPages > 4 && currentPage !== totalPages;
 
   // Pagination Text
-  const startIndex = filters.pageSize * (filters.page - 1);
+  const startIndex = filters.pageSize * (currentPage - 1);
   const endIndex =
-    filters.pageSize * filters.page < commentCount
-      ? filters.pageSize * filters.page
+    filters.pageSize * currentPage < commentCount
+      ? filters.pageSize * currentPage
       : commentCount;
 
   return (

--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -1,7 +1,8 @@
 import { joinUrl } from "./joinUrl";
 
 import {
-  FilterOptions,
+  OrderByType,
+  ThreadsType,
   DiscussionResponse,
   DiscussionOptions,
   UserProfile,
@@ -40,7 +41,12 @@ const objAsParams = (obj: any): string => {
 
 export const getDiscussion = (
   shortUrl: string,
-  opts: FilterOptions
+  opts: {
+    orderBy: OrderByType;
+    pageSize: number;
+    threads: ThreadsType;
+    page: number;
+  }
 ): Promise<DiscussionResponse> => {
   const apiOpts: DiscussionOptions = {
     orderBy: opts.orderBy,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -92,7 +92,6 @@ export interface FilterOptions {
   orderBy: OrderByType;
   pageSize: number;
   threads: ThreadsType;
-  page: number;
 }
 
 export interface UserProfile {
@@ -140,7 +139,7 @@ export interface DiscussionOptions {
   page: number;
 }
 
-export type AdditionalHeadersType = { [key: string]: string }
+export type AdditionalHeadersType = { [key: string]: string };
 
 export type DropdownOptionType = {
   value: string;


### PR DESCRIPTION
## What does this change?
We can now set the initial page for a discussion as a prop

As part of this PR I refactored the setFilters flow to remove `page` out from the FilterOptions object as it is no longer related to filters and should have it's own flow

## Why?
This is useful for permalinks where DCR needs to be able to specifiy the page a comment is on so the hash anchor works

## Link to supporting Trello card
https://trello.com/c/Di3G6pkZ/1180-permalinks
