### PR TITLE
Use pillar to style dropdown check

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -386,6 +386,7 @@ export const App = ({
                     />
                 )}
                 <Filters
+                    pillar={pillar}
                     filters={filters}
                     onFilterChange={onFilterChange}
                     totalPages={totalPages}

--- a/src/components/Filters/Filters.stories.tsx
+++ b/src/components/Filters/Filters.stories.tsx
@@ -14,6 +14,7 @@ export const Default = () => {
     });
     return (
         <Filters
+            pillar="culture"
             filters={filters}
             onFilterChange={setFilters}
             totalPages={5}

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -11,10 +11,12 @@ import {
     OrderByType,
     ThreadsType,
     PageSizeType,
+    Pillar,
 } from '../../types';
 
 type Props = {
     filters: FilterOptions;
+    pillar: Pillar;
     onFilterChange: (newFilterObject: FilterOptions) => void;
     totalPages: number;
     commentCount: number;
@@ -51,6 +53,7 @@ const filterPadding = css`
 
 export const Filters = ({
     filters,
+    pillar,
     onFilterChange,
     totalPages,
     commentCount,
@@ -60,7 +63,7 @@ export const Filters = ({
             <Dropdown
                 id="order-by-dropdown"
                 label="Sort by"
-                pillar="news"
+                pillar={pillar}
                 options={[
                     {
                         title: 'Newest',
@@ -91,7 +94,7 @@ export const Filters = ({
             <Dropdown
                 id="page-size-dropdown"
                 label="Per page"
-                pillar="news"
+                pillar={pillar}
                 options={[
                     {
                         title: '25',
@@ -125,7 +128,7 @@ export const Filters = ({
             <Dropdown
                 id="threads-dropdown"
                 label="Display threads"
-                pillar="news"
+                pillar={pillar}
                 options={[
                     {
                         title: 'Collapsed',


### PR DESCRIPTION
## What does this change?
Changes the colour of the checkmark used for selected Dropdown items based on `pillar`

![Screenshot 2020-04-09 at 16 38 23](https://user-images.githubusercontent.com/1336821/78913195-8db3e100-7a80-11ea-80d8-8b632b3b5670.jpg)


## Why?
To enhance the pillar styling of discussion

## Link to supporting Trello card
https://trello.com/c/IQ0WaZDC/1429-style-dropdown-by-pillar
