### PR TITLE
Restore scoping span

### DIFF
--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -546,7 +546,8 @@ export const Comment = ({
                                                             }
                                                             iconSide="left"
                                                         >
-                                                            Reply
+                                                            {/* We use this span to scope the styling */}
+                                                            <span>Reply</span>
                                                         </Link>
                                                     </div>
                                                 )}


### PR DESCRIPTION
## What does this change?
Adds back the span that I deleted without realising what it's for

## Why?
We needed the span to ensure style overrides only get applied to the text, not the svg
