### PR TITLE
Tell App which comment to scroll to

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import { Pagination } from "./components/Pagination/Pagination";
 type Props = {
   shortUrl: string;
   baseUrl: string;
+  commentToScrollTo?: number;
   initialPage?: number;
   pageSizeOverride?: PageSizeType;
   orderByOverride?: OrderByType;
@@ -140,6 +141,7 @@ export const App = ({
   baseUrl,
   shortUrl,
   initialPage,
+  commentToScrollTo,
   pageSizeOverride,
   orderByOverride,
   user,
@@ -188,23 +190,21 @@ export const App = ({
     fetchPicks();
   }, [shortUrl]);
 
-  // Check the url to see if there is a hash ref to a comment and if
+  // Check if there is a comment to scroll to and if
   // so, scroll to the div with this id.
   // We need to do this in javascript like this because the comments list isn't
-  // loaded on the inital page load and only gets added to the dom later after
+  // loaded on the inital page load and only gets added to the dom later, after
   // an api call is made.
   useEffect(() => {
-    const commentIdFromUrl = () => {
-      const { hash } = window.location;
-      return hash && hash.includes("comment") && hash.split("-")[1];
-    };
-
-    const commentId = commentIdFromUrl();
-    if (commentId) {
-      const commentElement = document.getElementById(`comment-${commentId}`);
+    if (commentToScrollTo) {
+      console.log("scrolling to ", commentToScrollTo);
+      const commentElement = document.getElementById(
+        `comment-${commentToScrollTo}`
+      );
+      console.log("scroll el", commentElement);
       commentElement && commentElement.scrollIntoView();
     }
-  }, [comments]); // Add comments to deps so we rerun this effect when comments are loaded
+  }, [comments, commentToScrollTo]); // Add comments to deps so we rerun this effect when comments are loaded
 
   const onFilterChange = (newFilterObject: FilterOptions) => {
     rememberFilters(newFilterObject);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -197,11 +197,9 @@ export const App = ({
   // an api call is made.
   useEffect(() => {
     if (commentToScrollTo) {
-      console.log("scrolling to ", commentToScrollTo);
       const commentElement = document.getElementById(
         `comment-${commentToScrollTo}`
       );
-      console.log("scroll el", commentElement);
       commentElement && commentElement.scrollIntoView();
     }
   }, [comments, commentToScrollTo]); // Add comments to deps so we rerun this effect when comments are loaded


### PR DESCRIPTION
## What does this change?
Adds a `commentToScrollTo` prop to App

## Why?
So that the parent component responsible for reading the url, not discussion - prevents multiple reads.

## Link to supporting Trello card
https://trello.com/c/ufWSGAzR/1330-commenttoscrollto