### PR TITLE
Reply preview styles

### DIFF
--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -204,7 +204,6 @@ export const CommentContainer = ({
             <div className={nestingStyles}>
               <CommentReplyPreview
                 commentBeingRepliedTo={commentBeingRepliedTo}
-                pillar={pillar}
               />
               <CommentForm
                 shortUrl={shortUrl}

--- a/src/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
@@ -1,14 +1,27 @@
 import React from "react";
 
-import { CommentReplyPreview } from "./CommentReplyPreview";
+import { CommentReplyPreview, Preview } from "./CommentReplyPreview";
 import { CommentType } from "../../types";
+import { css } from "emotion";
 
 export default { title: "CommentReplyPreview" };
+
+const singleLineParagraph =
+  "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>";
+
+const singleBlockParagraph =
+  "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec ullamcorper ante. Nunc vitae quam eros. Donec velit turpis, posuere ut cursus sed, tristique non libero. Donec molestie metus nunc, dapibus ultrices est luctus id. Fusce fringilla metus posuere imperdiet lobortis. Proin ut egestas lorem. Etiam scelerisque dolor felis, ac fermentum ex accumsan id. Ut dignissim et orci vel lobortis. Phasellus feugiat dictum varius. Praesent eu dui ante. Duis in tempor libero, et consectetur lacus. Nunc venenatis libero nec aliquam vulputate. Etiam volutpat accumsan enim ut mollis.</p>";
+
+const multiLBlockParagraph = `
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec ullamcorper ante. Nunc vitae quam eros. Donec velit turpis, posuere ut cursus sed, tristique non libero. Donec molestie metus nunc, dapibus ultrices est luctus id. Fusce fringilla metus posuere imperdiet lobortis. Proin ut egestas lorem. Etiam scelerisque dolor felis, ac fermentum ex accumsan id. Ut dignissim et orci vel lobortis. Phasellus feugiat dictum varius. Praesent eu dui ante. Duis in tempor libero, et consectetur lacus. Nunc venenatis libero nec aliquam vulputate. Etiam volutpat accumsan enim ut mollis.</p>
+
+  <p>Ut molestie feugiat ligula, at suscipit est eleifend eget. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Donec faucibus leo eros, faucibus maximus nisi semper sit amet. Nam eu finibus nibh. Quisque venenatis lacus non velit sagittis ultrices. Duis eget elit congue, molestie odio ut, gravida est. Aliquam erat volutpat. Duis feugiat dolor nulla, non elementum lorem finibus id. Duis non nibh justo. Phasellus dapibus pulvinar nulla, vel euismod magna dapibus ut. Vivamus iaculis eros in nisl ultrices fringilla. Cras ex libero, tristique ornare interdum id, porta a mauris. Praesent nulla enim, rhoncus quis lectus sed, viverra sollicitudin mauris.</p>
+`;
 
 const commentBeingRepliedTo: CommentType = {
   id: 25487686,
   body:
-    "Beau Jos pizza in Idaho Springs is a great place for mountain pizza pies. Order one with extra thick crust and drizzle it with honey. Y'all can try the Challenge if you fancy, and sketch on your napkins so your art can join their walls. This was 15 years ago, but I hope it's still there! As for music, anything from Boulder's own Big Head Todd &amp; the Monsters - 'Broken Hearted Savior' is a good start, with 'Bittersweet' a good road track. I'm jealous!!!",
+    "<p>Beau Jos pizza in Idaho Springs is a great place for mountain pizza pies. Order one with extra thick crust and drizzle it with honey. Y'all can try the Challenge if you fancy, and sketch on your napkins so your art can join their walls. This was 15 years ago, but I hope it's still there! As for music, anything from Boulder's own Big Head Todd &amp; the Monsters - 'Broken Hearted Savior' is a good start, with 'Bittersweet' a good road track. I'm jealous!!!<p>",
   date: "26 July 2013 4:13pm",
   isoDateTime: "2013-07-26T15:13:20Z",
   status: "visible",
@@ -36,11 +49,59 @@ const commentBeingRepliedTo: CommentType = {
   }
 };
 
+const padding = css`
+  padding: 15px;
+`;
+
 export const Default = () => (
   <CommentReplyPreview
     commentBeingRepliedTo={commentBeingRepliedTo}
     pillar={"sport"}
   />
 );
-
 Default.story = { name: "default" };
+
+export const SingleLinePreview = () => (
+  <div className={padding}>
+    <Preview
+      commentBeingRepliedTo={{
+        ...commentBeingRepliedTo,
+        body: singleLineParagraph
+      }}
+      pillar={"sport"}
+      setDisplayReplyComment={() => {}}
+      displayReplyComment={true}
+    />
+  </div>
+);
+SingleLinePreview.story = { name: "Single line" };
+
+export const SingleBlockPreview = () => (
+  <div className={padding}>
+    <Preview
+      commentBeingRepliedTo={{
+        ...commentBeingRepliedTo,
+        body: singleBlockParagraph
+      }}
+      pillar={"sport"}
+      setDisplayReplyComment={() => {}}
+      displayReplyComment={true}
+    />
+  </div>
+);
+SingleBlockPreview.story = { name: "Single Block" };
+
+export const MultiBlockPreview = () => (
+  <div className={padding}>
+    <Preview
+      commentBeingRepliedTo={{
+        ...commentBeingRepliedTo,
+        body: multiLBlockParagraph
+      }}
+      pillar={"sport"}
+      setDisplayReplyComment={() => {}}
+      displayReplyComment={true}
+    />
+  </div>
+);
+MultiBlockPreview.story = { name: "Multi Block" };

--- a/src/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
@@ -92,7 +92,6 @@ export const MultiBlockPreview = () => (
         ...commentBeingRepliedTo,
         body: multiLBlockParagraph
       }}
-      pillar={"sport"}
       setDisplayReplyComment={() => {}}
       displayReplyComment={true}
     />

--- a/src/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
@@ -20,8 +20,7 @@ const multiLBlockParagraph = `
 
 const commentBeingRepliedTo: CommentType = {
   id: 25487686,
-  body:
-    "<p>Beau Jos pizza in Idaho Springs is a great place for mountain pizza pies. Order one with extra thick crust and drizzle it with honey. Y'all can try the Challenge if you fancy, and sketch on your napkins so your art can join their walls. This was 15 years ago, but I hope it's still there! As for music, anything from Boulder's own Big Head Todd &amp; the Monsters - 'Broken Hearted Savior' is a good start, with 'Bittersweet' a good road track. I'm jealous!!!<p>",
+  body: multiLBlockParagraph,
   date: "26 July 2013 4:13pm",
   isoDateTime: "2013-07-26T15:13:20Z",
   status: "visible",

--- a/src/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
@@ -53,10 +53,7 @@ const padding = css`
 `;
 
 export const Default = () => (
-  <CommentReplyPreview
-    commentBeingRepliedTo={commentBeingRepliedTo}
-    pillar={"sport"}
-  />
+  <CommentReplyPreview commentBeingRepliedTo={commentBeingRepliedTo} />
 );
 Default.story = { name: "default" };
 
@@ -67,7 +64,6 @@ export const SingleLinePreview = () => (
         ...commentBeingRepliedTo,
         body: singleLineParagraph
       }}
-      pillar={"sport"}
       setDisplayReplyComment={() => {}}
       displayReplyComment={true}
     />
@@ -82,7 +78,6 @@ export const SingleBlockPreview = () => (
         ...commentBeingRepliedTo,
         body: singleBlockParagraph
       }}
-      pillar={"sport"}
       setDisplayReplyComment={() => {}}
       displayReplyComment={true}
     />

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -14,13 +14,17 @@ const commentControlsButton = (pillar: Pillar) => css`
 `;
 
 const replyWrapperStyles = css`
+  padding-top: 5px;
+  padding-bottom: 5px;
   display: flex;
   flex-direction: row;
-  padding: 5px;
+  align-items: center;
 `;
 const replyArrowStyles = css`
   fill: grey;
-  padding: 5px;
+  padding-top: 2px; /* TODO: find a better solution */
+  padding-left: 5px;
+  padding-right: 5px;
 `;
 
 const replyDisplayNameStyles = css`
@@ -67,8 +71,6 @@ const commentStyles = css`
 `;
 
 const hideCommentButtonStyles = css`
-  padding-top: 5px;
-  padding-bottom: 5px;
   ${textSans.xsmall()};
   :hover {
     cursor: pointer;

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -23,13 +23,13 @@ const replyWrapperStyles = css`
 const replyArrowStyles = css`
   fill: grey;
   padding-top: 2px; /* TODO: find a better solution */
-  padding-left: 5px;
-  padding-right: 5px;
 `;
 
 const replyDisplayNameStyles = css`
   ${textSans.small()};
-  padding: 5px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  padding-right: 5px;
   margin-right: 10px;
 `;
 

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -59,7 +59,7 @@ const previewStyle = css`
   :before {
     content: "";
     position: absolute;
-    border-left: ${arrowSize}px solid #ededed;
+    border-left: ${arrowSize}px solid ${bg};
     border-top: ${arrowSize}px solid transparent;
     top: -${arrowSize - 1}px;
     margin-left: 60px;

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -7,7 +7,7 @@ import { neutral, space, palette } from "@guardian/src-foundations";
 import { Pillar, CommentType } from "../../types";
 
 const commentControlsButton = (pillar: Pillar) => css`
-  ${textSans.xsmall()};
+  ${textSans.small()};
   margin-right: ${space[2]}px;
   color: ${palette[pillar][400]};
   border: 0;
@@ -71,7 +71,6 @@ const commentStyles = css`
 `;
 
 const hideCommentButtonStyles = css`
-  ${textSans.xsmall()};
   :hover {
     cursor: pointer;
   }

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -14,8 +14,8 @@ const commentControlsButton = (pillar: Pillar) => css`
 `;
 
 const replyWrapperStyles = css`
-  padding-top: 5px;
-  padding-bottom: 5px;
+  padding-top: ${space[1]}px;
+  padding-bottom: ${space[1]}px;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -31,10 +31,10 @@ const replyArrowStyles = css`
 
 const replyDisplayNameStyles = css`
   ${textSans.small()};
-  padding-top: 5px;
-  padding-bottom: 5px;
-  padding-right: 5px;
-  margin-right: 10px;
+  padding-top: ${space[1]}px;
+  padding-bottom: ${space[1]}px;
+  padding-right: ${space[1]}px;
+  margin-right: ${space[2]}px;
 `;
 
 const replyPreviewHeaderStyle = css`
@@ -46,10 +46,10 @@ const replyPreviewHeaderStyle = css`
 const arrowSize = 15;
 const bg = neutral[93];
 const previewStyle = css`
-  padding-top: 12px;
-  padding-bottom: 12px;
-  padding-left: 20px;
-  padding-right: 20px;
+  padding-top: ${space[3]}px;
+  padding-bottom: ${space[3]}px;
+  padding-left: ${space[5]}px;
+  padding-right: ${space[5]}px;
   background-color: ${bg};
   margin-top: ${arrowSize}px;
   margin-bottom: ${arrowSize + 5}px;

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -40,7 +40,7 @@ const replyDisplayNameStyles = css`
 const replyPreviewHeaderStyle = css`
   ${textSans.small({ fontWeight: "bold" })};
   margin-top: 0px;
-  margin-bottom: 6px;
+  margin-bottom: ${space[2]}px;
 `;
 
 const arrowSize = 15;
@@ -62,7 +62,7 @@ const previewStyle = css`
     border-left: ${arrowSize}px solid ${bg};
     border-top: ${arrowSize}px solid transparent;
     top: -${arrowSize - 1}px;
-    margin-left: 60px;
+    margin-left: ${space[9]}px;
   }
 `;
 

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -146,7 +146,7 @@ export const Preview = ({
         }}
       />
       <div>
-        <span
+        <button
           className={cx(
             hideCommentButtonStyles,
             commentControlsButtonStyles,
@@ -155,7 +155,7 @@ export const Preview = ({
           onClick={() => setDisplayReplyComment(!displayReplyComment)}
         >
           {displayReplyComment ? "Hide Comment" : "Show comment"}
-        </span>
+        </button>
       </div>
     </div>
   );

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -47,7 +47,7 @@ const previewStyle = css`
   padding-left: 20px;
   padding-right: 20px;
   background-color: ${bg};
