### PR TITLE
Type safety to fixtures

### DIFF
--- a/src/fixtures/comment.ts
+++ b/src/fixtures/comment.ts
@@ -1,4 +1,6 @@
-export const comment = {
+import { CommentType } from "../types";
+
+export const comment: CommentType = {
   id: 138809272,
   body:
     "<p>Begone ye self-serving Tory isolationists.</p> <p>Never has there been a more significant time for Big Government and public health provision. Nature has spoken.</p>",
@@ -20,17 +22,6 @@ export const comment = {
     secureAvatarUrl: "https://avatar.guim.co.uk/user/13239086",
     badge: []
   },
-  discussion: {
-    key: "/p/ddp96",
-    webUrl:
-      "https://www.theguardian.com/commentisfree/2020/mar/09/coronavirus-outbreak-nhs-staff-shortages",
-    apiUrl:
-      "https://discussion.guardianapis.com/discussion-api/discussion//p/ddp96",
-    title:
-      "Even a starved NHS is still our best defence against the coronavirus",
-    isClosedForComments: true,
-    isClosedForRecommendation: true
-  },
   responses: [
     {
       id: 138809396,
@@ -50,7 +41,7 @@ export const comment = {
           "https://discussion.guardianapis.com/discussion-api/comment/138809272",
         isoDateTime: "2020-03-09T19:09:28Z",
         date: "09 March 2020 7:09pm",
-        commentId: "138809272",
+        commentId: 138809272,
         commentWebUrl:
           "https://discussion.theguardian.com/comment-permalink/138809272"
       },
@@ -83,7 +74,7 @@ export const comment = {
           "https://discussion.guardianapis.com/discussion-api/comment/138809272",
         isoDateTime: "2020-03-09T19:09:28Z",
         date: "09 March 2020 7:09pm",
-        commentId: "138809272",
+        commentId: 138809272,
         commentWebUrl:
           "https://discussion.theguardian.com/comment-permalink/138809272"
       },
@@ -115,7 +106,7 @@ export const comment = {
           "https://discussion.guardianapis.com/discussion-api/comment/138809272",
         isoDateTime: "2020-03-09T19:09:28Z",
         date: "09 March 2020 7:09pm",
-        commentId: "138809272",
+        commentId: 138809272,
         commentWebUrl:
           "https://discussion.theguardian.com/comment-permalink/138809272"
       },
@@ -148,7 +139,7 @@ export const comment = {
           "https://discussion.guardianapis.com/discussion-api/comment/138809487",
         isoDateTime: "2020-03-09T19:24:46Z",
         date: "09 March 2020 7:24pm",
-        commentId: "138809487",
+        commentId: 138809487,
         commentWebUrl:
           "https://discussion.theguardian.com/comment-permalink/138809487"
       },

--- a/src/fixtures/discussion.ts
+++ b/src/fixtures/discussion.ts
@@ -1,4 +1,6 @@
-export const discussion = {
+import { DiscussionResponse } from "../types";
+
+export const discussion: DiscussionResponse = {
   status: "ok",
   currentPage: 1,
   pages: 4,
@@ -61,7 +63,7 @@ export const discussion = {
                 "https://discussion.guardianapis.com/discussion-api/comment/138809269",
               isoDateTime: "2020-03-09T19:09:11Z",
               date: "09 March 2020 7:09pm",
-              commentId: "138809269",
+              commentId: 138809269,
               commentWebUrl:
                 "https://discussion.theguardian.com/comment-permalink/138809269"
             },
@@ -95,7 +97,7 @@ export const discussion = {
                 "https://discussion.guardianapis.com/discussion-api/comment/138809269",
               isoDateTime: "2020-03-09T19:09:11Z",
               date: "09 March 2020 7:09pm",
-              commentId: "138809269",
+              commentId: 138809269,
               commentWebUrl:
                 "https://discussion.theguardian.com/comment-permalink/138809269"
             },
@@ -129,7 +131,7 @@ export const discussion = {
                 "https://discussion.guardianapis.com/discussion-api/comment/138809269",
               isoDateTime: "2020-03-09T19:09:11Z",
               date: "09 March 2020 7:09pm",
-              commentId: "138809269",
+              commentId: 138809269,
               commentWebUrl:
                 "https://discussion.theguardian.com/comment-permalink/138809269"
             },
@@ -163,7 +165,7 @@ export const discussion = {
                 "https://discussion.guardianapis.com/discussion-api/comment/138809269",
               isoDateTime: "2020-03-09T19:09:11Z",
               date: "09 March 2020 7:09pm",
-              commentId: "138809269",
+              commentId: 138809269,
               commentWebUrl:
                 "https://discussion.theguardian.com/comment-permalink/138809269"
             },
@@ -230,7 +232,7 @@ export const discussion = {
                 "https://discussion.guardianapis.com/discussion-api/comment/138809272",
               isoDateTime: "2020-03-09T19:09:28Z",
               date: "09 March 2020 7:09pm",
-              commentId: "138809272",
+              commentId: 138809272,
               commentWebUrl:
                 "https://discussion.theguardian.com/comment-permalink/138809272"
             },
@@ -264,7 +266,7 @@ export const discussion = {
                 "https://discussion.guardianapis.com/discussion-api/comment/138809272",
               isoDateTime: "2020-03-09T19:09:28Z",
               date: "09 March 2020 7:09pm",
-              commentId: "138809272",
+              commentId: 138809272,
               commentWebUrl:
                 "https://discussion.theguardian.com/comment-permalink/138809272"
             },
@@ -353,7 +355,7 @@ export const discussion = {
                 "https://discussion.guardianapis.com/discussion-api/comment/138811091",
               isoDateTime: "2020-03-09T20:54:08Z",
               date: "09 March 2020 8:54pm",
-              commentId: "138811091",
+              commentId: 138811091,
               commentWebUrl:
                 "https://discussion.theguardian.com/comment-permalink/138811091"
             },

--- a/src/lib/mockFetchCalls.js
+++ b/src/lib/mockFetchCalls.js
@@ -1,7 +1,7 @@
 import fetchMock from "fetch-mock";
 
-import { discussion } from "../../fixtures/discussion";
-import { comment } from "../../fixtures/comment";
+import { discussion } from "../fixtures/discussion.ts";
+import { comment } from "../fixtures/comment";
 
 export const mockFetchCalls = () => {
   fetchMock

--- a/src/lib/mockFetchCalls.ts
+++ b/src/lib/mockFetchCalls.ts
@@ -1,6 +1,6 @@
 import fetchMock from "fetch-mock";
 
-import { discussion } from "../fixtures/discussion.ts";
+import { discussion } from "../fixtures/discussion";
 import { comment } from "../fixtures/comment";
 
 export const mockFetchCalls = () => {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -119,7 +119,7 @@ export interface UserProfile {
 
 export interface DiscussionResponse {
   status: string;
-  page: number;
+  currentPage: number;
   pages: number;
   pageSize: number;
   orderBy: string;


### PR DESCRIPTION
## What does this change?
Move fixtures into `src/`

## Why?
Add type safety to fixtures

