### PR TITLE
Fix mute and report alignment

### DIFF
--- a/src/components/AbuseReportForm/AbuseReportForm.stories.tsx
+++ b/src/components/AbuseReportForm/AbuseReportForm.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { css } from "emotion";
 
-import { AbuseReportForm, Form } from "./AbuseReportForm";
+import { AbuseReportForm } from "./AbuseReportForm";
 
 export default { title: "Abuse Report Form" };
 
@@ -10,22 +10,15 @@ const wrapperStyles = css`
   height: 300px;
   width: 400px;
   background-color: blue;
+  position: relative;
 `;
 
-export const Container = () => (
+export const Default = () => (
   <div className={wrapperStyles}>
-    <AbuseReportForm commentId={123} pillar={"sport"} />
-  </div>
-);
-
-export const Dialog = () => (
-  <div className={wrapperStyles}>
-    <Form toggleSetShowForm={() => {}} pillar={"sport"} commentId={123} />
-  </div>
-);
-
-export const DialogWithError = () => (
-  <div className={wrapperStyles}>
-    <Form toggleSetShowForm={() => {}} pillar={"sport"} commentId={123} />
+    <AbuseReportForm
+      toggleSetShowForm={() => {}}
+      pillar={"sport"}
+      commentId={123}
+    />
   </div>
 );

--- a/src/components/AbuseReportForm/AbuseReportForm.tsx
+++ b/src/components/AbuseReportForm/AbuseReportForm.tsx
@@ -10,18 +10,13 @@ import { SvgClose } from "@guardian/src-svgs";
 import { Pillar } from "../../types";
 import { reportAbuse } from "../../lib/api";
 
-type Props = {
-  commentId: number;
-  pillar: Pillar;
-};
-
 type formData = {
   categoryId: number;
   reason?: string;
   email?: string;
 };
 
-const formWrapper = (pillar: Pillar) => css`
+const formWrapper = css`
   z-index: 1;
   border: 1px solid ${palette.neutral[86]};
   position: absolute;
@@ -58,26 +53,11 @@ const inputWrapper = css`
   }
 `;
 
-const buttonStyles = css`
-  ${textSans.xsmall({ fontWeight: "light" })}
-  color: ${palette.neutral[46]};
-  display: block;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  width: 100%;
-  background: transparent;
-  :hover {
-    text-decoration: underline;
-    cursor: pointer;
-  }
-`;
-
 const errorMessageStyles = css`
   color: red;
 `;
 
-export const Form: React.FC<{
+export const AbuseReportForm: React.FC<{
   commentId: number;
   toggleSetShowForm: () => void;
   pillar: Pillar;
@@ -178,7 +158,7 @@ export const Form: React.FC<{
   const labelStylesClass = labelStyles(pillar);
   return (
     <div aria-modal="true" ref={modalRef}>
-      <form className={formWrapper(pillar)} onSubmit={onSubmit}>
+      <form className={formWrapper} onSubmit={onSubmit}>
         {errors.response && (
           <span className={errorMessageStyles}>{errors.response}</span>
         )}
@@ -272,33 +252,6 @@ export const Form: React.FC<{
           />
         </div>
       </form>
-    </div>
-  );
-};
-
-export const AbuseReportForm: React.FC<{
-  commentId: number;
-  pillar: Pillar;
-}> = ({ commentId, pillar }: Props) => {
-  const [showForm, setShowForm] = useState(false);
-  const toggleSetShowForm = () => setShowForm(!showForm);
-
-  return (
-    <div
-      className={css`
-        position: relative;
-      `}
-    >
-      <button className={buttonStyles} onClick={toggleSetShowForm}>
-        Report
-      </button>
-      {showForm && (
-        <Form
-          toggleSetShowForm={toggleSetShowForm}
-          pillar={pillar}
-          commentId={commentId}
-        />
-      )}
     </div>
   );
 };

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -175,7 +175,7 @@ const removePaddingLeft = css`
   padding-left: 0px;
 `;
 
-const muteStyles = css`
+const muteReportInnerTextStyles = css`
   ${textSans.xsmall()};
   color: ${neutral[46]};
   margin-right: ${space[2]}px;
@@ -256,6 +256,9 @@ export const Comment = ({
     comment.isHighlighted
   );
   const [error, setError] = useState<string>();
+
+  const [showAbuseForm, setShowAbuseForm] = useState(false);
+  const toggleSetShowForm = () => setShowAbuseForm(!showAbuseForm);
 
   const pick = async () => {
     setError("");
@@ -544,7 +547,7 @@ export const Comment = ({
                 </div>
                 <Row>
                   {/* You can't mute unless logged in and you can't yourself */}
-                  {user && comment.userProfile.userId !== user.userId ? (
+                  {user && comment.userProfile.userId !== user.userId && (
                     <div className={buttonHeightOverrides}>
                       <Button
                         priority="tertiary"
@@ -553,13 +556,32 @@ export const Comment = ({
                           toggleMuteStatus(comment.userProfile.userId)
                         }
                       >
-                        <span className={muteStyles}>Mute</span>
+                        <span className={muteReportInnerTextStyles}>Mute</span>
                       </Button>
                     </div>
-                  ) : (
-                    <></>
                   )}
-                  <AbuseReportForm commentId={comment.id} pillar={pillar} />
+                  <div className={buttonHeightOverrides}>
+                    <Button
+                      priority="tertiary"
+                      size="small"
+                      onClick={toggleSetShowForm}
+                    >
+                      <span className={muteReportInnerTextStyles}>Report</span>
+                    </Button>
+                  </div>
+                  {showAbuseForm && (
+                    <div
+                      className={css`
+                        position: relative;
+                      `}
+                    >
+                      <AbuseReportForm
+                        toggleSetShowForm={toggleSetShowForm}
+                        commentId={comment.id}
+                        pillar={pillar}
+                      />
+                    </div>
+                  )}
                 </Row>
               </div>
             </>


### PR DESCRIPTION
## What does this change?
Use src foundations for both Report and Mute button, add the same wrapper styles for each

## Why?
The implementation of each button was different, causing alignment issues. By implementing both buttons using src-foundations styles, and giving them the same wrapper styles we are able to fix the alignment issue 

## Link to supporting Trello card
https://trello.com/c/cXEmgSuX/1395-fix-report-and-mute-button-alignment

## Before
<img width="178" alt="Screenshot 2020-04-03 at 10 47 05" src="https://user-images.githubusercontent.com/8831403/78349731-f4765d80-759b-11ea-8db9-3c6a6945cfab.png">

## After
<img width="123" alt="Screenshot 2020-04-03 at 11 08 16" src="https://user-images.githubusercontent.com/8831403/78349743-f8a27b00-759b-11ea-986d-222e62c23b44.png">
