### PR TITLE
Only allow recommendation attempts when signed in

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -315,6 +315,7 @@ export const App = ({
                 baseUrl={baseUrl}
                 pillar={pillar}
                 comments={picks.slice(0, 2)}
+                isSignedIn={!!user}
               />
             )}
           </div>
@@ -380,7 +381,12 @@ export const App = ({
         />
       )}
       {!!picks.length && (
-        <TopPicks baseUrl={baseUrl} pillar={pillar} comments={picks} />
+        <TopPicks
+          baseUrl={baseUrl}
+          pillar={pillar}
+          comments={picks}
+          isSignedIn={!!user}
+        />
       )}
       <Filters
         filters={filters}

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -439,6 +439,7 @@ export const Comment = ({
                 commentId={comment.id}
                 initialCount={comment.numRecommends}
                 alreadyRecommended={false}
+                isSignedIn={!!user}
               />
             )}
           </header>

--- a/src/components/RecommendationCount/RecommendationCount.stories.tsx
+++ b/src/components/RecommendationCount/RecommendationCount.stories.tsx
@@ -8,12 +8,24 @@ export const NeverRecomended = () => (
     commentId={123}
     initialCount={383}
     alreadyRecommended={false}
+    isSignedIn={true}
   />
 );
+
 export const AlreadyRecomended = () => (
   <RecommendationCount
     commentId={123}
     initialCount={83}
     alreadyRecommended={true}
+    isSignedIn={true}
+  />
+);
+
+export const NotSignedIn = () => (
+  <RecommendationCount
+    commentId={123}
+    initialCount={83}
+    alreadyRecommended={false}
+    isSignedIn={false}
   />
 );

