### PR TITLE
Remove margin replies

### DIFF
--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -72,6 +72,10 @@ const selectedStyles = css`
   padding-right: ${space[2]}px;
 `;
 
+const removeMargin = css`
+  margin: 0px;
+`;
+
 export const avatar = (avatarSize: number): string => css`
   border-radius: ${avatarSize + 10}px;
   width: ${avatarSize}px;
@@ -153,7 +157,7 @@ export const CommentContainer = ({
       <>
         {showResponses && responses && (
           <div className={nestingStyles}>
-            <ul className={commentContainerStyles}>
+            <ul className={cx(commentContainerStyles, removeMargin)}>
               {responses.map(responseComment => (
                 <li key={responseComment.id}>
                   <Comment


### PR DESCRIPTION
## What does this change?
Removes the margin styles from `<ul>` wrapper for replies

## Why?
They add unnecessary margin spacing between comment and replies

## Before
<img width="554" alt="Screenshot 2020-03-31 at 16 36 26" src="https://user-images.githubusercontent.com/8831403/78045663-21452d80-736e-11ea-9fac-767707b89c02.png">

## After
<img width="663" alt="Screenshot 2020-03-31 at 16 36 12" src="https://user-images.githubusercontent.com/8831403/78045676-25714b00-736e-11ea-9e88-aeb049450993.png">
