### PR TITLE
Closed for comments

### DIFF
--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -30,6 +30,7 @@ export const Default = () => (
       shortUrl="p/39f5z"
       baseUrl="https://discussion.theguardian.com/discussion-api"
       pillar="culture"
+      isClosedForComments={false}
       user={aUser}
       additionalHeaders={{
         "D2-X-UID": "testD2Header",
@@ -53,6 +54,7 @@ export const InitialPage = () => (
       initialPage={3}
       baseUrl="https://discussion.theguardian.com/discussion-api"
       pillar="lifestyle"
+      isClosedForComments={false}
       user={aUser}
       additionalHeaders={{
         "D2-X-UID": "testD2Header",
@@ -78,6 +80,7 @@ export const Overrides = () => (
       orderByOverride={"oldest"}
       baseUrl="https://discussion.theguardian.com/discussion-api"
       pillar="opinion"
+      isClosedForComments={false}
       user={aUser}
       additionalHeaders={{
         "D2-X-UID": "testD2Header",
@@ -101,6 +104,7 @@ export const Expanded = () => (
       initialPage={3}
       baseUrl="https://discussion.theguardian.com/discussion-api"
       pillar="sport"
+      isClosedForComments={false}
       user={aUser}
       additionalHeaders={{
         "D2-X-UID": "testD2Header",
@@ -111,3 +115,26 @@ export const Expanded = () => (
   </div>
 );
 Expanded.story = { name: "expanded by default and on page 3" };
+
+export const Closed = () => (
+  <div
+    className={css`
+      width: 100%;
+      max-width: 620px;
+    `}
+  >
+    <App
+      shortUrl="p/39f5z"
+      baseUrl="https://discussion.theguardian.com/discussion-api"
+      pillar="lifestyle"
+      isClosedForComments={true}
+      user={aUser}
+      additionalHeaders={{
+        "D2-X-UID": "testD2Header",
+        "GU-Client": "testClientHeader"
+      }}
+      expanded={true}
+    />
+  </div>
+);
+Closed.story = { name: "closed for comments" };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ type Props = {
   shortUrl: string;
   baseUrl: string;
   pillar: Pillar;
+  isClosedForComments: boolean;
   commentToScrollTo?: number;
   initialPage?: number;
   pageSizeOverride?: PageSizeType;
@@ -149,6 +150,7 @@ export const App = ({
   baseUrl,
   shortUrl,
   pillar,
+  isClosedForComments,
   initialPage,
   commentToScrollTo,
   pageSizeOverride,
@@ -295,7 +297,7 @@ export const App = ({
   if (!isExpanded) {
     return (
       <div className={commentContainerStyles}>
-        {user && (
+        {user && !isClosedForComments && (
           <CommentForm
             shortUrl={shortUrl}
             onAddComment={onAddComment}
@@ -326,6 +328,7 @@ export const App = ({
                       baseUrl={baseUrl}
                       comment={comment}
                       pillar={pillar}
+                      isClosedForComments={isClosedForComments}
                       shortUrl={shortUrl}
                       onAddComment={onAddComment}
                       user={user}
@@ -364,7 +367,7 @@ export const App = ({
 
   return (
     <div className={containerStyles}>
-      {user && (
+      {user && !isClosedForComments && (
         <CommentForm
           shortUrl={shortUrl}
           onAddComment={onAddComment}
@@ -403,6 +406,7 @@ export const App = ({
                 baseUrl={baseUrl}
                 comment={comment}
                 pillar={pillar}
+                isClosedForComments={isClosedForComments}
                 shortUrl={shortUrl}
                 onAddComment={onAddComment}
                 user={user}

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -20,6 +20,7 @@ type Props = {
   user?: UserProfile;
   comment: CommentType;
   pillar: Pillar;
+  isClosedForComments: boolean;
   setCommentBeingRepliedTo: (commentBeingRepliedTo?: CommentType) => void;
   isReply: boolean;
   wasScrolledTo?: boolean;
@@ -179,6 +180,7 @@ export const Comment = ({
   baseUrl,
   comment,
   pillar,
+  isClosedForComments,
   setCommentBeingRepliedTo,
   user,
   isReply,
@@ -298,18 +300,21 @@ export const Comment = ({
               />
               <div className={spaceBetween}>
                 <div className={commentControls}>
-                  <button
-                    onClick={() => setCommentBeingRepliedTo(comment)}
-                    className={cx(
-                      commentControlsButtonStyles,
-                      removePaddingLeft
-                    )}
-                  >
-                    <div className={flexRowStyles}>
-                      <ReplyArrow />
-                      Reply
-                    </div>
-                  </button>
+                  {/* When commenting is closed, no reply link shows at all */}
+                  {!isClosedForComments && (
+                    <button
+                      onClick={() => setCommentBeingRepliedTo(comment)}
+                      className={cx(
+                        commentControlsButtonStyles,
+                        removePaddingLeft
+                      )}
+                    >
+                      <div className={flexRowStyles}>
+                        <ReplyArrow />
+                        Reply
+                      </div>
+                    </button>
+                  )}
                   <button className={commentControlsButtonStyles}>Share</button>
                   {/* Only staff can pick, and they cannot pick thier own comment */}
                   {user &&

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -14,6 +14,7 @@ type Props = {
   baseUrl: string;
   comment: CommentType;
   pillar: Pillar;
+  isClosedForComments: boolean;
   shortUrl: string;
   user?: UserProfile;
   onAddComment: (commentId: number, body: string, user: UserProfile) => void;
@@ -98,6 +99,7 @@ export const CommentContainer = ({
   baseUrl,
   comment,
   pillar,
+  isClosedForComments,
   onAddComment,
   user,
   shortUrl,
@@ -142,6 +144,7 @@ export const CommentContainer = ({
         baseUrl={baseUrl}
         comment={comment}
         pillar={pillar}
+        isClosedForComments={isClosedForComments}
         setCommentBeingRepliedTo={setCommentBeingRepliedTo}
         user={user}
         isReply={false}
@@ -157,6 +160,7 @@ export const CommentContainer = ({
                     baseUrl={baseUrl}
                     comment={responseComment}
                     pillar={pillar}
+                    isClosedForComments={isClosedForComments}
                     setCommentBeingRepliedTo={setCommentBeingRepliedTo}
                     user={user}
                     isReply={true}


### PR DESCRIPTION
## What does this change?
Respects the property `isClosedForComments`. Hides the comment form and reply button when a discussion is closed.

## Why?
Because you have to know when to stop

## Link to supporting Trello card
https://trello.com/c/UYOqDFtZ/1230-sometimes-a-discussion-is-closed-for-comments