### PR TITLE
Use src foundations button for report abuse

### DIFF
--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -10,7 +10,7 @@ import { Button } from "@guardian/src-button";
 
 import { GuardianStaff, GuardianPick } from "../Badges/Badges";
 import { RecommendationCount } from "../RecommendationCount/RecommendationCount";
-import { AbuseReportForm } from "../AbuseReportForm/AbuseReportForm";
+import { Form } from "../AbuseReportForm/AbuseReportForm";
 import { Timestamp } from "../Timestamp/Timestamp";
 import { Avatar } from "../Avatar/Avatar";
 
@@ -175,7 +175,7 @@ const removePaddingLeft = css`
   padding-left: 0px;
 `;
 
-const muteStyles = css`
+const muteReportTextStyles = css`
   ${textSans.xsmall()};
   color: ${neutral[46]};
   margin-right: ${space[2]}px;
@@ -256,6 +256,9 @@ export const Comment = ({
     comment.isHighlighted
   );
   const [error, setError] = useState<string>();
+
+  const [showForm, setShowForm] = useState(false);
+  const toggleSetShowForm = () => setShowForm(!showForm);
 
   const pick = async () => {
     setError("");
@@ -553,13 +556,34 @@ export const Comment = ({
                           toggleMuteStatus(comment.userProfile.userId)
                         }
                       >
-                        <span className={muteStyles}>Mute</span>
+                        <span className={muteReportTextStyles}>Mute</span>
                       </Button>
                     </div>
                   ) : (
                     <></>
                   )}
-                  <AbuseReportForm commentId={comment.id} pillar={pillar} />
+                  <div className={buttonHeightOverrides}>
+                    <Button
+                      priority="tertiary"
+                      size="small"
+                      onClick={toggleSetShowForm}
+                    >
+                      <span className={muteReportTextStyles}>Report</span>
+                    </Button>
+                  </div>
+                  {showForm && (
+                    <div
+                      className={css`
+                        position: relative;
+                      `}
+                    >
+                      <Form
+                        toggleSetShowForm={toggleSetShowForm}
+                        pillar={pillar}
+                        commentId={comment.id}
+                      />
+                    </div>
+                  )}
                 </Row>
               </div>
             </>


### PR DESCRIPTION
## What does this change?
Use src foundations button for report abuse button in comment

## Why?
Consistency with Mute button, fixes alignment issue

## Link to supporting Trello card
https://trello.com/c/cXEmgSuX/1395-fix-report-and-mute-button-alignment

## Before
<img width="178" alt="Screenshot 2020-04-03 at 10 47 05" src="https://user-images.githubusercontent.com/8831403/78356249-20e3a700-75a7-11ea-9f45-e9bc870f08c3.png">

## After
<img width="123" alt="Screenshot 2020-04-03 at 11 08 16" src="https://user-images.githubusercontent.com/8831403/78356263-25a85b00-75a7-11ea-9211-9b04c0c89405.png">