--- a/src/components/RecommendationCount/RecommendationCount.tsx
+++ b/src/components/RecommendationCount/RecommendationCount.tsx
@@ -10,6 +10,7 @@ type Props = {
   commentId: number;
   initialCount: number;
   alreadyRecommended: boolean;
+  isSignedIn: boolean;
 };
 
 const flexStyles = css`
@@ -30,8 +31,8 @@ const ArrowUp = () => (
   </svg>
 );
 
-const buttonStyles = (recommended: Boolean) => css`
-  cursor: ${recommended ? "default" : "pointer"};
+const buttonStyles = (recommended: boolean, isSignedIn: boolean) => css`
+  cursor: ${recommended || !isSignedIn ? "default" : "pointer"};
   width: 1.1875rem;
   height: 1.1875rem;
   background-color: ${recommended ? "#00b2ff" : "#f6f6f6"};
@@ -50,7 +51,8 @@ const arrowStyles = (recommended: Boolean) => css`
 export const RecommendationCount = ({
   commentId,
   initialCount,
-  alreadyRecommended
+  alreadyRecommended,
+  isSignedIn
 }: Props) => {
   const [count, setCount] = useState(initialCount);
   const [recommended, setRecommended] = useState(alreadyRecommended);
@@ -73,9 +75,9 @@ export const RecommendationCount = ({
     <div className={flexStyles}>
       <div className={countStyles}>{count}</div>
       <button
-        className={buttonStyles(recommended)}
+        className={buttonStyles(recommended, isSignedIn)}
         onClick={() => tryToRecommend()}
-        disabled={recommended}
+        disabled={recommended || !isSignedIn}
       >
         <div className={arrowStyles(recommended)}>
           <ArrowUp />

--- a/src/components/TopPick/TopPick.stories.tsx
+++ b/src/components/TopPick/TopPick.stories.tsx
@@ -58,6 +58,7 @@ export const LongPick = () => (
       baseUrl="https://discussion.guardianapis.com/discussion-api"
       pillar="news"
       comment={comment}
+      isSignedIn={false}
     />
   </div>
 );
@@ -74,6 +75,7 @@ export const ShortPick = () => (
       baseUrl="https://discussion.guardianapis.com/discussion-api"
       pillar="opinion"
       comment={commentWithShortBody}
+      isSignedIn={true}
     />
   </div>
 );

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -17,6 +17,7 @@ type Props = {
   baseUrl: string;
   pillar: Pillar;
   comment: CommentType;
+  isSignedIn: boolean;
 };
 
 const pickStyles = css`
@@ -150,7 +151,7 @@ const truncateText = (input: string, limit: number) => {
   return input;
 };
 
-export const TopPick = ({ baseUrl, pillar, comment }: Props) => (
+export const TopPick = ({ baseUrl, pillar, comment, isSignedIn }: Props) => (
   <div className={pickStyles}>
     <div className={pickComment}>
       <SpaceBetween>
@@ -226,6 +227,7 @@ export const TopPick = ({ baseUrl, pillar, comment }: Props) => (
           commentId={comment.id}
           initialCount={comment.numRecommends}
           alreadyRecommended={false}
+          isSignedIn={isSignedIn}
         />
       </div>
     </div>

--- a/src/components/TopPicks/TopPicks.stories.tsx
+++ b/src/components/TopPicks/TopPicks.stories.tsx
@@ -58,6 +58,7 @@ export const SingleComment = () => (
     baseUrl="https://discussion.guardianapis.com/discussion-api"
     pillar="news"
     comments={[commentWithShortBody]}
+    isSignedIn={true}
   />
 );
 SingleComment.story = { name: "Single Comment" };
@@ -72,6 +73,7 @@ export const MulitColumn = () => (
       commentWithShortBody,
       commentWithShortBody
     ]}
+    isSignedIn={true}
   />
 );
 MulitColumn.story = { name: "Mulitple Columns Comments" };
@@ -86,6 +88,7 @@ export const SingleColumn = () => (
       commentWithShortBody,
       commentWithShortBody
     ]}
+    isSignedIn={true}
   />
 );
 SingleColumn.story = {

--- a/src/components/TopPicks/TopPicks.tsx
+++ b/src/components/TopPicks/TopPicks.tsx
@@ -6,7 +6,12 @@ import { until, from } from "@guardian/src-foundations/mq";
 import { CommentType, Pillar } from "../../types";
 import { TopPick } from "../TopPick/TopPick";
 
-type Props = { baseUrl: string; pillar: Pillar; comments: CommentType[] };
+type Props = {
+  baseUrl: string;
+  pillar: Pillar;
+  comments: CommentType[];
+  isSignedIn: boolean;
+};
 
 const columWrapperStyles = css`
   width: 50%;
@@ -41,7 +46,7 @@ const oneColCommentsStyles = css`
   }
 `;
 
-export const TopPicks = ({ baseUrl, pillar, comments }: Props) => {
+export const TopPicks = ({ baseUrl, pillar, comments, isSignedIn }: Props) => {
   const leftColComments: CommentType[] = [];
   const rightColComments: CommentType[] = [];
   comments.forEach((comment, index) =>
@@ -54,18 +59,33 @@ export const TopPicks = ({ baseUrl, pillar, comments }: Props) => {
       <div className={twoColCommentsStyles}>
         <div className={cx(columWrapperStyles, paddingRight)}>
           {leftColComments.map(comment => (
-            <TopPick baseUrl={baseUrl} pillar={pillar} comment={comment} />
+            <TopPick
+              baseUrl={baseUrl}
+              pillar={pillar}
+              comment={comment}
+              isSignedIn={isSignedIn}
+            />
           ))}
         </div>
         <div className={cx(columWrapperStyles, paddingLeft)}>
           {rightColComments.map(comment => (
-            <TopPick baseUrl={baseUrl} pillar={pillar} comment={comment} />
+            <TopPick
+              baseUrl={baseUrl}
+              pillar={pillar}
+              comment={comment}
+              isSignedIn={isSignedIn}
+            />
           ))}
         </div>
       </div>
       <div className={oneColCommentsStyles}>
         {comments.map(comment => (
-          <TopPick baseUrl={baseUrl} pillar={pillar} comment={comment} />
+          <TopPick
+            baseUrl={baseUrl}
+            pillar={pillar}
+            comment={comment}
+            isSignedIn={isSignedIn}
+          />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## What does this change?
Prevent user's who are not signed in from making attempts to recommend

## Why?
Their attempts will fail (as unauthorised) so it's better not to let them even try. This also better communicates how the recommendation action should work

## Link to supporting Trello card
https://trello.com/c/TNjPc4SA/1391-signed-out-recommend-state