### PR TITLE
Reduce Link font size for jump to comment

### DIFF
--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -76,6 +76,12 @@ const avatarMargin = css`
   margin-right: ${space[2]}px;
 `;
 
+const smallFontSize = css`
+  a {
+    ${textSans.small()}
+  }
+`;
+
 const linkStyles = css`
   text-decoration: none;
   :hover {
@@ -138,21 +144,23 @@ export const TopPick = ({ baseUrl, comment }: Props) => (
           ></p>
         </Top>
         <Bottom>
-          <Link
-            priority="primary"
-            subdued={true}
-            href={joinUrl([
-              // Remove the discussion-api path from the baseUrl
-              baseUrl
-                .split("/")
-                .filter(path => path !== "discussion-api")
-                .join("/"),
-              "comment-permalink",
-              comment.id.toString()
-            ])}
-          >
-            Jump to comment
-          </Link>
+          <div className={smallFontSize}>
+            <Link
+              priority="primary"
+              subdued={true}
+              href={joinUrl([
+                // Remove the discussion-api path from the baseUrl
+                baseUrl
+                  .split("/")
+                  .filter(path => path !== "discussion-api")
+                  .join("/"),
+                "comment-permalink",
+                comment.id.toString()
+              ])}
+            >
+              Jump to comment
+            </Link>
+          </div>
         </Bottom>
       </SpaceBetween>
     </div>


### PR DESCRIPTION
## What does this change?
This overrides the Link font size to make it smaller

## Before
![Screenshot 2020-03-28 at 17 12 07](https://user-images.githubusercontent.com/1336821/77829034-455b0180-7117-11ea-857b-96bd33017c15.jpg)

## After
![Screenshot 2020-03-28 at 17 11 56](https://user-images.githubusercontent.com/1336821/77829036-49871f00-7117-11ea-9e81-0e7c293cca43.jpg)

## Why?
So it's matches the font size of the other text in the Top Pick

## Link to supporting Trello card
https://trello.com/c/eM0zziXg/1362-jump-to-comment-font-size