### PR TITLE
Remove page size 20

### DIFF
--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -76,7 +76,7 @@ export const Overrides = () => (
     <App
       shortUrl="p/39f5z"
       initialPage={3}
-      pageSizeOverride={20}
+      pageSizeOverride={50}
       orderByOverride={"oldest"}
       baseUrl="https://discussion.theguardian.com/discussion-api"
       user={aUser}
@@ -88,7 +88,7 @@ export const Overrides = () => (
     />
   </div>
 );
-Overrides.story = { name: "with page size overridden to 20" };
+Overrides.story = { name: "with page size overridden to 50" };
 
 export const Expanded = () => (
   <div

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -88,11 +88,6 @@ export const Filters = ({ filters, onFilterChange, totalPages }: Props) => (
         pillar="news"
         options={[
           {
-            title: "20",
-            value: "20",
-            isActive: filters.pageSize === 20
-          },
-          {
             title: "25",
             value: "25",
             isActive: filters.pageSize === 25

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -87,7 +87,7 @@ export type UserNameResponse = {
 
 export type OrderByType = "newest" | "oldest" | "mostrecommended";
 export type ThreadsType = "collapsed" | "expanded" | "unthreaded";
-export type PageSizeType = 20 | 25 | 50 | 100;
+export type PageSizeType = 25 | 50 | 100;
 export interface FilterOptions {
   orderBy: OrderByType;
   pageSize: PageSizeType;


### PR DESCRIPTION
## What does this change?
This removes the option to have 20 items per page

## Why?
We previously were getting `pageSize: 20` in the response to `/context` calls for a comment, forcing us to support this page size. But now that we pass the `pageSize` [param to that call](https://github.com/guardian/dotcom-rendering/pull/1298) we don't have this problem and can revert to 25, 50 & 100.

## Depends on
https://github.com/guardian/dotcom-rendering/pull/1298

## Link to supporting Trello card
https://trello.com/c/7v4VDNY0/1326-review-page-size-values