### PR TITLE
Reverse workflow names

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,8 +1,8 @@
-name: 👓
+name: chromatic
 on: push
 
 jobs:
-  chromatic:
+  👓:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,8 +1,8 @@
-name: 🤔
+name: jest
 on: [push]
 
 jobs:
-  jest:
+  🤔:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,8 @@
-name: 🔎
+name: lint
 on: [push]
 
 jobs:
-  lint:
+  🔎:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -1,8 +1,8 @@
-name: 🕵‍♀
+name: typescript
 on: [push]
 
 jobs:
-  typescript:
+  🕵‍♀:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## What does this change?
Swaps the workflow and job names around

## Why?
because the workflow name is often used by itself in emails and in other lists and emojis are cute and everything but text is more useful

## Link to supporting Trello card
https://trello.com/c/QN9W8Rh1/1386-reverse-workflow-names