### PR TITLE
Disable irrelevant page size options

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -369,6 +369,7 @@ export const App = ({
         filters={filters}
         onFilterChange={onFilterChange}
         totalPages={totalPages}
+        commentCount={commentCount}
       />
       {showPagination && (
         <Pagination

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -54,10 +54,10 @@ const ulExpanded = css`
   display: block;
 `;
 
-const linkStyles = css`
+const linkStyles = (disabled: boolean) => css`
   ${textSans.small()};
   text-align: left;
-  color: ${neutral[46]};
+  color: ${disabled ? neutral[86] : neutral[46]};
   position: relative;
   text-decoration: none;
   margin-top: 1px;
@@ -66,18 +66,21 @@ const linkStyles = css`
   padding-bottom: 8px;
   padding-left: 8px;
   width: 100%;
-  cursor: pointer;
+  cursor: ${disabled ? "default" : "pointer"};
   background-color: white;
   border: none;
 
-  :hover {
-    background-color: ${neutral[93]};
-    text-decoration: underline;
-  }
+  ${!disabled &&
+    `
+    :hover {
+      background-color: ${neutral[93]};
+      text-decoration: underline;
+    }
 
-  :focus {
-    text-decoration: underline;
-  }
+    :focus {
+      text-decoration: underline;
+    }
+  `}
 `;
 
 const firstStyles = css`
@@ -208,11 +211,11 @@ export const Dropdown = ({ id, label, options, pillar, onSelect }: Props) => {
               <button
                 onClick={() => onSelect(option.value)}
                 className={cx(
-                  linkStyles,
+                  linkStyles(!!option.disabled),
                   option.isActive && activeStyles(pillar),
                   index === 0 && firstStyles
                 )}
-                disabled={option.isActive}
+                disabled={option.isActive || option.disabled}
               >
                 {option.title}
               </button>

--- a/src/components/Filters/Filters.stories.tsx
+++ b/src/components/Filters/Filters.stories.tsx
@@ -13,7 +13,12 @@ export const Default = () => {
     threads: "collapsed"
   });
   return (
-    <Filters filters={filters} onFilterChange={setFilters} totalPages={5} />
+    <Filters
+      filters={filters}
+      onFilterChange={setFilters}
+      totalPages={5}
+      commentCount={74}
+    />
   );
 };
 Default.story = { name: "default" };

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -17,6 +17,7 @@ type Props = {
   filters: FilterOptions;
   onFilterChange: (newFilterObject: FilterOptions) => void;
   totalPages: number;
+  commentCount: number;
 };
 
 const filterBar = css`
@@ -48,7 +49,12 @@ const filterPadding = css`
   padding-right: ${space[3]}px;
 `;
 
-export const Filters = ({ filters, onFilterChange, totalPages }: Props) => (
+export const Filters = ({
+  filters,
+  onFilterChange,
+  totalPages,
+  commentCount
+}: Props) => (
   <div className={filterBar}>
     <div className={filterPadding}>
       <Dropdown
@@ -90,16 +96,19 @@ export const Filters = ({ filters, onFilterChange, totalPages }: Props) => (
           {
             title: "25",
             value: "25",
+            disabled: commentCount <= 25,
             isActive: filters.pageSize === 25
           },
           {
             title: "50",
             value: "50",
+            disabled: commentCount <= 50,
             isActive: filters.pageSize === 50
           },
           {
             title: "100",
             value: "100",
+            disabled: commentCount <= 100,
             isActive: filters.pageSize === 100
           }
         ]}

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -144,5 +144,6 @@ export type AdditionalHeadersType = { [key: string]: string };
 export type DropdownOptionType = {
   value: string;
   title: string;
+  disabled?: boolean;
   isActive?: boolean;
 };


### PR DESCRIPTION
## What does this change?
This disables a page size option in the discussion filters where the count of comments makes it irrelevant

![2020-03-26 19 34 20](https://user-images.githubusercontent.com/1336821/77688993-d9528f00-6f98-11ea-9247-1ea54f5e615d.gif)



## Why?
Because it's better to display to the reader what options there are, even if they are not valid at the point in time and are disabled, so that they learn and know what to expect later, when the options might be useful

## Link to supporting Trello card
https://trello.com/c/8osvOezc/1353-disable-irrelevant-page-size-options