### PR TITLE
Fix button spacing

### DIFF
--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -50,7 +50,13 @@ const commentControlsButton = (pillar: Pillar) => css`
   :hover {
     text-decoration: underline
   }
-  padding-top: 0px; /* In order to remove variations between buttons and a tags */
+  padding-top: 0px; /* In order to remove variations between <button> and <a> tags */
+`;
+
+const commentControlsLink = (pillar: Pillar) => css`
+  ${textSans.xsmall({ fontWeight: "bold" })}
+  margin-right: ${space[2]}px;
+  color: ${palette[pillar][400]};
 `;
 
 const spaceBetween = css`
@@ -226,6 +232,7 @@ export const Comment = ({
   toggleMuteStatus
 }: Props) => {
   const commentControlsButtonStyles = commentControlsButton(pillar);
+  const commentControlsLinkStyles = commentControlsLink(pillar);
   const [isHighlighted, setIsHighlighted] = useState<boolean>(
     comment.isHighlighted
   );
@@ -484,31 +491,29 @@ export const Comment = ({
                         <button
                           onClick={() => setCommentBeingRepliedTo(comment)}
                           className={cx(
-                            commentControlsButtonStyles,
+                            flexRowStyles,
                             removePaddingLeft,
-                            flexRowStyles
+                            commentControlsButtonStyles
                           )}
                         >
                           <ReplyArrow />
                           Reply
                         </button>
                       ) : (
-                        <div className={commentControlsButtonStyles}>
-                          <Link
-                            href={`https://profile.theguardian.com/signin?returnUrl=https://discussion.theguardian.com/comment-permalink/${comment.id}`}
-                            subdued={true}
+                        <Link
+                          href={`https://profile.theguardian.com/signin?returnUrl=https://discussion.theguardian.com/comment-permalink/${comment.id}`}
+                          subdued={true}
+                        >
+                          <div
+                            className={cx(
+                              flexRowStyles,
+                              commentControlsLinkStyles
+                            )}
                           >
