### PR TITLE
Remove duplicate peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "@guardian/src-link": "^0.16.1",
     "regenerator-runtime": "^0.13.3",
     "emotion": "^10.0.27",
-    "react-dom": "^16.12.0",
-    "regenerator-runtime": "^0.13.3"
+    "react-dom": "^16.12.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",


### PR DESCRIPTION
## What does this change?
Remove duplicate peer dependency

## Why?
we shouldn't have duplicate keys in package.json