### PR TITLE
Ensure override updates are set

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -188,6 +188,22 @@ export const App = ({
     fetchPicks();
   }, [shortUrl]);
 
+  // If these override props are updated we want to respect them
+  useEffect(() => {
+    setFilters(oldFilters => {
+      return {
+        ...oldFilters,
+        orderBy: orderByOverride ? orderByOverride : oldFilters.orderBy,
+        pageSize: pageSizeOverride ? pageSizeOverride : oldFilters.pageSize
+      };
+    });
+  }, [pageSizeOverride, orderByOverride]);
+
+  // Keep initialPage prop in sync with page
+  useEffect(() => {
+    if (initialPage) setPage(initialPage);
+  }, [initialPage]);
+
   // Check the url to see if there is a hash ref to a comment and if
   // so, scroll to the div with this id.
   // We need to do this in javascript like this because the comments list isn't


### PR DESCRIPTION
## What does this change?
This uses the useEffect hook to capture any change to the override props and ensures the local state is updated with them

## Why?
So we respect these props

## Link to supporting Trello card
https://trello.com/c/PE2nQYb2/1328-respect-overrides
