### PR TITLE
Username colour

### DIFF
--- a/src/components/Comment/Comment.stories.tsx
+++ b/src/components/Comment/Comment.stories.tsx
@@ -86,7 +86,7 @@ export const Root = () => (
   <Comment
     baseUrl="https://discussion.theguardian.com/discussion-api"
     comment={commentData}
-    pillar={"sport"}
+    pillar={"news"}
     isClosedForComments={false}
     setCommentBeingRepliedTo={() => {}}
     isReply={false}
@@ -126,7 +126,7 @@ export const ReplyComment = () => (
   <Comment
     baseUrl="https://discussion.theguardian.com/discussion-api"
     comment={replyCommentData}
-    pillar={"sport"}
+    pillar={"lifestyle"}
     isClosedForComments={false}
     setCommentBeingRepliedTo={() => {}}
     isReply={true}
@@ -146,7 +146,7 @@ export const MobileReply = () => (
   <Comment
     baseUrl="https://discussion.theguardian.com/discussion-api"
     comment={replyCommentData}
-    pillar={"sport"}
+    pillar={"culture"}
     setCommentBeingRepliedTo={() => {}}
     isReply={true}
     isClosedForComments={false}
@@ -169,7 +169,7 @@ export const PickedComment = () => (
       ...commentData,
       isHighlighted: true
     }}
-    pillar={"sport"}
+    pillar={"labs"}
     isClosedForComments={false}
     setCommentBeingRepliedTo={() => {}}
     isReply={false}
@@ -183,7 +183,7 @@ export const StaffUserComment = () => (
   <Comment
     baseUrl="https://discussion.theguardian.com/discussion-api"
     comment={commentStaffData}
-    pillar={"sport"}
+    pillar={"opinion"}
     isClosedForComments={false}
     setCommentBeingRepliedTo={() => {}}
     isReply={false}
@@ -200,7 +200,7 @@ export const PickedStaffUserComment = () => (
       ...commentStaffData,
       isHighlighted: true
     }}
-    pillar={"sport"}
+    pillar={"news"}
     isClosedForComments={false}
     setCommentBeingRepliedTo={() => {}}
     isReply={false}
@@ -243,7 +243,7 @@ export const LoggedInAsModerator = () => (
   <Comment
     baseUrl="https://discussion.theguardian.com/discussion-api"
     comment={commentData}
-    pillar={"sport"}
+    pillar={"lifestyle"}
     isClosedForComments={false}
     setCommentBeingRepliedTo={() => {}}
     user={staffUser}
@@ -258,7 +258,7 @@ export const BlockedComment = () => (
   <Comment
     baseUrl="https://discussion.theguardian.com/discussion-api"
     comment={blockedCommentData}
-    pillar={"sport"}
+    pillar={"culture"}
     isClosedForComments={false}
     setCommentBeingRepliedTo={() => {}}
     isReply={false}

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -111,7 +111,9 @@ const avatarMargin = css`
 `;
 
 const colourStyles = (pillar: Pillar) => css`
-  color: ${palette[pillar][400]};
+  a {
+    color: ${palette[pillar][400]};
+  }
 `;
 
 const boldFont = css`


### PR DESCRIPTION
## What does this change?
This makes sure the css color property is properly set for the comment username

## Before
![Screenshot 2020-04-03 at 09 45 50](https://user-images.githubusercontent.com/1336821/78341642-f508f700-758f-11ea-9d3c-cdb323c1594e.jpg)

## Afrer
![Screenshot 2020-04-03 at 09 45 15](https://user-images.githubusercontent.com/1336821/78341650-f803e780-758f-11ea-8555-e8429866de3d.jpg)

## Why?
Because before it wasn't being applied. This was a regression after we upgraded to using the `Link` component

## Link to supporting Trello card
https://trello.com/c/GiasiE49/1392-pillar-for-username