### PR TITLE
Refactor reply preview

### DIFF
--- a/src/components/ButtonLink/ButtonLink.stories.tsx
+++ b/src/components/ButtonLink/ButtonLink.stories.tsx
@@ -30,6 +30,19 @@ export const Single = () => (
 );
 Single.story = { name: 'a single button' };
 
+export const Small = () => (
+    <ButtonLink
+        onClick={() => {
+            alert('Clicked!');
+        }}
+        size="small"
+        pillar="lifestyle"
+    >
+        I'm small
+    </ButtonLink>
+);
+Small.story = { name: 'a small button' };
+
 export const Group = () => (
     <Row>
         <ButtonLink onClick={() => {}} pillar="culture">

--- a/src/components/ButtonLink/ButtonLink.tsx
+++ b/src/components/ButtonLink/ButtonLink.tsx
@@ -10,14 +10,17 @@ import { Pillar } from '../../types';
 type Props = {
     onClick: () => void;
     pillar?: Pillar;
+    size?: 'small' | 'default';
     icon?: JSX.Element;
     iconSide?: 'left' | 'right';
     children: string;
 };
 
-const buttonOverrides = (pillar?: Pillar) => css`
+const buttonOverrides = (size: 'small' | 'default', pillar?: Pillar) => css`
   button {
-    ${textSans.xsmall({ fontWeight: pillar ? 'bold' : 'regular' })}
+    ${textSans[size === 'small' ? 'xsmall' : 'small']({
+        fontWeight: pillar ? 'bold' : 'regular',
+    })}
     color: ${pillar ? palette[pillar][400] : neutral[46]};
     background-color: transparent;
     height: 18px;
@@ -40,14 +43,15 @@ const buttonOverrides = (pillar?: Pillar) => css`
 export const ButtonLink = ({
     pillar,
     onClick,
+    size = 'default',
     icon,
     iconSide,
     children,
 }: Props) => (
-    <div className={cx(buttonOverrides(pillar))}>
+    <div className={cx(buttonOverrides(size, pillar))}>
         <Button
             priority="tertiary"
-            size="small"
+            size={size}
             onClick={onClick}
             icon={icon}
             iconSide={iconSide}

--- a/src/components/ButtonLink/ButtonLink.tsx
+++ b/src/components/ButtonLink/ButtonLink.tsx
@@ -13,7 +13,7 @@ type Props = {
     size?: 'small' | 'default';
     icon?: JSX.Element;
     iconSide?: 'left' | 'right';
-    children: string;
+    children: string | JSX.Element;
 };
 
 const buttonOverrides = (size: 'small' | 'default', pillar?: Pillar) => css`

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -544,7 +544,7 @@ export const Comment = ({
                                                             }
                                                             iconSide="left"
                                                         >
-                                                            <span>Reply</span>
+                                                            Reply
                                                         </Link>
                                                     </div>
                                                 )}

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -551,12 +551,6 @@ export const Comment = ({
                                                 <Space amount={4} />
                                             </>
                                         )}
-                                        <ButtonLink
-                                            pillar={pillar}
-                                            onClick={() => {}}
-                                        >
-                                            Share
-                                        </ButtonLink>
                                         <Space amount={4} />
                                         {/* Only staff can pick, and they cannot pick thier own comment */}
                                         {user &&

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -591,6 +591,7 @@ export const Comment = ({
                                                     comment.userProfile.userId,
                                                 )
                                             }
+                                            size="small"
                                         >
                                             Mute
                                         </ButtonLink>
@@ -598,7 +599,10 @@ export const Comment = ({
                                         <></>
                                     )}
                                     <Space amount={4} />
-                                    <ButtonLink onClick={toggleSetShowForm}>
+                                    <ButtonLink
+                                        size="small"
+                                        onClick={toggleSetShowForm}
+                                    >
                                         Report
                                     </ButtonLink>
                                     {showAbuseReportForm && (

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -38,6 +38,8 @@ const shiftLeft = css`
 `;
 
 const commentControlsLink = (pillar: Pillar) => css`
+    margin-top: -2px;
+
     a {
     ${textSans.small({ fontWeight: 'bold' })}
     margin-right: ${space[2]}px;

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -39,7 +39,7 @@ const shiftLeft = css`
 
 const commentControlsLink = (pillar: Pillar) => css`
     a {
-    ${textSans.xsmall({ fontWeight: 'bold' })}
+    ${textSans.small({ fontWeight: 'bold' })}
     margin-right: ${space[2]}px;
     color: ${palette[pillar][400]};
     /*

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -215,6 +215,7 @@ export const CommentContainer = ({
                     user && (
                         <div className={nestingStyles}>
                             <CommentReplyPreview
+                                pillar={pillar}
                                 commentBeingRepliedTo={commentBeingRepliedTo}
                             />
                             <CommentForm

--- a/src/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
@@ -54,7 +54,10 @@ const padding = css`
 `;
 
 export const Default = () => (
-    <CommentReplyPreview commentBeingRepliedTo={commentBeingRepliedTo} />
+    <CommentReplyPreview
+        pillar="news"
+        commentBeingRepliedTo={commentBeingRepliedTo}
+    />
 );
 Default.story = { name: 'default' };
 

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -20,8 +20,9 @@ const replyWrapperStyles = css`
     flex-direction: row;
     align-items: center;
 `;
+
 const replyArrowStyles = css`
-    fill: grey;
+    fill: ${neutral[46]};
     /*
     In order to get the arrow SVG alinged correctly with the reply text
     we need to add 2px padding to the top

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -24,10 +24,10 @@ const replyWrapperStyles = css`
 const replyArrowStyles = css`
     fill: ${neutral[46]};
     /*
-    In order to get the arrow SVG alinged correctly with the reply text
-    we need to add 2px padding to the top
-  */
-    padding-top: 2px;
+      In order to get the arrow SVG alinged correctly with the reply text
+      we need to add 2px padding to the top
+    */
+    padding-top: ${space[2]}px;
 `;
 
 const replyDisplayNameStyles = css`

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -5,6 +5,9 @@ import { textSans } from '@guardian/src-foundations/typography';
 import { neutral, space, brand } from '@guardian/src-foundations';
 
 import { CommentType } from '../../types';
+type Props = {
+    commentBeingRepliedTo: CommentType;
+};
 
 const commentControlsButtonStyles = css`
     ${textSans.small()};
@@ -91,11 +94,7 @@ const ReplyArrow = () => (
     </svg>
 );
 
-export const CommentReplyPreview = ({
-    commentBeingRepliedTo,
-}: {
-    commentBeingRepliedTo: CommentType;
-}) => {
+export const CommentReplyPreview = ({ commentBeingRepliedTo }: Props) => {
     const [displayReplyComment, setDisplayReplyComment] = useState<boolean>(
         false,
     );

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
-import { css, cx } from 'emotion';
+import { css } from 'emotion';
 
 import { textSans } from '@guardian/src-foundations/typography';
-import { neutral, space, brand } from '@guardian/src-foundations';
+import { neutral, space, text } from '@guardian/src-foundations';
 
 import { ButtonLink } from '../ButtonLink/ButtonLink';
+import { Row } from '../Row/Row';
 
 import { CommentType, Pillar } from '../../types';
 
@@ -13,36 +14,21 @@ type Props = {
     commentBeingRepliedTo: CommentType;
 };
 
-const commentControlsButtonStyles = css`
-    ${textSans.small()};
-    margin-right: ${space[2]}px;
-    color: ${brand[500]};
-    border: 0;
-`;
+const Space = ({ amount }: { amount: 1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24 }) => (
+    <div
+        className={css`
+            width: ${space[amount]}px;
+        `}
+    />
+);
 
-const replyWrapperStyles = css`
-    padding-top: ${space[1]}px;
-    padding-bottom: ${space[1]}px;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-`;
-
-const replyArrowStyles = css`
+const fillGrey = css`
     fill: ${neutral[46]};
-    /*
-      In order to get the arrow SVG alinged correctly with the reply text
-      we need to add 2px padding to the top
-    */
-    padding-top: ${space[2]}px;
 `;
 
-const replyDisplayNameStyles = css`
+const smallFontStyles = css`
     ${textSans.small()};
-    padding-top: ${space[1]}px;
-    padding-bottom: ${space[1]}px;
-    padding-right: ${space[1]}px;
-    margin-right: ${space[2]}px;
+    line-height: 19px;
 `;
 
 const replyPreviewHeaderStyle = css`
@@ -82,14 +68,8 @@ const commentStyles = css`
     }
 `;
 
-const hideCommentButtonStyles = css`
-    :hover {
-        cursor: pointer;
-    }
-`;
-const previewHideCommentButtonStyles = css`
-    background-color: inherit;
-    padding-left: 0px;
+const blueLink = css`
+    color: ${text.anchorPrimary};
 `;
 
 const ReplyArrow = () => (
@@ -107,20 +87,22 @@ export const CommentReplyPreview = ({
     );
     return (
         <>
-            <div className={replyWrapperStyles}>
-                <div className={replyArrowStyles}>
+            <Row>
+                <div className={fillGrey}>
                     <ReplyArrow />
                 </div>
-                <div className={replyDisplayNameStyles}>
+                <Space amount={1} />
+                <div className={smallFontStyles}>
                     {commentBeingRepliedTo.userProfile.displayName}
                 </div>
+                <Space amount={3} />
                 <ButtonLink
                     pillar={pillar}
                     onClick={() => setDisplayReplyComment(!displayReplyComment)}
                 >
                     {displayReplyComment ? 'Hide Comment' : 'Show comment'}
                 </ButtonLink>
-            </div>
+            </Row>
             {displayReplyComment && (
                 <Preview
                     commentBeingRepliedTo={commentBeingRepliedTo}
@@ -153,18 +135,12 @@ export const Preview = ({
                     __html: commentBeingRepliedTo.body || '',
                 }}
             />
-            <div>
-                <button
-                    className={cx(
-                        hideCommentButtonStyles,
-                        commentControlsButtonStyles,
-                        previewHideCommentButtonStyles,
-                    )}
-                    onClick={() => setDisplayReplyComment(!displayReplyComment)}
-                >
-                    {displayReplyComment ? 'Hide Comment' : 'Show comment'}
-                </button>
-            </div>
+
+            <ButtonLink
+                onClick={() => setDisplayReplyComment(!displayReplyComment)}
+            >
+                <span className={blueLink}>Hide Comment</span>
+            </ButtonLink>
         </div>
     );
 };

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -4,8 +4,12 @@ import { css, cx } from 'emotion';
 import { textSans } from '@guardian/src-foundations/typography';
 import { neutral, space, brand } from '@guardian/src-foundations';
 
-import { CommentType } from '../../types';
+import { ButtonLink } from '../ButtonLink/ButtonLink';
+
+import { CommentType, Pillar } from '../../types';
+
 type Props = {
+    pillar: Pillar;
     commentBeingRepliedTo: CommentType;
 };
 
@@ -94,7 +98,10 @@ const ReplyArrow = () => (
     </svg>
 );
 
-export const CommentReplyPreview = ({ commentBeingRepliedTo }: Props) => {
+export const CommentReplyPreview = ({
+    pillar,
+    commentBeingRepliedTo,
+}: Props) => {
     const [displayReplyComment, setDisplayReplyComment] = useState<boolean>(
         false,
     );
@@ -107,15 +114,12 @@ export const CommentReplyPreview = ({ commentBeingRepliedTo }: Props) => {
                 <div className={replyDisplayNameStyles}>
                     {commentBeingRepliedTo.userProfile.displayName}
                 </div>
-                <span
-                    className={cx(
-                        hideCommentButtonStyles,
-                        commentControlsButtonStyles,
-                    )}
+                <ButtonLink
+                    pillar={pillar}
                     onClick={() => setDisplayReplyComment(!displayReplyComment)}
                 >
                     {displayReplyComment ? 'Hide Comment' : 'Show comment'}
-                </span>
+                </ButtonLink>
             </div>
             {displayReplyComment && (
                 <Preview


### PR DESCRIPTION
## What does this change?
Refactors the `CommentReplyPreview` component to use the new `ButtonLink` and other helper components in place of custom code

Also adjusts some colouring, sizing and alignment issues

## Before
![Screenshot 2020-04-08 at 22 59 20](https://user-images.githubusercontent.com/1336821/78837858-e174ea80-79ec-11ea-8186-47e3de9e17c1.jpg)

## After
![Screenshot 2020-04-08 at 22 58 23](https://user-images.githubusercontent.com/1336821/78837875-eb96e900-79ec-11ea-9b07-972854b7f3bd.jpg)



## Why?
To make the code more readable and provide a consistent look and feel to the styles

