### PR TITLE
Use jest for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "rollup --config && yarn createTsDec",
-    "test": "react-scripts test",
+    "test": "jest",
     "tsc": "tsc --project tsconfig.project.json",
     "eject": "react-scripts eject",
     "storybook": "start-storybook",


### PR DESCRIPTION
## What does this change?
Use `jest` instead of `react-scripts` 

## Why?
using `react-scripts test` causes the auto generation of `tsconfig.json` if that file is not found. We use `tsconfig.module.json` and `tsconfig.base.json` and do not want to use `tsconfig.json`
