### PR TITLE
Added pageSizeOverride prop

### DIFF
--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -63,3 +63,25 @@ export const InitialPage = () => (
   </div>
 );
 InitialPage.story = { name: "with initial page set to 3" };
+
+export const PageSize = () => (
+  <div
+    className={css`
+      width: 100%;
+      max-width: 620px;
+    `}
+  >
+    <App
+      shortUrl="p/39f5z"
+      initialPage={3}
+      pageSizeOverride={20}
+      baseUrl="https://discussion.theguardian.com/discussion-api"
+      user={aUser}
+      additionalHeaders={{
+        "D2-X-UID": "testD2Header",
+        "GU-Client": "testClientHeader"
+      }}
+    />
+  </div>
+);
+PageSize.story = { name: "with page size overridden to 20" };

--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -64,7 +64,7 @@ export const InitialPage = () => (
 );
 InitialPage.story = { name: "with initial page set to 3" };
 
-export const PageSize = () => (
+export const Overrides = () => (
   <div
     className={css`
       width: 100%;
@@ -75,6 +75,7 @@ export const PageSize = () => (
       shortUrl="p/39f5z"
       initialPage={3}
       pageSizeOverride={20}
+      orderByOverride={"oldest"}
       baseUrl="https://discussion.theguardian.com/discussion-api"
       user={aUser}
       additionalHeaders={{
@@ -84,4 +85,4 @@ export const PageSize = () => (
     />
   </div>
 );
-PageSize.story = { name: "with page size overridden to 20" };
+Overrides.story = { name: "with page size overridden to 20" };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,8 @@ import {
   FilterOptions,
   UserProfile,
   AdditionalHeadersType,
-  PageSizeType
+  PageSizeType,
+  OrderByType
 } from "./types";
 import {
   getDiscussion,
@@ -31,6 +32,7 @@ type Props = {
   baseUrl: string;
   initialPage?: number;
   pageSizeOverride?: PageSizeType;
+  orderByOverride?: OrderByType;
   user?: UserProfile;
   additionalHeaders: AdditionalHeadersType;
 };
@@ -97,12 +99,16 @@ const rememberFilters = (filtersToRemember: FilterOptions) => {
   }
 };
 
-const initialiseFilters = (pageSizeOverride?: PageSizeType) => {
+const initialiseFilters = (
+  pageSizeOverride?: PageSizeType,
+  orderByOverride?: OrderByType
+) => {
   const initialisedFilters = initFiltersFromLocalStorage();
   return {
     ...initialisedFilters,
-    // Override pageSize if this prop was given
-    pageSize: pageSizeOverride || initialisedFilters.pageSize
+    // Override if prop given
+    pageSize: pageSizeOverride || initialisedFilters.pageSize,
+    orderBy: orderByOverride || initialisedFilters.orderBy
   };
 };
 
@@ -135,11 +141,12 @@ export const App = ({
   shortUrl,
   initialPage,
   pageSizeOverride,
+  orderByOverride,
   user,
   additionalHeaders
 }: Props) => {
   const [filters, setFilters] = useState<FilterOptions>(
-    initialiseFilters(pageSizeOverride)
+    initialiseFilters(pageSizeOverride, orderByOverride)
   );
   const [isPreview, setIsPreview] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(true);
@@ -180,24 +187,6 @@ export const App = ({
     };
     fetchPicks();
   }, [shortUrl]);
-
-  // Check the url to see if there is a hash ref to a comment and if
-  // so, scroll to the div with this id.
-  // We need to do this in javascript like this because the comments list isn't
-  // loaded on the inital page load and only gets added to the dom later after
-  // an api call is made.
-  useEffect(() => {
-    const commentIdFromUrl = () => {
-      const { hash } = window.location;
-      return hash && hash.includes("comment") && hash.split("-")[1];
-    };
-
-    const commentId = commentIdFromUrl();
-    if (commentId) {
-      const commentElement = document.getElementById(`comment-${commentId}`);
-      commentElement && commentElement.scrollIntoView();
-    }
-  }, [comments]); // Add comments to deps so we rerun this effect when comments are loaded
 
   const onFilterChange = (newFilterObject: FilterOptions) => {
     rememberFilters(newFilterObject);
@@ -355,6 +344,7 @@ export const App = ({
               <CommentContainer
                 baseUrl={baseUrl}
                 comment={comment}
+                commentToScrollTo={commentToScrollTo}
                 pillar="news"
                 shortUrl={shortUrl}
                 onAddComment={onAddComment}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -188,6 +188,24 @@ export const App = ({
     fetchPicks();
   }, [shortUrl]);
 
+  // Check the url to see if there is a hash ref to a comment and if
+  // so, scroll to the div with this id.
+  // We need to do this in javascript like this because the comments list isn't
+  // loaded on the inital page load and only gets added to the dom later after
+  // an api call is made.
+  useEffect(() => {
+    const commentIdFromUrl = () => {
+      const { hash } = window.location;
+      return hash && hash.includes("comment") && hash.split("-")[1];
+    };
+
+    const commentId = commentIdFromUrl();
+    if (commentId) {
+      const commentElement = document.getElementById(`comment-${commentId}`);
+      commentElement && commentElement.scrollIntoView();
+    }
+  }, [comments]); // Add comments to deps so we rerun this effect when comments are loaded
+
   const onFilterChange = (newFilterObject: FilterOptions) => {
     rememberFilters(newFilterObject);
     setFilters(newFilterObject);
@@ -344,7 +362,6 @@ export const App = ({
               <CommentContainer
                 baseUrl={baseUrl}
                 comment={comment}
-                commentToScrollTo={commentToScrollTo}
                 pillar="news"
                 shortUrl={shortUrl}
                 onAddComment={onAddComment}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,8 @@ import {
   CommentType,
   FilterOptions,
   UserProfile,
-  AdditionalHeadersType
+  AdditionalHeadersType,
+  PageSizeType
 } from "./types";
 import {
   getDiscussion,
@@ -29,6 +30,7 @@ type Props = {
   shortUrl: string;
   baseUrl: string;
   initialPage?: number;
+  pageSizeOverride?: PageSizeType;
   user?: UserProfile;
   additionalHeaders: AdditionalHeadersType;
 };
@@ -95,7 +97,16 @@ const rememberFilters = (filtersToRemember: FilterOptions) => {
   }
 };
 
-const readFiltersFromLocalStorage = (): FilterOptions => {
+const initialiseFilters = (pageSizeOverride?: PageSizeType) => {
+  const initialisedFilters = initFiltersFromLocalStorage();
+  return {
+    ...initialisedFilters,
+    // Override pageSize if this prop was given
+    pageSize: pageSizeOverride || initialisedFilters.pageSize
+  };
+};
+
+const initFiltersFromLocalStorage = (): FilterOptions => {
   let threads;
   let pageSize;
   let orderBy;
@@ -123,11 +134,12 @@ export const App = ({
   baseUrl,
   shortUrl,
   initialPage,
+  pageSizeOverride,
   user,
   additionalHeaders
 }: Props) => {
   const [filters, setFilters] = useState<FilterOptions>(
-    readFiltersFromLocalStorage()
+    initialiseFilters(pageSizeOverride)
   );
   const [isPreview, setIsPreview] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(true);

--- a/src/components/Filters/Filters.stories.tsx
+++ b/src/components/Filters/Filters.stories.tsx
@@ -9,7 +9,7 @@ export default { title: "Filters" };
 export const Default = () => {
   const [filters, setFilters] = useState<FilterOptions>({
     orderBy: "newest",
-    pageSize: 5,
+    pageSize: 25,
     threads: "collapsed"
   });
   return (

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -6,7 +6,12 @@ import { border } from "@guardian/src-foundations/palette";
 
 import { Dropdown } from "../Dropdown/Dropdown";
 
-import { FilterOptions, OrderByType, ThreadsType } from "../../types";
+import {
+  FilterOptions,
+  OrderByType,
+  ThreadsType,
+  PageSizeType
+} from "../../types";
 
 type Props = {
   filters: FilterOptions;
@@ -83,6 +88,11 @@ export const Filters = ({ filters, onFilterChange, totalPages }: Props) => (
         pillar="news"
         options={[
           {
+            title: "20",
+            value: "20",
+            isActive: filters.pageSize === 20
+          },
+          {
             title: "25",
             value: "25",
             isActive: filters.pageSize === 25
@@ -101,7 +111,7 @@ export const Filters = ({ filters, onFilterChange, totalPages }: Props) => (
         onSelect={value =>
           onFilterChange({
             ...filters,
-            pageSize: parseInt(value) as number
+            pageSize: parseInt(value) as PageSizeType
           })
         }
       />

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -87,10 +87,10 @@ export type UserNameResponse = {
 
 export type OrderByType = "newest" | "oldest" | "mostrecommended";
 export type ThreadsType = "collapsed" | "expanded" | "unthreaded";
-
+export type PageSizeType = 20 | 25 | 50 | 100;
 export interface FilterOptions {
   orderBy: OrderByType;
-  pageSize: number;
+  pageSize: PageSizeType;
   threads: ThreadsType;
 }
 


### PR DESCRIPTION
## What does this change?
Adds the `pageSizeOverride?: PageSizeType` and `orderByOverride?: OrderByType`props to `App` and uses them to override the value of the filters

## Why do we now have page sizes of 20 and 25?
Because the `/context` api returns a page size value of 20 so we need to support this value when paginating the list or we won't be able to correctly permalink to a comment.

It's possible that the /context endpoint never returns 25 in which case we can remove this option, balancing things up. This work is covered in https://trello.com/c/7v4VDNY0/1326-review-page-size-values

## Why?
Because this is required to support permalinks

## Link to supporting Trello card
https://trello.com/c/Ww9xHaBk/1327-page-size-override