### PR TITLE
"recommendations" vs. "mostRecommended"

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,15 +83,15 @@ const PlusSVG = () => (
 const rememberFilters = (filtersToRemember: FilterOptions) => {
   try {
     localStorage.setItem(
-      "gu.prefs.discussioni.threading",
+      "gu.prefs.discussion.threading",
       JSON.stringify({ value: filtersToRemember.threads })
     );
     localStorage.setItem(
-      "gu.prefs.discussioni.pagesize",
+      "gu.prefs.discussion.pagesize",
       JSON.stringify({ value: filtersToRemember.pageSize })
     );
     localStorage.setItem(
-      "gu.prefs.discussioni.order",
+      "gu.prefs.discussion.order",
       JSON.stringify({ value: filtersToRemember.orderBy })
     );
   } catch (error) {
@@ -159,7 +159,7 @@ const readMutes = (): string[] => {
 const writeMutes = (mutes: string[]) => {
   try {
     localStorage.setItem(
-      "gu.prefs.discussioni.mutes",
+      "gu.prefs.discussion.mutes",
       JSON.stringify({ value: mutes })
     );
   } catch (error) {

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -74,8 +74,8 @@ export const Filters = ({
           },
           {
             title: "Recommendations",
-            value: "mostrecommended",
-            isActive: filters.orderBy === "mostrecommended"
+            value: "recommendations",
+            isActive: filters.orderBy === "recommendations"
           }
         ]}
         onSelect={value =>

--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -49,7 +49,10 @@ export const getDiscussion = (
   }
 ): Promise<DiscussionResponse> => {
   const apiOpts: DiscussionOptions = {
-    orderBy: opts.orderBy,
+    // Frontend uses the 'recommendations' key to store this options but the api expects
+    // 'mostRecommended' so we have to map here to support both
+    orderBy:
+      opts.orderBy === "recommendations" ? "mostRecommended" : opts.orderBy,
     pageSize: opts.pageSize,
     displayThreaded: opts.threads !== "unthreaded",
     maxResponses: opts.threads === "collapsed" ? 3 : 100,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -146,7 +146,7 @@ export interface DiscussionResponse {
 }
 
 export interface DiscussionOptions {
-  orderBy: OrderByType;
+  orderBy: string;
   pageSize: number;
   displayThreaded: boolean;
   maxResponses: number;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -99,7 +99,7 @@ export type UserNameResponse = {
   errors?: UserNameError[];
 };
 
-export type OrderByType = "newest" | "oldest" | "mostrecommended";
+export type OrderByType = "newest" | "oldest" | "recommendations";
 export type ThreadsType = "collapsed" | "expanded" | "unthreaded";
 export type PageSizeType = 25 | 50 | 100;
 export interface FilterOptions {


### PR DESCRIPTION
## What does this change?
This defaults the `orderBy` key for "Most Recommended" to `recommendations` but then maps it to `mostRecommended` when we make the api call.

## Why?
Because the api expects `mostRecommended` but the frontend code uses `recommendations` as the key in local storage and we need to respect this value so when users transfer from frontend to DCR their preferences are not forgotten

## Link to supporting Trello card
https://trello.com/c/sQJVtW1H/1399-bug-commenting-todo-displayed-on-all-comment-threads