-  margin-top: 6px;
+  margin-top: ${arrowSize}px;
   margin-bottom: ${arrowSize + 5}px;
   position: relative;
   display: flex;

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -23,8 +23,8 @@ const replyWrapperStyles = css`
 const replyArrowStyles = css`
   fill: grey;
   /*
-    In order to get teh arrow SVG alinged correctly with the text reply text
-    we need to add 2px padding
+    In order to get the arrow SVG alinged correctly with the reply text
+    we need to add 2px padding to the top
   */
   padding-top: 2px;
 `;

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -7,7 +7,7 @@ import { neutral, space, palette } from "@guardian/src-foundations";
 import { Pillar, CommentType } from "../../types";
 
 const commentControlsButton = (pillar: Pillar) => css`
-  font-weight: bold;
+  ${textSans.xsmall()};
   margin-right: ${space[2]}px;
   color: ${palette[pillar][400]};
   border: 0;
@@ -30,9 +30,9 @@ const replyDisplayNameStyles = css`
 `;
 
 const replyPreviewHeaderStyle = css`
+  ${textSans.small({ fontWeight: "bold" })};
   margin-top: 0px;
   margin-bottom: 6px;
-  font-weight: bold;
 `;
 
 const arrowSize = 15;
@@ -60,6 +60,7 @@ const previewStyle = css`
 
 const commentStyles = css`
   p {
+    ${textSans.small()};
     margin-top: 0px;
     margin-bottom: ${space[3]}px;
   }

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -2,14 +2,14 @@ import React, { useState } from "react";
 import { css, cx } from "emotion";
 
 import { textSans } from "@guardian/src-foundations/typography";
