### PR TITLE
Mock date

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,4 +1,7 @@
 import { configure, addParameters } from "@storybook/react";
+import MockDate from "mockdate";
+
+MockDate.set("Fri March 27 2020 12:00:00 GMT+0000 (Greenwich Mean Time)");
 
 const guardianViewports = {
   mobileMedium: {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "emotion": "^10.0.27",
     "eslint-plugin-react-hooks": "^2.3.0",
     "husky": "^4.2.3",
+    "mockdate": "^2.0.5",
     "prettier": "^1.19.1",
     "pretty-quick": "^2.0.1",
     "react": "^16.12.0",

--- a/src/components/Timestamp/Timestamp.stories.tsx
+++ b/src/components/Timestamp/Timestamp.stories.tsx
@@ -1,11 +1,10 @@
 import React from "react";
-import MockDate from "mockdate";
 
 import { Timestamp } from "./Timestamp";
 
 export default { component: Timestamp, title: "Timestamp" };
 
-MockDate.set("Fri March 27 2020 12:00:00 GMT+0000 (Greenwich Mean Time)");
+// Date is mocked to "Fri March 27 2020 12:00:00 GMT+0000 (Greenwich Mean Time)" in config
 
 export const TwoMonths = () => (
   <Timestamp isoDateTime={"2020-01-26T14:22:39Z"} linkTo="" />

--- a/src/components/Timestamp/Timestamp.stories.tsx
+++ b/src/components/Timestamp/Timestamp.stories.tsx
@@ -1,30 +1,28 @@
 import React from "react";
+import MockDate from "mockdate";
+
 import { Timestamp } from "./Timestamp";
 
 export default { component: Timestamp, title: "Timestamp" };
 
-const hoursBeforeNow = (hours: number) => {
-  var date = new Date();
-  date.setHours(date.getHours() - hours);
-  return date.toISOString();
-};
+MockDate.set("Sun Nov 17 2019 12:00:00 GMT+0000 (Greenwich Mean Time)");
 
-export const Default = () => (
-  <Timestamp isoDateTime={"2010-11-18T14:22:39Z"} linkTo="" />
+export const TwoMonths = () => (
+  <Timestamp isoDateTime={"2019-09-14T14:22:39Z"} linkTo="" />
 );
-Default.story = { name: "default" };
+TwoMonths.story = { name: "Two months" };
 
 export const OneHour = () => (
-  <Timestamp isoDateTime={hoursBeforeNow(1)} linkTo="" />
+  <Timestamp isoDateTime={"2019-11-17T11:00:00Z"} linkTo="" />
 );
 OneHour.story = { name: "One Hour" };
 
 export const TwentyThreeHours = () => (
-  <Timestamp isoDateTime={hoursBeforeNow(23)} linkTo="" />
+  <Timestamp isoDateTime={"2019-11-16T13:00:00Z"} linkTo="" />
 );
 TwentyThreeHours.story = { name: "Twenty three hours" };
 
 export const TwentyFiveHours = () => (
-  <Timestamp isoDateTime={hoursBeforeNow(25)} linkTo="" />
+  <Timestamp isoDateTime={"2019-11-16T11:00:00Z"} linkTo="" />
 );
 TwentyFiveHours.story = { name: "Twenty five hours" };

--- a/src/components/Timestamp/Timestamp.stories.tsx
+++ b/src/components/Timestamp/Timestamp.stories.tsx
@@ -5,24 +5,24 @@ import { Timestamp } from "./Timestamp";
 
 export default { component: Timestamp, title: "Timestamp" };
 
-MockDate.set("Sun Nov 17 2019 12:00:00 GMT+0000 (Greenwich Mean Time)");
+MockDate.set("Fri March 27 2020 12:00:00 GMT+0000 (Greenwich Mean Time)");
 
 export const TwoMonths = () => (
-  <Timestamp isoDateTime={"2019-09-14T14:22:39Z"} linkTo="" />
+  <Timestamp isoDateTime={"2020-01-26T14:22:39Z"} linkTo="" />
 );
 TwoMonths.story = { name: "Two months" };
 
 export const OneHour = () => (
-  <Timestamp isoDateTime={"2019-11-17T11:00:00Z"} linkTo="" />
+  <Timestamp isoDateTime={"2020-03-27T11:00:00Z"} linkTo="" />
 );
 OneHour.story = { name: "One Hour" };
 
 export const TwentyThreeHours = () => (
-  <Timestamp isoDateTime={"2019-11-16T13:00:00Z"} linkTo="" />
+  <Timestamp isoDateTime={"2020-03-26T13:00:00Z"} linkTo="" />
 );
 TwentyThreeHours.story = { name: "Twenty three hours" };
 
 export const TwentyFiveHours = () => (
-  <Timestamp isoDateTime={"2019-11-16T11:00:00Z"} linkTo="" />
+  <Timestamp isoDateTime={"2020-03-26T11:00:00Z"} linkTo="" />
 );
 TwentyFiveHours.story = { name: "Twenty five hours" };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10366,6 +10366,11 @@ mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
+mockdate@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.5.tgz#70c6abf9ed4b2dae65c81dfc170dd1a5cec53620"
+  integrity sha512-ST0PnThzWKcgSLyc+ugLVql45PvESt3Ul/wrdV/OPc/6Pr8dbLAIJsN1cIp41FLzbN+srVTNIRn+5Cju0nyV6A==
+
 moment@^2.18.1:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"


### PR DESCRIPTION
## What does this change?
Makes the date in Storybook. It is now static at

`"Fri March 27 2020 12:00:00 GMT+0000 (Greenwich Mean Time)"`

## Why?
Because some components display a relative date string which can change over time and cause false negatives in visual regression

## Link to supporting Trello card
https://trello.com/c/yE5OAyT1/1374-mock-date-for-timestamp