### PR TITLE
A tag hover color fix

### DIFF
--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -54,9 +54,24 @@ const commentControlsButton = (pillar: Pillar) => css`
 `;
 
 const commentControlsLink = (pillar: Pillar) => css`
-  ${textSans.xsmall({ fontWeight: "bold" })}
-  margin-right: ${space[2]}px;
-  color: ${palette[pillar][400]};
+    a {
+    ${textSans.xsmall({ fontWeight: "bold" })}
+    margin-right: ${space[2]}px;
+    color: ${palette[pillar][400]};
+    /*
+      We do not want underline to be applied to SVG
+      therefore we override the styles and apply them to the nested <span>
+    */
+    :hover {
+      text-decoration: none;
+      text-decoration-color: none;
+      span {
+        color: ${palette[pillar][400]};
+        text-decoration: underline;
+        text-decoration-color: ${palette[pillar][400]};
+      }
+    }
+  }
 `;
 
 const spaceBetween = css`
@@ -122,6 +137,11 @@ const avatarMargin = css`
 const colourStyles = (pillar: Pillar) => css`
   a {
     color: ${palette[pillar][400]};
+    text-decoration-color: ${palette[pillar][400]};
+    :hover {
+      color: ${palette[pillar][400]};
+      text-decoration-color: ${palette[pillar][400]};
+    }
   }
 `;
 
@@ -232,7 +252,6 @@ export const Comment = ({
   toggleMuteStatus
 }: Props) => {
   const commentControlsButtonStyles = commentControlsButton(pillar);
-  const commentControlsLinkStyles = commentControlsLink(pillar);
   const [isHighlighted, setIsHighlighted] = useState<boolean>(
     comment.isHighlighted
   );
@@ -500,20 +519,21 @@ export const Comment = ({
                           Reply
                         </button>
                       ) : (
-                        <Link
-                          href={`https://profile.theguardian.com/signin?returnUrl=https://discussion.theguardian.com/comment-permalink/${comment.id}`}
-                          subdued={true}
+                        <div
+                          className={cx(
+                            svgOverrides,
+                            commentControlsLink(pillar)
+                          )}
                         >
-                          <div
-                            className={cx(
-                              flexRowStyles,
-                              commentControlsLinkStyles
-                            )}
+                          <Link
+                            href={`https://profile.theguardian.com/signin?returnUrl=https://discussion.theguardian.com/comment-permalink/${comment.id}`}
+                            subdued={true}
+                            icon={<ReplyArrow />}
+                            iconSide="left"
                           >
-                            <ReplyArrow />
-                            Reply
-                          </div>
-                        </Link>
+                            <span>Reply</span>
+                          </Link>
+                        </div>
                       )}
                     </>
                   )}


### PR DESCRIPTION
## What does this change?
Apply pillar colors on hover

## Why?
<a> tags do no apply pillar colors on hover

## Before
<img width="92" alt="Screenshot 2020-04-06 at 19 21 22" src="https://user-images.githubusercontent.com/8831403/78591982-332a4300-783c-11ea-9076-972e3e2e262f.png">
<img width="127" alt="Screenshot 2020-04-06 at 19 21 18" src="https://user-images.githubusercontent.com/8831403/78591987-34f40680-783c-11ea-8d80-f2dd0455ff95.png">

## After
<img width="104" alt="Screenshot 2020-04-06 at 19 20 48" src="https://user-images.githubusercontent.com/8831403/78592004-3a515100-783c-11ea-8773-fbb25029f466.png">
<img width="138" alt="Screenshot 2020-04-06 at 19 20 56" src="https://user-images.githubusercontent.com/8831403/78592005-3cb3ab00-783c-11ea-8b0c-1db2d2fe0fb9.png">