-                            <div
-                              className={cx(
-                                flexRowStyles,
-                                commentControlsButtonStyles
-                              )}
-                            >
-                              <ReplyArrow />
-                              Reply
-                            </div>
-                          </Link>
-                        </div>
+                            <ReplyArrow />
+                            Reply
+                          </div>
+                        </Link>
                       )}
                     </>
                   )}

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -501,35 +501,28 @@ export const Comment = ({
                 <div className={commentControls}>
                   {/* When commenting is closed, no reply link shows at all */}
                   {!isClosedForComments && (
-                    <>
+                    <div className={commentControlsButtonStyles}>
                       {/* If user is not logged in we link to the login page */}
                       {user ? (
                         <button
                           onClick={() => setCommentBeingRepliedTo(comment)}
-                          className={cx(
-                            commentControlsButtonStyles,
-                            removePaddingLeft
-                          )}
+                          className={cx(removePaddingLeft, flexRowStyles)}
                         >
-                          <div className={flexRowStyles}>
-                            <ReplyArrow />
-                            Reply
-                          </div>
+                          <ReplyArrow />
+                          Reply
                         </button>
                       ) : (
-                        <div className={commentControlsButtonStyles}>
-                          <Row>
-                            <ReplyArrow />
-                            <a
-                              className={linkStyles(pillar)}
-                              href={`https://profile.theguardian.com/signin?returnUrl=https://discussion.theguardian.com/comment-permalink/${comment.id}`}
-                            >
-                              Reply
-                            </a>
-                          </Row>
+                        <div className={cx(flexRowStyles)}>
+                          <ReplyArrow />
+                          <a
+                            className={linkStyles(pillar)}
+                            href={`https://profile.theguardian.com/signin?returnUrl=https://discussion.theguardian.com/comment-permalink/${comment.id}`}
+                          >
+                            Reply
+                          </a>
                         </div>
                       )}
-                    </>
+                    </div>
                   )}
                   <button className={commentControlsButtonStyles}>Share</button>
                   {/* Only staff can pick, and they cannot pick thier own comment */}

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -48,6 +48,7 @@ const commentControlsButton = (pillar: Pillar) => css`
   :hover {
     text-decoration: underline
   }
+  padding-top: 0px; /* In order to remove variations between buttons and a tags */
 `;
 
 const spaceBetween = css`
@@ -516,15 +517,17 @@ export const Comment = ({
                           </div>
                         </button>
                       ) : (
-                        <Row>
-                          <ReplyArrow />
-                          <a
-                            className={linkStyles(pillar)}
-                            href={`https://profile.theguardian.com/signin?returnUrl=https://discussion.theguardian.com/comment-permalink/${comment.id}`}
-                          >
-                            Reply
-                          </a>
-                        </Row>
+                        <div className={commentControlsButtonStyles}>
+                          <Row>
+                            <ReplyArrow />
+                            <a
+                              className={linkStyles(pillar)}
+                              href={`https://profile.theguardian.com/signin?returnUrl=https://discussion.theguardian.com/comment-permalink/${comment.id}`}
+                            >
+                              Reply
+                            </a>
+                          </Row>
+                        </div>
                       )}
                     </>
                   )}

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -501,18 +501,27 @@ export const Comment = ({
                 <div className={commentControls}>
                   {/* When commenting is closed, no reply link shows at all */}
                   {!isClosedForComments && (
-                    <div className={commentControlsButtonStyles}>
+                    <>
                       {/* If user is not logged in we link to the login page */}
                       {user ? (
                         <button
                           onClick={() => setCommentBeingRepliedTo(comment)}
-                          className={cx(removePaddingLeft, flexRowStyles)}
+                          className={cx(
+                            commentControlsButtonStyles,
+                            removePaddingLeft,
+                            flexRowStyles
+                          )}
                         >
                           <ReplyArrow />
                           Reply
                         </button>
                       ) : (
-                        <div className={cx(flexRowStyles)}>
+                        <div
+                          className={cx(
+                            commentControlsButtonStyles,
+                            flexRowStyles
+                          )}
+                        >
                           <ReplyArrow />
                           <a
                             className={linkStyles(pillar)}
@@ -522,7 +531,7 @@ export const Comment = ({
                           </a>
                         </div>
                       )}
-                    </div>
+                    </>
                   )}
                   <button className={commentControlsButtonStyles}>Share</button>
                   {/* Only staff can pick, and they cannot pick thier own comment */}

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -158,15 +158,6 @@ const timestampWrapperStyles = css`
   justify-content: center;
 `;
 
-const linkStyles = (pillar: Pillar) => css`
-  ${textSans.xsmall({ fontWeight: "bold" })};
-  color: ${palette[pillar][400]};
-  text-decoration: none;
-  :hover {
-    text-decoration: underline;
-  }
-`;
-
 const flexRowStyles = css`
   display: flex;
   flex-direction: row;
@@ -516,19 +507,21 @@ export const Comment = ({
                           Reply
                         </button>
                       ) : (
-                        <div
-                          className={cx(
-                            commentControlsButtonStyles,
-                            flexRowStyles
-                          )}
-                        >
-                          <ReplyArrow />
-                          <a
-                            className={linkStyles(pillar)}
+                        <div className={commentControlsButtonStyles}>
+                          <Link
                             href={`https://profile.theguardian.com/signin?returnUrl=https://discussion.theguardian.com/comment-permalink/${comment.id}`}
+                            subdued={true}
                           >
-                            Reply
-                          </a>
+                            <div
+                              className={cx(
+                                flexRowStyles,
+                                commentControlsButtonStyles
+                              )}
+                            >
+                              <ReplyArrow />
+                              Reply
+                            </div>
+                          </Link>
                         </div>
                       )}
                     </>


### PR DESCRIPTION
## What does this change?
Wrap link with button styles and remove padding-top from buttons and links

## Why?
Buttons did not have correct spacing between each other, this was due to the fact that some buttons were implicitly links and did not implement wrapper styles. In order to keep buttons and links to the same margin we removed top padding to all of them.

## Link to supporting Trello card
https://trello.com/c/rgRHUKEV/1394-discussion-button-spacing

## Before
<img width="258" alt="Screenshot 2020-04-03 at 10 42 41" src="https://user-images.githubusercontent.com/8831403/78347140-ede5e700-7597-11ea-88bd-feb0755566ab.png">

## After
<img width="287" alt="Screenshot 2020-04-03 at 10 42 53" src="https://user-images.githubusercontent.com/8831403/78347148-f2aa9b00-7597-11ea-9927-785193863ab9.png">
