### PR TITLE
Link format

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,12 +16,7 @@ import {
   OrderByType,
   Pillar
 } from "./types";
-import {
-  getDiscussion,
-  getCommentCount,
-  getPicks,
-  initialiseApi
-} from "./lib/api";
+import { getDiscussion, getPicks, initialiseApi } from "./lib/api";
 import { CommentContainer } from "./components/CommentContainer/CommentContainer";
 import { TopPicks } from "./components/TopPicks/TopPicks";
 import { CommentForm } from "./components/CommentForm/CommentForm";

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -104,6 +104,17 @@ const msgContainerStyles = css`
   margin-top: 8px;
 `;
 
+const linkStyles = css`
+  a {
+    color: ${text.anchorPrimary};
+    text-decoration: none;
+    :hover,
+    :focus {
+      text-decoration: underline;
+    }
+  }
+`;
+
 const wrapperHeaderTextStyles = css`
   background-color: #f6f6f6;
   padding: 8px 10px 10px 8px;
@@ -343,25 +354,25 @@ export const CommentForm = ({
         {error && (
           <div className={msgContainerStyles}>
             <p
-              className={errorTextStyles}
+              className={cx(errorTextStyles, linkStyles)}
               dangerouslySetInnerHTML={{ __html: error }}
             />
           </div>
         )}
         {info && (
           <div className={msgContainerStyles}>
-            <p className={infoTextStyles}>{info}</p>
+            <p className={cx(infoTextStyles, linkStyles)}>{info}</p>
           </div>
         )}
         {isActive && (
           <div className={wrapperHeaderTextStyles}>
-            <p className={headerTextStyles}>
+            <p className={cx(headerTextStyles, linkStyles)}>
               Please keep comments respectful and abide by the{" "}
               <a href="/community-standards">community guidelines</a>.
             </p>
 
             {user.privateFields && user.privateFields.isPremoderated && (
-              <p className={errorTextStyles}>
+              <p className={cx(errorTextStyles, linkStyles)}>
                 Your comments are currently being pre-moderated (
                 <a href="/community-faqs#311" target="_blank">
                   why?

--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -203,25 +203,6 @@ export const recommend = (commentId: number): Promise<boolean> => {
   }).then(resp => resp.ok);
 };
 
-export const getCommentCount = (
-  shortUrl: string
-): Promise<{ shortUrl: string; numberOfComments: number }> => {
-  const url = joinUrl([
-    options.baseUrl,
-    "discussion",
-    shortUrl,
-    "comments/count"
-  ]);
-
-  return fetch(url, {
-    headers: {
-      ...options.headers
-    }
-  })
-    .then(resp => resp.json())
-    .catch(error => console.error(`Error fetching ${url}`, error));
-};
-
 export const addUserName = (userName: string): Promise<UserNameResponse> => {
   const url = "https://idapi.theguardian.com/user/me";
   return fetch(url, {


### PR DESCRIPTION
## What does this change?
Styles the links shown in the text above the comment form

## Before
![Screenshot 2020-03-30 at 10 40 57](https://user-images.githubusercontent.com/1336821/77898382-f4f8b680-7272-11ea-944d-395babb1ee51.jpg)

## After
![Screenshot 2020-03-30 at 10 40 29](https://user-images.githubusercontent.com/1336821/77898362-eca07b80-7272-11ea-962a-f412fed3290f.jpg)

## Why?
For consistancy

## Link to supporting Trello card
https://trello.com/c/5sUiDIl8/1368-link-format