-import { neutral, space, palette } from "@guardian/src-foundations";
+import { neutral, space, brand } from "@guardian/src-foundations";
 
-import { Pillar, CommentType } from "../../types";
+import { CommentType } from "../../types";
 
-const commentControlsButton = (pillar: Pillar) => css`
+const commentControlsButtonStyles = css`
   ${textSans.small()};
   margin-right: ${space[2]}px;
-  color: ${palette[pillar][400]};
+  color: ${brand[500]};
   border: 0;
 `;
 
@@ -90,13 +90,10 @@ const ReplyArrow = () => (
 );
 
 export const CommentReplyPreview = ({
-  commentBeingRepliedTo,
-  pillar
+  commentBeingRepliedTo
 }: {
   commentBeingRepliedTo: CommentType;
-  pillar: Pillar;
 }) => {
-  const commentControlsButtonStyles = commentControlsButton(pillar);
   const [displayReplyComment, setDisplayReplyComment] = useState<boolean>(
     false
   );
@@ -118,7 +115,6 @@ export const CommentReplyPreview = ({
       </div>
       {displayReplyComment && (
         <Preview
-          pillar={pillar}
           commentBeingRepliedTo={commentBeingRepliedTo}
           setDisplayReplyComment={setDisplayReplyComment}
           displayReplyComment={displayReplyComment}
@@ -130,16 +126,13 @@ export const CommentReplyPreview = ({
 
 export const Preview = ({
   commentBeingRepliedTo,
-  pillar,
   setDisplayReplyComment,
   displayReplyComment
 }: {
   commentBeingRepliedTo: CommentType;
-  pillar: Pillar;
   setDisplayReplyComment: (displayReplyComment: boolean) => void;
   displayReplyComment: boolean;
 }) => {
-  const commentControlsButtonStyles = commentControlsButton(pillar);
   return (
     <div className={previewStyle}>
       <p className={replyPreviewHeaderStyle}>

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -22,7 +22,11 @@ const replyWrapperStyles = css`
 `;
 const replyArrowStyles = css`
   fill: grey;
