### PR TITLE
Move marging spacing to p tag

### DIFF
--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -55,11 +55,9 @@ const commentCss = css`
   display: block;
   clear: left;
   ${textSans.small()}
-  margin-top: 0.375rem;
-  margin-bottom: 0.5rem;
 
   p {
-    margin-top: 0;
+    margin-top: ${space[2]}px;
     margin-bottom: ${space[3]}px;
   }
 `;


### PR DESCRIPTION
## What does this change?
Move the margin spacing out of div wrapper and into p tag

## Why?
simplify margin spacing into a simple source
