### PR TITLE
Jump to pick

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build/**/*"
   ],
   "dependencies": {
+    "@guardian/src-link": "^0.15.1",
     "regenerator-runtime": "^0.13.3",
     "timeago.js": "^4.0.2"
   },

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import { css, cx } from "emotion";
 
 import { from } from "@guardian/src-foundations/mq";
-import { space, neutral, palette, brandAlt } from "@guardian/src-foundations";
+import { space, neutral, palette } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
+import { Link } from "@guardian/src-link";
 
 import { GuardianStaff } from "../Badges/Badges";
 import { CommentType } from "../../types";
@@ -137,8 +138,9 @@ export const TopPick = ({ baseUrl, comment }: Props) => (
           ></p>
         </Top>
         <Bottom>
-          <a
-            className={linkStyles}
+          <Link
+            priority="primary"
+            subdued={true}
             href={joinUrl([
               // Remove the discussion-api path from the baseUrl
               baseUrl
@@ -150,7 +152,7 @@ export const TopPick = ({ baseUrl, comment }: Props) => (
             ])}
           >
             Jump to comment
-          </a>
+          </Link>
         </Bottom>
       </SpaceBetween>
     </div>

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { css } from "emotion";
+import { css, cx } from "emotion";
 
 import { from } from "@guardian/src-foundations/mq";
-import { space, neutral, palette } from "@guardian/src-foundations";
+import { space, neutral, palette, brandAlt } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
 
 import { GuardianStaff } from "../Badges/Badges";
@@ -29,6 +29,7 @@ const arrowSize = 25;
 const bg = neutral[93];
 
 const pickComment = css`
+  display: flex;
   padding: ${space[3]}px;
   background-color: ${bg};
   border-radius: 15px;
@@ -75,13 +76,39 @@ const avatarMargin = css`
 `;
 
 const linkStyles = css`
-  color: inherit;
-
   text-decoration: none;
   :hover {
     text-decoration: underline;
   }
 `;
+
+const inheritColour = css`
+  color: inherit;
+`;
+
+const SpaceBetween = ({
+  children
+}: {
+  children: JSX.Element | JSX.Element[];
+}) => (
+  <div
+    className={css`
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+    `}
+  >
+    {children}
+  </div>
+);
+
+const Top = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+  <div>{children}</div>
+);
+
+const Bottom = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+  <div>{children}</div>
+);
 
 const truncateText = (input: string, limit: number) => {
   // If input greater than limit trucate by limit and append an ellipsis
@@ -92,18 +119,40 @@ const truncateText = (input: string, limit: number) => {
 export const TopPick = ({ baseUrl, comment }: Props) => (
   <div className={pickStyles}>
     <div className={pickComment}>
-      <h3
-        className={css`
-          ${textSans.small()};
-          font-weight: bold;
-          margin: 0px;
-        `}
-      >
-        Guardian Pick
-      </h3>
-      <p
-        dangerouslySetInnerHTML={{ __html: truncateText(comment.body, 450) }}
-      ></p>
+      <SpaceBetween>
+        <Top>
+          <h3
+            className={css`
+              ${textSans.small()};
+              font-weight: bold;
+              margin: 0px;
+            `}
+          >
+            Guardian Pick
+          </h3>
+          <p
+            dangerouslySetInnerHTML={{
+              __html: truncateText(comment.body, 450)
+            }}
+          ></p>
+        </Top>
+        <Bottom>
+          <a
+            className={linkStyles}
+            href={joinUrl([
+              // Remove the discussion-api path from the baseUrl
+              baseUrl
+                .split("/")
+                .filter(path => path !== "discussion-api")
+                .join("/"),
+              "comment-permalink",
+              comment.id.toString()
+            ])}
+          >
+            Jump to comment
+          </a>
+        </Bottom>
+      </SpaceBetween>
     </div>
     <div className={pickMetaWrapper}>
       <div className={userDetails}>
@@ -118,7 +167,7 @@ export const TopPick = ({ baseUrl, comment }: Props) => (
           <span className={userName}>
             <a
               href={`https://profile.theguardian.com/user/${comment.userProfile.userId}`}
-              className={linkStyles}
+              className={cx(linkStyles, inheritColour)}
             >
               {comment.userProfile.displayName}
             </a>

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -12,7 +12,10 @@ import { RecommendationCount } from "../RecommendationCount/RecommendationCount"
 import { Timestamp } from "../Timestamp/Timestamp";
 import { joinUrl } from "../../lib/joinUrl";
 
-type Props = { baseUrl: string; comments: CommentType[] };
+type Props = {
+  baseUrl: string;
+  comment: CommentType;
+};
 
 const pickStyles = css`
   width: 100%;
@@ -86,13 +89,7 @@ const truncateText = (input: string, limit: number) => {
   return input;
 };
 
-export const TopPick = ({
-  baseUrl,
-  comment
-}: {
-  baseUrl: string;
-  comment: CommentType;
-}) => (
+export const TopPick = ({ baseUrl, comment }: Props) => (
   <div className={pickStyles}>
     <div className={pickComment}>
       <h3

--- a/yarn.lock
+++ b/yarn.lock
@@ -1842,6 +1842,13 @@
     "@guardian/src-helpers" "^0.15.1"
     "@guardian/src-svgs" "^0.15.1"
 
+"@guardian/src-link@^0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-link/-/src-link-0.15.1.tgz#2b5c196e9c57ac7a920d630ef7c47cacbefa9997"
+  integrity sha512-WZHHoFSd+vx1CU01M5lWAob3lrnNzIoPH00M5cxL5mXvl/3911l2WeiwMGC46MZkmZvHQ+ju3b4khk9nuBDFeA==
+  dependencies:
+    "@guardian/src-helpers" "^0.15.1"
+
 "@guardian/src-svgs@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-svgs/-/src-svgs-0.1.0.tgz#18eb61504ab8535dbd235f1d33447059f881f404"


### PR DESCRIPTION
## What does this change?
Adds a link at the bottom of a pick

Uses `@guardian/src-link` to add the a tag

![Screenshot 2020-03-24 at 13 14 45](https://user-images.githubusercontent.com/1336821/77429372-7793f880-6dd1-11ea-8a52-3921e4a2936e.jpg)


## Why?
To take the reader to the comment in context

## Link to supporting Trello card
https://trello.com/c/qu0bNXyB/1185-jump-to-comment-on-picks