-  padding-top: 2px; /* TODO: find a better solution */
+  /*
+    In order to get teh arrow SVG alinged correctly with the text reply text
+    we need to add 2px padding
+  */
+  padding-top: 2px;
 `;
 
 const replyDisplayNameStyles = css`

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -81,6 +81,7 @@ const hideCommentButtonStyles = css`
 `;
 const previewHideCommentButtonStyles = css`
   background-color: inherit;
+  padding-left: 0px;
 `;
 
 const ReplyArrow = () => (

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -24,22 +24,26 @@ const replyArrowStyles = css`
 `;
 
 const replyDisplayNameStyles = css`
-  ${textSans.small({ fontWeight: "bold" })};
+  ${textSans.small()};
   padding: 5px;
   margin-right: 10px;
 `;
 
 const replyPreviewHeaderStyle = css`
+  margin-top: 0px;
+  margin-bottom: 6px;
   font-weight: bold;
-  margin: 0;
 `;
 
 const arrowSize = 15;
 const bg = neutral[93];
 const previewStyle = css`
-  padding: ${space[2]}px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 20px;
+  padding-right: 20px;
   background-color: ${bg};
-  border-radius: 5px;
+  margin-top: 6px;
   margin-bottom: ${arrowSize + 5}px;
   position: relative;
   display: flex;
@@ -47,14 +51,23 @@ const previewStyle = css`
   :before {
     content: "";
     position: absolute;
-    border-right: ${arrowSize}px solid transparent;
-    border-top: ${arrowSize}px solid ${bg};
-    bottom: -${arrowSize - 1}px;
+    border-left: ${arrowSize}px solid #ededed;
+    border-top: ${arrowSize}px solid transparent;
+    top: -${arrowSize - 1}px;
+    margin-left: 60px;
+  }
+`;
+
+const commentStyles = css`
+  p {
+    margin-top: 0px;
+    margin-bottom: ${space[3]}px;
   }
 `;
 
 const hideCommentButtonStyles = css`
-  padding: 5px;
+  padding-top: 5px;
+  padding-bottom: 5px;
   ${textSans.xsmall()};
   :hover {
     cursor: pointer;
@@ -98,30 +111,53 @@ export const CommentReplyPreview = ({
         </span>
       </div>
       {displayReplyComment && (
-        <div className={previewStyle}>
-          <p className={replyPreviewHeaderStyle}>
-            {commentBeingRepliedTo.userProfile.displayName} @{" "}
-            {commentBeingRepliedTo.date} said:
-          </p>
-          <p
-            dangerouslySetInnerHTML={{
-              __html: commentBeingRepliedTo.body || ""
-            }}
-          />
-          <div>
-            <span
-              className={cx(
-                hideCommentButtonStyles,
-                commentControlsButtonStyles,
-                previewHideCommentButtonStyles
-              )}
-              onClick={() => setDisplayReplyComment(!displayReplyComment)}
-            >
-              {displayReplyComment ? "Hide Comment" : "Show comment"}
-            </span>
-          </div>
-        </div>
+        <Preview
+          pillar={pillar}
+          commentBeingRepliedTo={commentBeingRepliedTo}
+          setDisplayReplyComment={setDisplayReplyComment}
+          displayReplyComment={displayReplyComment}
+        />
       )}
     </>
+  );
+};
+
+export const Preview = ({
+  commentBeingRepliedTo,
+  pillar,
+  setDisplayReplyComment,
+  displayReplyComment
+}: {
+  commentBeingRepliedTo: CommentType;
+  pillar: Pillar;
+  setDisplayReplyComment: (displayReplyComment: boolean) => void;
+  displayReplyComment: boolean;
+}) => {
+  const commentControlsButtonStyles = commentControlsButton(pillar);
+  return (
+    <div className={previewStyle}>
+      <p className={replyPreviewHeaderStyle}>
+        {commentBeingRepliedTo.userProfile.displayName} @{" "}
+        {commentBeingRepliedTo.date} said:
+      </p>
+      <div
+        className={commentStyles}
+        dangerouslySetInnerHTML={{
+          __html: commentBeingRepliedTo.body || ""
+        }}
+      />
+      <div>
+        <span
+          className={cx(
+            hideCommentButtonStyles,
+            commentControlsButtonStyles,
+            previewHideCommentButtonStyles
+          )}
+          onClick={() => setDisplayReplyComment(!displayReplyComment)}
+        >
+          {displayReplyComment ? "Hide Comment" : "Show comment"}
+        </span>
+      </div>
+    </div>
   );
 };


### PR DESCRIPTION
## What does this change?
Changes styles of reply previews

## Why?
Parity

## Link to supporting Trello card
https://trello.com/c/k8JhVYit/1382-style-comment-preview-when-replying

## Before
![Screenshot 2020-04-02 at 17 03 55](https://user-images.githubusercontent.com/8831403/78271364-fc82be80-7503-11ea-841f-0e402e125fba.png)

## After
<img width="406" alt="Screenshot 2020-04-02 at 17 14 34" src="https://user-images.githubusercontent.com/8831403/78272553-91d28280-7505-11ea-9394-368c6434a62e.png">
