### PR TITLE
Comment mobile layout v4

### DIFF
--- a/src/components/Comment/Comment.stories.tsx
+++ b/src/components/Comment/Comment.stories.tsx
@@ -94,6 +94,24 @@ export const Default = () => (
 );
 Default.story = { name: "Default" };
 
+export const MobileDefault = () => (
+  <Comment
+    baseUrl="https://discussion.theguardian.com/discussion-api"
+    comment={commentData}
+    pillar={"sport"}
+    setCommentBeingRepliedTo={() => {}}
+    isReply={false}
+    isClosedForComments={false}
+  />
+);
+MobileDefault.story = {
+  name: "Mobile Default",
+  parameters: {
+    viewport: { defaultViewport: "mobileMedium" },
+    chromatic: { viewports: [375] }
+  }
+};
+
 export const ReplyComment = () => (
   <Comment
     baseUrl="https://discussion.theguardian.com/discussion-api"
@@ -105,6 +123,24 @@ export const ReplyComment = () => (
   />
 );
 ReplyComment.story = { name: "Reply Default" };
+
+export const MobileReply = () => (
+  <Comment
+    baseUrl="https://discussion.theguardian.com/discussion-api"
+    comment={replyCommentData}
+    pillar={"sport"}
+    setCommentBeingRepliedTo={() => {}}
+    isReply={true}
+    isClosedForComments={false}
+  />
+);
+MobileReply.story = {
+  name: "Mobile Reply",
+  parameters: {
+    viewport: { defaultViewport: "mobileMedium" },
+    chromatic: { viewports: [375] }
+  }
+};
 
 export const PickedComment = () => (
   <Comment

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -155,12 +155,16 @@ const iconWrapper = css`
   white-space: nowrap;
 `;
 
-const timestampWrapperStyles = css`
+const defaultTimestampWrapperStyles = css`
   margin-left: ${space[2]}px;
   margin-bottom: -2px;
   display: flex;
   flex-direction: column;
   justify-content: center;
+`;
+
+const mobileTimestampWrapperStyles = css`
+  margin-bottom: -2px;
 `;
 
 const linkStyles = (pillar: Pillar) => css`
@@ -311,7 +315,7 @@ export const Comment = ({
                   ) : (
                     <></>
                   )}
-                  <div className={timestampWrapperStyles}>
+                  <div className={defaultTimestampWrapperStyles}>
                     <Timestamp
                       isoDateTime={comment.isoDateTime}
                       linkTo={joinUrl([
@@ -446,7 +450,7 @@ export const Comment = ({
                   {comment.userProfile.displayName}
                 </Link>
               </div>
-              <div className={timestampWrapperStyles}>
+              <div className={mobileTimestampWrapperStyles}>
                 <Timestamp
                   isoDateTime={comment.isoDateTime}
                   linkTo={joinUrl([

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -461,18 +461,22 @@ export const Comment = ({
                 />
               </div>
               <Row>
-                {!!comment.userProfile.badge.filter(
-                  obj => obj["name"] === "Staff"
-                ).length && (
-                  <div className={iconWrapper}>
-                    <GuardianStaff />
-                  </div>
-                )}
-                {comment.status !== "blocked" && isHighlighted && (
-                  <div className={iconWrapper}>
-                    <GuardianPick />
-                  </div>
-                )}
+                <>
+                  {!!comment.userProfile.badge.filter(
+                    obj => obj["name"] === "Staff"
+                  ).length && (
+                    <div className={iconWrapper}>
+                      <GuardianStaff />
+                    </div>
+                  )}
+                </>
+                <>
+                  {comment.status !== "blocked" && isHighlighted && (
+                    <div className={iconWrapper}>
+                      <GuardianPick />
+                    </div>
+                  )}
+                </>
               </Row>
             </Column>
             <>


### PR DESCRIPTION
## What does this change?
On mobile width now the image will appear as part of the comment header row rather than in its own column

## Why?
Parity with frontend

## Before
![Screenshot 2020-03-25 at 14 36 25](https://user-images.githubusercontent.com/8831403/77548156-0e31e980-6ea6-11ea-9bf8-937972bc073f.png)

![Screenshot 2020-03-25 at 14 36 12](https://user-images.githubusercontent.com/8831403/77548165-12f69d80-6ea6-11ea-81f1-27a925c84433.png)

## After
![Screenshot 2020-03-25 at 14 34 01](https://user-images.githubusercontent.com/8831403/77548197-1ab64200-6ea6-11ea-8a61-9c19c204bbf2.png)


![Screenshot 2020-03-25 at 14 34 23](https://user-images.githubusercontent.com/8831403/77548176-17bb5180-6ea6-11ea-92bb-06673e022197.png)

## Link to supporting Trello card
https://trello.com/c/m6Td7ai3/1332-comment-mobile-layout
