### PR TITLE
Support passing in default expanded state as a prop

### DIFF
--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -38,6 +38,7 @@ export const Default = () => (
         "D2-X-UID": "testD2Header",
         "GU-Client": "testClientHeader"
       }}
+      expanded={false}
     />
   </div>
 );
@@ -59,6 +60,7 @@ export const InitialPage = () => (
         "D2-X-UID": "testD2Header",
         "GU-Client": "testClientHeader"
       }}
+      expanded={false}
     />
   </div>
 );
@@ -82,7 +84,30 @@ export const Overrides = () => (
         "D2-X-UID": "testD2Header",
         "GU-Client": "testClientHeader"
       }}
+      expanded={false}
     />
   </div>
 );
 Overrides.story = { name: "with page size overridden to 20" };
+
+export const Expanded = () => (
+  <div
+    className={css`
+      width: 100%;
+      max-width: 620px;
+    `}
+  >
+    <App
+      shortUrl="p/39f5z"
+      initialPage={3}
+      baseUrl="https://discussion.theguardian.com/discussion-api"
+      user={aUser}
+      additionalHeaders={{
+        "D2-X-UID": "testD2Header",
+        "GU-Client": "testClientHeader"
+      }}
+      expanded={true}
+    />
+  </div>
+);
+Expanded.story = { name: "expanded by default and on page 3" };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ type Props = {
   orderByOverride?: OrderByType;
   user?: UserProfile;
   additionalHeaders: AdditionalHeadersType;
+  expanded: boolean;
 };
 
 const containerStyles = css`
@@ -143,12 +144,13 @@ export const App = ({
   pageSizeOverride,
   orderByOverride,
   user,
-  additionalHeaders
+  additionalHeaders,
+  expanded
 }: Props) => {
   const [filters, setFilters] = useState<FilterOptions>(
     initialiseFilters(pageSizeOverride, orderByOverride)
   );
-  const [isPreview, setIsPreview] = useState<boolean>(false);
+  const [isExpanded, setIsExpanded] = useState<boolean>(expanded);
   const [loading, setLoading] = useState<boolean>(true);
   const [totalPages, setTotalPages] = useState<number>(0);
   const [page, setPage] = useState<number>(initialPage || 1);
@@ -259,7 +261,7 @@ export const App = ({
 
   const showPagination = totalPages > 1;
 
-  if (isPreview) {
+  if (!isExpanded) {
     return (
       <div className={commentContainerStyles}>
         {user && (
@@ -307,7 +309,7 @@ export const App = ({
             width: 250px;
           `}
         >
-          <Button size="small" onClick={() => setIsPreview(false)}>
+          <Button size="small" onClick={() => setIsExpanded(true)}>
             <div className={viewMoreButtonContentStyles}>
               <PlusSVG />
             </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,7 @@ ReactDOM.render(
       "D2-X-UID": "testD2Header",
       "GU-Client": "testClientHeader"
     }}
+    expanded={false}
   />,
   document.getElementById("root")
 );


### PR DESCRIPTION
## What does this change?
This adds an `expanded` prop to App setting the default for if comments are expanded or not

## Why?
Because we need to default to expanded when permalinking to a comment. It also has the bonus benefit of making the comment layout more testable

## Link to supporting Trello card
https://trello.com/c/VWlUDIrk/1329-expanded-prop
