### PR TITLE
Center recommendation count button

### DIFF
--- a/src/components/RecommendationCount/RecommendationCount.tsx
+++ b/src/components/RecommendationCount/RecommendationCount.tsx
@@ -26,7 +26,7 @@ const countStyles = css`
 `;
 
 const ArrowUp = () => (
-  <svg height="14" width="15">
+  <svg height="14" width="13">
     <path d="M.5 7l5.25-4.5V14h1.5V2.5L12.5 7l.5-1-5.75-6h-1.5L0 6l.5 1z"></path>
   </svg>
 );

--- a/src/components/RecommendationCount/RecommendationCount.tsx
+++ b/src/components/RecommendationCount/RecommendationCount.tsx
@@ -41,7 +41,7 @@ const buttonStyles = (recommended: boolean, isSignedIn: boolean) => css`
 `;
 
 const arrowStyles = (recommended: Boolean) => css`
-  margin-left: -5px;
+  margin-left: -4px;
   margin-bottom: -2px;
   svg {
     fill: ${recommended ? palette.neutral[100] : palette.neutral[46]};


### PR DESCRIPTION
## What does this change?
- Match SVG width to content's width
- change margin left styles in wrapper div to reflect content change

## Why?
The SVG wasn't being centered correctly

## Before
<img width="254" alt="Screenshot 2020-04-03 at 13 12 49" src="https://user-images.githubusercontent.com/8831403/78359357-d9601980-75ac-11ea-86f4-43e49f3f129b.png">

## After
<img width="231" alt="Screenshot 2020-04-03 at 13 04 11" src="https://user-images.githubusercontent.com/8831403/78359302-bd5c7800-75ac-11ea-985b-aeb806364d5f.png">
