### PR TITLE
Show replies for permalinks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,8 @@ import {
   UserProfile,
   AdditionalHeadersType,
   PageSizeType,
-  OrderByType
+  OrderByType,
+  ThreadsType
 } from "./types";
 import {
   getDiscussion,
@@ -104,17 +105,23 @@ const rememberFilters = (filtersToRemember: FilterOptions) => {
 
 const initialiseFilters = ({
   pageSizeOverride,
-  orderByOverride
+  orderByOverride,
+  permalinkBeingUsed
 }: {
   pageSizeOverride?: PageSizeType;
   orderByOverride?: OrderByType;
+  permalinkBeingUsed: boolean;
 }) => {
   const initialisedFilters = initFiltersFromLocalStorage();
   return {
     ...initialisedFilters,
     // Override if prop given
     pageSize: pageSizeOverride || initialisedFilters.pageSize,
-    orderBy: orderByOverride || initialisedFilters.orderBy
+    orderBy: orderByOverride || initialisedFilters.orderBy,
+    threads:
+      initialisedFilters.threads === "collapsed" && permalinkBeingUsed
+        ? "expanded"
+        : initialisedFilters.threads
   };
 };
 
@@ -154,7 +161,11 @@ export const App = ({
   expanded
 }: Props) => {
   const [filters, setFilters] = useState<FilterOptions>(
-    initialiseFilters({ pageSizeOverride, orderByOverride })
+    initialiseFilters({
+      pageSizeOverride,
+      orderByOverride,
+      permalinkBeingUsed: !!commentToScrollTo
+    })
   );
   const [isExpanded, setIsExpanded] = useState<boolean>(expanded);
   const [loading, setLoading] = useState<boolean>(true);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,10 +102,13 @@ const rememberFilters = (filtersToRemember: FilterOptions) => {
   }
 };
 
-const initialiseFilters = (
-  pageSizeOverride?: PageSizeType,
-  orderByOverride?: OrderByType
-) => {
+const initialiseFilters = ({
+  pageSizeOverride,
+  orderByOverride
+}: {
+  pageSizeOverride?: PageSizeType;
+  orderByOverride?: OrderByType;
+}) => {
   const initialisedFilters = initFiltersFromLocalStorage();
   return {
     ...initialisedFilters,
@@ -151,7 +154,7 @@ export const App = ({
   expanded
 }: Props) => {
   const [filters, setFilters] = useState<FilterOptions>(
-    initialiseFilters(pageSizeOverride, orderByOverride)
+    initialiseFilters({ pageSizeOverride, orderByOverride })
   );
   const [isExpanded, setIsExpanded] = useState<boolean>(expanded);
   const [loading, setLoading] = useState<boolean>(true);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,8 +13,7 @@ import {
   UserProfile,
   AdditionalHeadersType,
   PageSizeType,
-  OrderByType,
-  ThreadsType
+  OrderByType
 } from "./types";
 import {
   getDiscussion,


### PR DESCRIPTION
## What does this change?
This ensures that reply threads are expanded when a permalink is being used

## Why?
Because in "collapsed" mode some replies are hidden and can't be scrolled

## Depends on
https://github.com/guardian/dotcom-rendering/pull/1298

## Link to supporting Trello card
https://trello.com/c/oD8wVrK2/1345-permalink-to-hidden-replies
