### PR TITLE
Report abuse stories

### DIFF
--- a/src/components/AbuseReportForm/AbuseReportForm.stories.tsx
+++ b/src/components/AbuseReportForm/AbuseReportForm.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { css } from "emotion";
 
-import { AbuseReportForm, Form } from "./AbuseReportForm";
+import { Form } from "./AbuseReportForm";
 
 export default { title: "Abuse Report Form" };
 
@@ -10,21 +10,10 @@ const wrapperStyles = css`
   height: 300px;
   width: 400px;
   background-color: blue;
+  position: relative;
 `;
 
-export const Container = () => (
-  <div className={wrapperStyles}>
-    <AbuseReportForm commentId={123} pillar={"sport"} />
-  </div>
-);
-
 export const Dialog = () => (
-  <div className={wrapperStyles}>
-    <Form toggleSetShowForm={() => {}} pillar={"sport"} commentId={123} />
-  </div>
-);
-
-export const DialogWithError = () => (
   <div className={wrapperStyles}>
     <Form toggleSetShowForm={() => {}} pillar={"sport"} commentId={123} />
   </div>


### PR DESCRIPTION
## What does this change?
- Render only the Report abuse dialog
- Remove dialog with error story
- Add position relative to dialog in story

## Why?
- The button should reside in the comment, and not the report abuse form component
- Dialog with error did not work because the error state is encapsulated with the dialog from
- Shows the dialog positioning with blue background
