### PR TITLE
Update README with npm publish instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Once you've cloned the repo, run
 
 ### Publishing changes to NPM
 
-You need a @guardian scoped user account to be able to publish changes. To do so, update the version number in the package.json file and then run
-`npm pubish`
+You need a @guardian scoped NPM user account to be able to publish changes. You then will need to login to this NPM account locally on your maching. Once authenticated, run:
+`yarn pubish --access public` updating the version number as required
 
 ### Connection this package to DCR/Frontend to test local changes
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Once you've cloned the repo, run
 ### Publishing changes to NPM
 
 You need a @guardian scoped NPM user account to be able to publish changes. You then will need to login to this NPM account locally on your maching. Once authenticated, run:
-`yarn pubish --access public` updating the version number as required
+`yarn publish --access public` updating the version number as required
 
 ### Connection this package to DCR/Frontend to test local changes
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Once you've cloned the repo, run
 ### Publishing changes to NPM
 
 You need a @guardian scoped NPM user account to be able to publish changes. You then will need to login to this NPM account locally on your maching. Once authenticated, run:
-`yarn publish --access public` updating the version number as required
+`yarn build && yarn publish --access public` updating the version number as required
 
 ### Connection this package to DCR/Frontend to test local changes
 


### PR DESCRIPTION
## What does this change?
Updated README

## Why?
So we have up to date instruction for publishing

## Link to supporting Trello card
https://trello.com/c/xEUSfflr/1406-npm-readme