### PR TITLE
Support mobile view

### DIFF
--- a/src/components/Comment/Comment.stories.tsx
+++ b/src/components/Comment/Comment.stories.tsx
@@ -94,6 +94,24 @@ export const Default = () => (
 );
 Default.story = { name: "Default" };
 
+export const MobileDefault = () => (
+  <Comment
+    baseUrl="https://discussion.theguardian.com/discussion-api"
+    comment={commentData}
+    pillar={"sport"}
+    setCommentBeingRepliedTo={() => {}}
+    isReply={false}
+    isClosedForComments={false}
+  />
+);
+MobileDefault.story = {
+  name: "Mobile Default",
+  parameters: {
+    viewport: { defaultViewport: "mobileMedium" },
+    chromatic: { viewports: [375] }
+  }
+};
+
 export const ReplyComment = () => (
   <Comment
     baseUrl="https://discussion.theguardian.com/discussion-api"
@@ -105,6 +123,24 @@ export const ReplyComment = () => (
   />
 );
 ReplyComment.story = { name: "Reply Default" };
+
+export const MobileReply = () => (
+  <Comment
+    baseUrl="https://discussion.theguardian.com/discussion-api"
+    comment={replyCommentData}
+    pillar={"sport"}
+    setCommentBeingRepliedTo={() => {}}
+    isReply={true}
+    isClosedForComments={false}
+  />
+);
+MobileReply.story = {
+  name: "Mobile Reply",
+  parameters: {
+    viewport: { defaultViewport: "mobileMedium" },
+    chromatic: { viewports: [375] }
+  }
+};
 
 export const PickedComment = () => (
   <Comment

--- a/src/components/Comment/Comment.stories.tsx
+++ b/src/components/Comment/Comment.stories.tsx
@@ -82,7 +82,7 @@ const staffUser: UserProfile = {
   }
 };
 
-export const Default = () => (
+export const Root = () => (
   <Comment
     baseUrl="https://discussion.theguardian.com/discussion-api"
     comment={commentData}
@@ -92,9 +92,15 @@ export const Default = () => (
     isReply={false}
   />
 );
-Default.story = { name: "Default" };
+Root.story = {
+  name: "A root comment on desktop view",
+  parameters: {
+    viewport: { defaultViewport: "desktop" },
+    chromatic: { viewports: [1300] }
+  }
+};
 
-export const MobileDefault = () => (
+export const RootMobile = () => (
   <Comment
     baseUrl="https://discussion.theguardian.com/discussion-api"
     comment={commentData}
@@ -104,8 +110,8 @@ export const MobileDefault = () => (
     isClosedForComments={false}
   />
 );
-MobileDefault.story = {
-  name: "Mobile Default",
+RootMobile.story = {
+  name: "A root comment on mobile view",
   parameters: {
     viewport: { defaultViewport: "mobileMedium" },
     chromatic: { viewports: [375] }
@@ -122,7 +128,13 @@ export const ReplyComment = () => (
     isReply={true}
   />
 );
-ReplyComment.story = { name: "Reply Default" };
+ReplyComment.story = {
+  name: "A reply on desktop view",
+  parameters: {
+    viewport: { defaultViewport: "desktop" },
+    chromatic: { viewports: [1300] }
+  }
+};
 
 export const MobileReply = () => (
   <Comment
@@ -135,7 +147,7 @@ export const MobileReply = () => (
   />
 );
 MobileReply.story = {
-  name: "Mobile Reply",
+  name: "A reply on mobile view",
   parameters: {
     viewport: { defaultViewport: "mobileMedium" },
     chromatic: { viewports: [375] }
@@ -182,7 +194,34 @@ export const PickedStaffUserComment = () => (
     isReply={false}
   />
 );
-PickedStaffUserComment.story = { name: "Picked Staff User Comment" };
+PickedStaffUserComment.story = {
+  name: "with staff and picked badges on desktop",
+  parameters: {
+    viewport: { defaultViewport: "desktop" },
+    chromatic: { viewports: [1300] }
+  }
+};
+
+export const PickedStaffUserCommentMobile = () => (
+  <Comment
+    baseUrl="https://discussion.theguardian.com/discussion-api"
+    comment={{
+      ...commentStaffData,
+      isHighlighted: true
+    }}
+    pillar={"sport"}
+    isClosedForComments={false}
+    setCommentBeingRepliedTo={() => {}}
+    isReply={false}
+  />
+);
+PickedStaffUserCommentMobile.story = {
+  name: "with staff and picked badges on mobile",
+  parameters: {
+    viewport: { defaultViewport: "mobileMedium" },
+    chromatic: { viewports: [375] }
+  }
+};
 
 export const LoggedInAsModerator = () => (
   <Comment

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { css, cx } from "emotion";
 
 import { space, palette } from "@guardian/src-foundations";
+import { from, until } from "@guardian/src-foundations/mq";
 import { neutral, border } from "@guardian/src-foundations/palette";
 import { textSans } from "@guardian/src-foundations/typography";
 import { Link } from "@guardian/src-link";
@@ -96,6 +97,10 @@ const selectedStyles = css`
 
 const avatarMargin = css`
   margin-right: ${space[2]}px;
+
+  ${until.mobileLandscape} {
+    display: none;
+  }
 `;
 
 const colourStyles = (pillar: Pillar) => css`
@@ -161,6 +166,23 @@ const flexRowStyles = css`
 
 const removePaddingLeft = css`
   padding-left: 0px;
+`;
+
+const hideBelowMobileLandscape = css`
+  ${until.mobileLandscape} {
+    display: none;
+  }
+`;
+
+const hideAboveMobileLandscape = css`
+  ${from.mobileLandscape} {
+    display: none;
+  }
+`;
+
+const negativeMargin = css`
+  margin-top: 0px;
+  margin-bottom: -6px;
 `;
 
 const Column = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
@@ -233,6 +255,12 @@ export const Comment = ({
     }
   };
 
+  const showStaffbadge = comment.userProfile.badge.find(
+    obj => obj["name"] === "Staff"
+  );
+
+  const showPickBadge = comment.status !== "blocked" && isHighlighted;
+
   return (
     <>
       {error && (
@@ -248,7 +276,7 @@ export const Comment = ({
         id={`comment-${comment.id}`}
         className={cx(commentWrapper, wasScrolledTo && selectedStyles)}
       >
-        <div className={avatarMargin}>
+        <div className={cx(avatarMargin)}>
           <Avatar
             imageUrl={comment.userProfile.avatar}
             displayName={comment.userProfile.displayName}
@@ -259,71 +287,129 @@ export const Comment = ({
         <div className={commentDetails}>
           <header className={headerStyles}>
             <Column>
-              <Row>
-                <div className={cx(colourStyles(pillar), boldFont)}>
-                  <Link
-                    href={joinUrl([
-                      "https://profile.theguardian.com/user",
-                      comment.userProfile.userId
-                    ])}
-                    subdued={true}
-                  >
-                    {comment.userProfile.displayName}
-                  </Link>
-                </div>
-                {comment.responseTo ? (
+              <div
+                className={cx(
+                  comment.responseTo && hideBelowMobileLandscape,
+                  hideAboveMobileLandscape
+                )}
+              >
+                <Row>
                   <div
-                    className={cx(
-                      colourStyles(pillar),
-                      regularFont,
-                      svgOverrides
-                    )}
+                    className={css`
+                      margin-right: ${space[2]}px;
+                    `}
                   >
-                    <Link
-                      href={`#comment-${comment.responseTo.commentId}`}
-                      subdued={true}
-                      icon={<ReplyArrow />}
-                      iconSide="left"
+                    <Avatar
+                      imageUrl={comment.userProfile.avatar}
+                      displayName={""}
+                      size="small"
+                    />
+                  </div>
+                  <Column>
+                    <div
+                      className={cx(
+                        colourStyles(pillar),
+                        boldFont,
+                        negativeMargin
+                      )}
                     >
-                      {comment.responseTo.displayName}
+                      <Link
+                        href={joinUrl([
+                          "https://profile.theguardian.com/user",
+                          comment.userProfile.userId
+                        ])}
+                        subdued={true}
+                      >
+                        {comment.userProfile.displayName}
+                      </Link>
+                    </div>
+                    <Timestamp
+                      isoDateTime={comment.isoDateTime}
+                      linkTo={joinUrl([
+                        // Remove the discussion-api path from the baseUrl
+                        baseUrl
+                          .split("/")
+                          .filter(path => path !== "discussion-api")
+                          .join("/"),
+                        "comment-permalink",
+                        comment.id.toString()
+                      ])}
+                    />
+                  </Column>
+                </Row>
+              </div>
+              <div
+                className={cx(!comment.responseTo && hideBelowMobileLandscape)}
+              >
+                <Row>
+                  <div className={cx(colourStyles(pillar), boldFont)}>
+                    <Link
+                      href={joinUrl([
+                        "https://profile.theguardian.com/user",
+                        comment.userProfile.userId
+                      ])}
+                      subdued={true}
+                    >
+                      {comment.userProfile.displayName}
                     </Link>
                   </div>
-                ) : (
-                  <></>
-                )}
-                <div className={timestampWrapperStyles}>
-                  <Timestamp
-                    isoDateTime={comment.isoDateTime}
-                    linkTo={joinUrl([
-                      // Remove the discussion-api path from the baseUrl
-                      baseUrl
-                        .split("/")
-                        .filter(path => path !== "discussion-api")
-                        .join("/"),
-                      "comment-permalink",
-                      comment.id.toString()
-                    ])}
-                  />
-                </div>
-              </Row>
-              <Row>
-                {!!comment.userProfile.badge.filter(
-                  obj => obj["name"] === "Staff"
-                ).length ? (
-                  <div className={iconWrapper}>
-                    <GuardianStaff />
+                  {comment.responseTo ? (
+                    <div
+                      className={cx(
+                        colourStyles(pillar),
+                        regularFont,
+                        svgOverrides
+                      )}
+                    >
+                      <Link
+                        href={`#comment-${comment.responseTo.commentId}`}
+                        subdued={true}
+                        icon={<ReplyArrow />}
+                        iconSide="left"
+                      >
+                        {comment.responseTo.displayName}
+                      </Link>
+                    </div>
+                  ) : (
+                    <></>
+                  )}
+                  <div
+                    className={cx(
+                      timestampWrapperStyles,
+                      comment.responseTo && hideBelowMobileLandscape
+                    )}
+                  >
+                    <Timestamp
+                      isoDateTime={comment.isoDateTime}
+                      linkTo={joinUrl([
+                        // Remove the discussion-api path from the baseUrl
+                        baseUrl
+                          .split("/")
+                          .filter(path => path !== "discussion-api")
+                          .join("/"),
+                        "comment-permalink",
+                        comment.id.toString()
+                      ])}
+                    />
                   </div>
-                ) : (
-                  <></>
-                )}
-                {comment.status !== "blocked" && isHighlighted ? (
-                  <div className={iconWrapper}>
-                    <GuardianPick />
-                  </div>
-                ) : (
-                  <></>
-                )}
-              </Row>
+                </Row>
+                <Row>
+                  {showStaffbadge ? (
+                    <div className={iconWrapper}>
+                      <GuardianStaff />
+                    </div>
+                  ) : (
+                    <></>
+                  )}
+                  {showPickBadge ? (
+                    <div className={iconWrapper}>
+                      <GuardianPick />
+                    </div>
+                  ) : (
+                    <></>
+                  )}
+                </Row>
+              </div>
             </Column>
             {comment.status !== "blocked" && (
               <RecommendationCount
@@ -333,6 +419,29 @@ export const Comment = ({
               />
             )}
           </header>
+          <div
+            className={cx(
+              comment.responseTo && hideBelowMobileLandscape,
+              hideAboveMobileLandscape
+            )}
+          >
+            <Row>
+              {showStaffbadge ? (
+                <div className={iconWrapper}>
+                  <GuardianStaff />
+                </div>
+              ) : (
+                <></>
+              )}
+              {showPickBadge ? (
+                <div className={iconWrapper}>
+                  <GuardianPick />
+                </div>
+              ) : (
+                <></>
+              )}
+            </Row>
+          </div>
           {comment.status !== "blocked" ? (
             <>
               <div


### PR DESCRIPTION
## What does this change?
Adds support for the mobile layout of comments for both top level and replies

### Before
![Screenshot 2020-04-02 at 11 58 34](https://user-images.githubusercontent.com/1336821/78242176-72256500-74d9-11ea-8aed-e1ba64ba263e.jpg)

### After
![Screenshot 2020-04-02 at 11 57 54](https://user-images.githubusercontent.com/1336821/78242179-75205580-74d9-11ea-97fa-54de92487130.jpg)

## Why?
To support readers on phones

## Link to supporting Trello card
https://trello.com/c/m6Td7ai3/1332-comment-mobile-layout