### PR TITLE
Restyle First Post Message

### DIFF
--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -32,10 +32,16 @@ const textStyling = css`
   ${textSans.small()};
 `;
 
-const flexRow = css`
-  display: flex;
-  flex-direction: row;
-`;
+const Row = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
+  <div
+    className={css`
+      display: flex;
+      flex-direction: row;
+    `}
+  >
+    {children}
+  </div>
+);
 
 export const FirstCommentWelcome = ({
   body,
@@ -110,7 +116,7 @@ export const FirstCommentWelcome = ({
           className={cx(previewStyle, textStyling)}
           dangerouslySetInnerHTML={{ __html: previewBody || "" }}
         />
-        <div className={flexRow}>
+        <Row>
           <Button size="small" onClick={() => submitForm(userName)}>
             Post your comment
           </Button>
@@ -122,7 +128,7 @@ export const FirstCommentWelcome = ({
           <Button size="small" priority="tertiary" onClick={cancelSubmit}>
             Cancel
           </Button>
-        </div>
+        </Row>
       </form>
     </div>
   );

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -23,11 +23,6 @@ const textStyling = css`
   ${textSans.small()};
 `;
 
-const flexCol = css`
-  display: flex;
-  flex-direction: column;
-`;
-
 const flexRow = css`
   display: flex;
   flex-direction: row;
@@ -67,36 +62,30 @@ export const FirstCommentWelcome = ({
         submitForm(userName);
       }}
     >
-      <div>
-        <h3
-          className={css`
-            ${headline.xxsmall({ fontWeight: "bold" })};
-          `}
-        >
-          Welcome, you’re about to make your first comment!
-        </h3>
-      </div>
-      <div>
-        <p className={textStyling}>
-          Before you post, we’d like to thank you for joining the debate - we’re
-          glad you’ve chosen to participate and we value your opinions and
-          experiences.
-        </p>
-        <p className={textStyling}>
-          Please choose your username under which you would like all your
-          comments to show up. You can only set your username once.
-        </p>
-      </div>
-      <div className={cx(flexCol, textStyling)}>
-        <TextInput
-          label="Username:"
-          supporting="Must be 6-20 characters, letters and/or numbers only, no spaces."
-          value={userName}
-          onChange={e => setUserName(e.target.value)}
-          width={30}
-          error={error}
-        />
-      </div>
+      <h3
+        className={css`
+          ${headline.xxsmall({ fontWeight: "bold" })};
+        `}
+      >
+        Welcome, you’re about to make your first comment!
+      </h3>
+      <p className={textStyling}>
+        Before you post, we’d like to thank you for joining the debate - we’re
+        glad you’ve chosen to participate and we value your opinions and
+        experiences.
+      </p>
+      <p className={textStyling}>
+        Please choose your username under which you would like all your comments
+        to show up. You can only set your username once.
+      </p>
+      <TextInput
+        label="Username:"
+        supporting="Must be 6-20 characters, letters and/or numbers only, no spaces."
+        value={userName}
+        onChange={e => setUserName(e.target.value)}
+        width={30}
+        error={error}
+      />
       <p className={textStyling}>
         Please keep your posts respectful and abide by the{" "}
         <a

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -58,77 +58,83 @@ export const FirstCommentWelcome = ({
   }, [body]);
 
   return (
-    <form
-      onSubmit={e => {
-        e.preventDefault();
-        submitForm(userName);
-      }}
+    <div
+      className={css`
+        padding: ${space[2]}px;
+      `}
     >
-      <h3
-        className={css`
-          ${headline.xxsmall({ fontWeight: "bold" })};
-        `}
+      <form
+        onSubmit={e => {
+          e.preventDefault();
+          submitForm(userName);
+        }}
       >
-        Welcome, you’re about to make your first comment!
-      </h3>
-      <p className={textStyling}>
-        Before you post, we’d like to thank you for joining the debate - we’re
-        glad you’ve chosen to participate and we value your opinions and
-        experiences.
-      </p>
-      <p className={textStyling}>
-        Please choose your username under which you would like all your comments
-        to show up. You can only set your username once.
-      </p>
-      <TextInput
-        label="Username:"
-        supporting="Must be 6-20 characters, letters and/or numbers only, no spaces."
-        value={userName}
-        onChange={e => setUserName(e.target.value)}
-        width={30}
-        error={error}
-      />
-      <p className={textStyling}>
-        Please keep your posts respectful and abide by the{" "}
-        <a
+        <h3
           className={css`
-            color: ${palette.brand[500]};
-            text-decoration: none;
-            :hover {
-              text-decoration: underline;
-            }
+            ${headline.xxsmall({ fontWeight: "bold" })};
           `}
-          href="/community-standards"
         >
-          community guidelines
-        </a>
-        {` -`} and if you spot a comment you think doesn’t adhere to the
-        guidelines, please use the ‘Report’ link next to it to let us know.
-      </p>
-      <p className={textStyling}>
-        Please preview your comment below and click ‘post’ when you’re happy
-        with it.
-      </p>
-      {previewBody && (
-        <div
-          className={cx(previewStyle, textStyling)}
-          dangerouslySetInnerHTML={{ __html: previewBody || "" }}
+          Welcome, you’re about to make your first comment!
+        </h3>
+        <p className={textStyling}>
+          Before you post, we’d like to thank you for joining the debate - we’re
+          glad you’ve chosen to participate and we value your opinions and
+          experiences.
+        </p>
+        <p className={textStyling}>
+          Please choose your username under which you would like all your
+          comments to show up. You can only set your username once.
+        </p>
+        <TextInput
+          label="Username:"
+          supporting="Must be 6-20 characters, letters and/or numbers only, no spaces."
+          value={userName}
+          onChange={e => setUserName(e.target.value)}
+          width={30}
+          error={error}
         />
-      )}
-      <div className={flexRow}>
-        <Button size="small" onClick={() => submitForm(userName)}>
-          Post your comment
-        </Button>
-        <div
-          className={css`
-            margin-left: 20px;
-          `}
-        >
-          <Button size="small" priority="tertiary" onClick={cancelSubmit}>
-            Cancel
+        <p className={textStyling}>
+          Please keep your posts respectful and abide by the{" "}
+          <a
+            className={css`
+              color: ${palette.brand[500]};
+              text-decoration: none;
+              :hover {
+                text-decoration: underline;
+              }
+            `}
+            href="/community-standards"
+          >
+            community guidelines
+          </a>
+          {` -`} and if you spot a comment you think doesn’t adhere to the
+          guidelines, please use the ‘Report’ link next to it to let us know.
+        </p>
+        <p className={textStyling}>
+          Please preview your comment below and click ‘post’ when you’re happy
+          with it.
+        </p>
+        {previewBody && (
+          <div
+            className={cx(previewStyle, textStyling)}
+            dangerouslySetInnerHTML={{ __html: previewBody || "" }}
+          />
+        )}
+        <div className={flexRow}>
+          <Button size="small" onClick={() => submitForm(userName)}>
+            Post your comment
           </Button>
+          <div
+            className={css`
+              margin-left: 20px;
+            `}
+          >
+            <Button size="small" priority="tertiary" onClick={cancelSubmit}>
+              Cancel
+            </Button>
+          </div>
         </div>
-      </div>
-    </form>
+      </form>
+    </div>
   );
 };

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -20,6 +20,8 @@ const previewStyle = css`
   border-radius: 5px;
   margin-bottom: 20px;
   position: relative;
+  min-height: ${space[9]}px;
+
   /* p is returned by API and this is the only way to apply styles */
   p {
     padding-left: 10px;
@@ -113,12 +115,10 @@ export const FirstCommentWelcome = ({
           Please preview your comment below and click ‘post’ when you’re happy
           with it.
         </p>
-        {previewBody && (
-          <div
-            className={cx(previewStyle, textStyling)}
-            dangerouslySetInnerHTML={{ __html: previewBody || "" }}
-          />
-        )}
+        <div
+          className={cx(previewStyle, textStyling)}
+          dangerouslySetInnerHTML={{ __html: previewBody || "" }}
+        />
         <div className={flexRow}>
           <Button size="small" onClick={() => submitForm(userName)}>
             Post your comment

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -17,13 +17,13 @@ type Props = {
 const previewStyle = css`
   padding: ${space[2]}px;
   background-color: ${neutral[93]};
-  margin-bottom: 20px;
+  margin-bottom: ${space[5]}px;
   position: relative;
   min-height: ${space[9]}px;
 
   /* p is returned by API and this is the only way to apply styles */
   p {
-    padding-left: 10px;
+    padding-left: ${space[2]}px;
   }
 `;
 

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { css, cx } from "emotion";
 import { textSans, headline } from "@guardian/src-foundations/typography";
 import { space, neutral, palette } from "@guardian/src-foundations";
-import { TextInput } from "@guardian/src-text-input"
+import { TextInput } from "@guardian/src-text-input";
 import { Button } from "@guardian/src-button";
 
 import { preview } from "../../lib/api";
@@ -128,13 +128,14 @@ export const FirstCommentWelcome = ({
         <Button size="small" onClick={() => submitForm(userName)}>
           Post your comment
         </Button>
-        <div className={css`margin-left: 20px;`}>
-          <Button
-            size="small"
-            onClick={cancelSubmit}
-          >
+        <div
+          className={css`
+            margin-left: 20px;
+          `}
+        >
+          <Button size="small" onClick={cancelSubmit}>
             Cancel
-        </Button>
+          </Button>
         </div>
       </div>
     </form>

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { css, cx } from "emotion";
 import { textSans, headline } from "@guardian/src-foundations/typography";
-import { space, neutral, palette } from "@guardian/src-foundations";
+import { space, neutral } from "@guardian/src-foundations";
 import { TextInput } from "@guardian/src-text-input";
 import { Button } from "@guardian/src-button";
 import { Link } from "@guardian/src-link";

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { css, cx } from "emotion";
-import { textSans } from "@guardian/src-foundations/typography";
+import { textSans, headline } from "@guardian/src-foundations/typography";
 import { space, neutral, palette } from "@guardian/src-foundations";
 import { TextInput } from "@guardian/src-text-input"
 import { Button } from "@guardian/src-button";
@@ -70,7 +70,7 @@ export const FirstCommentWelcome = ({
       <div>
         <h3
           className={css`
-            ${textSans.medium({ fontWeight: "bold" })};
+            ${headline.xxsmall({ fontWeight: "bold" })};
           `}
         >
           Welcome, you’re about to make your first comment!

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -124,13 +124,12 @@ export const FirstCommentWelcome = ({
           </Button>
           <div
             className={css`
-              margin-left: 20px;
+              width: ${space[3]}px;
             `}
-          >
-            <Button size="small" priority="tertiary" onClick={cancelSubmit}>
-              Cancel
-            </Button>
-          </div>
+          ></div>
+          <Button size="small" priority="tertiary" onClick={cancelSubmit}>
+            Cancel
+          </Button>
         </div>
       </form>
     </div>

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -20,7 +20,7 @@ const previewStyle = css`
 `;
 
 const textStyling = css`
-  ${textSans.xsmall()};
+  ${textSans.small()};
 `;
 
 const flexCol = css`

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -17,7 +17,6 @@ type Props = {
 const previewStyle = css`
   padding: ${space[2]}px;
   background-color: ${neutral[93]};
-  border-radius: 5px;
   margin-bottom: 20px;
   position: relative;
   min-height: ${space[9]}px;

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -50,7 +50,6 @@ export const FirstCommentWelcome = ({
         const response = await preview(body);
         setPreviewBody(response);
       } catch (e) {
-        // TODO: handle errors?
         setPreviewBody("");
       }
     };

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -7,6 +7,13 @@ import { Button } from "@guardian/src-button";
 
 import { preview } from "../../lib/api";
 
+type Props = {
+  body: string;
+  error?: string;
+  submitForm: (userName: string) => void;
+  cancelSubmit: () => void;
+};
+
 const previewStyle = css`
   padding: ${space[2]}px;
   background-color: ${neutral[93]};
@@ -33,12 +40,7 @@ export const FirstCommentWelcome = ({
   error = "",
   submitForm,
   cancelSubmit
-}: {
-  body: string;
-  error?: string;
-  submitForm: (userName: string) => void;
-  cancelSubmit: () => void;
-}) => {
+}: Props) => {
   const [previewBody, setPreviewBody] = useState<string>("");
   const [userName, setUserName] = useState<string>("");
 

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -32,6 +32,12 @@ const textStyling = css`
   ${textSans.small()};
 `;
 
+const Text = ({
+  children
+}: {
+  children: string | JSX.Element | JSX.Element[];
+}) => <p className={textStyling}>{children}</p>;
+
 const Row = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
   <div
     className={css`
@@ -83,15 +89,15 @@ export const FirstCommentWelcome = ({
         >
           Welcome, you’re about to make your first comment!
         </h3>
-        <p className={textStyling}>
+        <Text>
           Before you post, we’d like to thank you for joining the debate - we’re
           glad you’ve chosen to participate and we value your opinions and
           experiences.
-        </p>
-        <p className={textStyling}>
+        </Text>
+        <Text>
           Please choose your username under which you would like all your
           comments to show up. You can only set your username once.
-        </p>
+        </Text>
         <TextInput
           label="Username:"
           supporting="Must be 6-20 characters, letters and/or numbers only, no spaces."
@@ -100,18 +106,20 @@ export const FirstCommentWelcome = ({
           width={30}
           error={error}
         />
-        <p className={textStyling}>
-          Please keep your posts respectful and abide by the{" "}
-          <Link href="/community-standards" priority="primary" subdued={true}>
-            <span className={textStyling}>community guidelines</span>
-          </Link>
-          {` -`} and if you spot a comment you think doesn’t adhere to the
-          guidelines, please use the ‘Report’ link next to it to let us know.
-        </p>
-        <p className={textStyling}>
+        <Text>
+          <>
+            Please keep your posts respectful and abide by the{" "}
+            <Link href="/community-standards" priority="primary" subdued={true}>
+              <span className={textStyling}>community guidelines</span>
+            </Link>
+            {` -`} and if you spot a comment you think doesn’t adhere to the
+            guidelines, please use the ‘Report’ link next to it to let us know.
+          </>
+        </Text>
+        <Text>
           Please preview your comment below and click ‘post’ when you’re happy
           with it.
-        </p>
+        </Text>
         <div
           className={cx(previewStyle, textStyling)}
           dangerouslySetInnerHTML={{ __html: previewBody || "" }}

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -4,6 +4,7 @@ import { textSans, headline } from "@guardian/src-foundations/typography";
 import { space, neutral, palette } from "@guardian/src-foundations";
 import { TextInput } from "@guardian/src-text-input";
 import { Button } from "@guardian/src-button";
+import { Link } from "@guardian/src-link";
 
 import { preview } from "../../lib/api";
 
@@ -95,18 +96,9 @@ export const FirstCommentWelcome = ({
         />
         <p className={textStyling}>
           Please keep your posts respectful and abide by the{" "}
-          <a
-            className={css`
-              color: ${palette.brand[500]};
-              text-decoration: none;
-              :hover {
-                text-decoration: underline;
-              }
-            `}
-            href="/community-standards"
-          >
-            community guidelines
-          </a>
+          <Link href="/community-standards" priority="primary" subdued={true}>
+            <span className={textStyling}>community guidelines</span>
+          </Link>
           {` -`} and if you spot a comment you think doesn’t adhere to the
           guidelines, please use the ‘Report’ link next to it to let us know.
         </p>

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -133,7 +133,7 @@ export const FirstCommentWelcome = ({
             margin-left: 20px;
           `}
         >
-          <Button size="small" onClick={cancelSubmit}>
+          <Button size="small" priority="tertiary" onClick={cancelSubmit}>
             Cancel
           </Button>
         </div>


### PR DESCRIPTION
## What does this change?
This brings the FirstPostMessage form more into line with source foundation

### Before (master)
![Screenshot 2020-04-02 at 17 48 58](https://user-images.githubusercontent.com/1336821/78276059-656d3500-750a-11ea-8fa5-72e8c36ba96f.jpg)

## After
![Screenshot 2020-04-02 at 17 48 36](https://user-images.githubusercontent.com/1336821/78276044-61411780-750a-11ea-8252-3b200f8f16aa.jpg)

## Why?
We prefer using source foundation over having exact parity with frontend

## Link to supporting Trello card
https://trello.com/c/09kdF5rZ/1179-create-username-form-first-comment
