### PR TITLE
Fix filter keyname typo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,9 +122,9 @@ const initFiltersFromLocalStorage = (): FilterOptions => {
 
   try {
     // Try to read from local storage
-    orderBy = localStorage.getItem("gu.prefs.discussioni.order");
-    threads = localStorage.getItem("gu.prefs.discussioni.threading");
-    pageSize = localStorage.getItem("gu.prefs.discussioni.pagesize");
+    orderBy = localStorage.getItem("gu.prefs.discussion.order");
+    threads = localStorage.getItem("gu.prefs.discussion.threading");
+    pageSize = localStorage.getItem("gu.prefs.discussion.pagesize");
   } catch (error) {
     // Sometimes it's not possible to access localStorage, we accept this and don't want to
     // capture these errors


### PR DESCRIPTION
## What does this change?
Fixes a typo in the name used to store filter values

## Why?
So we maintain parity with frontend and both read the same values

## Link to supporting Trello card
https://trello.com/c/3W52wpoO/1350-keyname-typo
