### PR TITLE
Refactor placeholder styling

### DIFF
--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -65,21 +65,25 @@ const greyPlaceholder = css`
 const blackPlaceholder = css`
   ::-webkit-input-placeholder {
     font-weight: bold;
+    opacity: 1;
     color: ${neutral[0]};
   }
 
   ::-moz-placeholder {
     font-weight: bold;
+    opacity: 1;
     color: ${neutral[0]};
   }
 
   ::-ms-placeholder {
     font-weight: bold;
+    opacity: 1;
     color: ${neutral[0]};
   }
 
   ::placeholder {
     font-weight: bold;
+    opacity: 1;
     color: ${neutral[0]};
   }
 `;

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -43,15 +43,44 @@ const commentTextArea = css`
   }
 `;
 
-const placeholderCommentStyles = css`
+// https://stackoverflow.com/questions/9451902/changing-an-inputs-html5-placeholder-color-with-css-does-not-work-on-chrome
+const greyPlaceholder = css`
+  ::-webkit-input-placeholder {
+    color: ${neutral[46]};
+  }
+
+  ::-moz-placeholder {
+    color: ${neutral[46]};
+  }
+
+  ::-ms-placeholder {
+    color: ${neutral[46]};
+  }
+
   ::placeholder {
-    font-weight: bold;
-    color: black;
+    color: ${neutral[46]};
   }
 `;
-const placeholderReplyStyles = css`
+
+const blackPlaceholder = css`
+  ::-webkit-input-placeholder {
+    font-weight: bold;
+    color: ${neutral[0]};
+  }
+
+  ::-moz-placeholder {
+    font-weight: bold;
+    color: ${neutral[0]};
+  }
+
+  ::-ms-placeholder {
+    font-weight: bold;
+    color: ${neutral[0]};
+  }
+
   ::placeholder {
-    color: grey;
+    font-weight: bold;
+    color: ${neutral[0]};
   }
 `;
 
@@ -383,12 +412,13 @@ export const CommentForm = ({
           </div>
         )}
         <textarea
-          placeholder={"Join the discussion"}
+          placeholder={
+            commentBeingRepliedTo || !isActive ? "Join the discussion" : ""
+          }
           className={cx(
             commentTextArea,
-            commentBeingRepliedTo
-              ? placeholderReplyStyles
-              : placeholderCommentStyles
+            commentBeingRepliedTo && isActive && greyPlaceholder,
+            !commentBeingRepliedTo && !isActive && blackPlaceholder
           )}
           ref={textAreaRef}
           style={{ height: isActive ? "132px" : "50px" }}

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -43,44 +43,14 @@ const commentTextArea = css`
   }
 `;
 
-// https://stackoverflow.com/questions/9451902/changing-an-inputs-html5-placeholder-color-with-css-does-not-work-on-chrome
 const greyPlaceholder = css`
-  ::-webkit-input-placeholder {
-    color: ${neutral[46]};
-  }
-
-  ::-moz-placeholder {
-    color: ${neutral[46]};
-  }
-
-  ::-ms-placeholder {
-    color: ${neutral[46]};
-  }
-
   ::placeholder {
     color: ${neutral[46]};
   }
 `;
 
+// Opacity? See: https://stackoverflow.com/questions/19621306/css-placeholder-text-color-on-firefox
 const blackPlaceholder = css`
-  ::-webkit-input-placeholder {
-    font-weight: bold;
-    opacity: 1;
-    color: ${neutral[0]};
-  }
-
-  ::-moz-placeholder {
-    font-weight: bold;
-    opacity: 1;
-    color: ${neutral[0]};
-  }
-
-  ::-ms-placeholder {
-    font-weight: bold;
-    opacity: 1;
-    color: ${neutral[0]};
-  }
-
   ::placeholder {
     font-weight: bold;
     opacity: 1;


### PR DESCRIPTION
## What does this change?
This fixes a problem where the placeholder font was coloured incorrectly cross browser. It also refacotrs how we set placeholder foprmatting in general.

There are 3 states the placeholder text can be in:

### Reader is replying, form open
![Screenshot 2020-03-31 at 11 52 51](https://user-images.githubusercontent.com/1336821/78018667-360dcb00-7346-11ea-9061-fc67ef73b53d.jpg)

### Reader is not replying, form open
![Screenshot 2020-03-31 at 11 50 33](https://user-images.githubusercontent.com/1336821/78018483-dc0d0580-7345-11ea-98cf-a8710c12f709.jpg)

### Reader is not replying, form closed
![Screenshot 2020-03-31 at 11 50 23](https://user-images.githubusercontent.com/1336821/78018485-e0392300-7345-11ea-8c6c-575058291141.jpg)

## Why?
To communicate well to the user what the form is for

## Link to supporting Trello card
https://trello.com/c/ZekHLd7m/1367-chrome-placeholder-colour