### PR TITLE
Scroll to filters

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -263,6 +263,7 @@ export const App = ({
     };
 
     const onPageChange = (page: number) => {
+        document.getElementById('comment-filters')?.scrollIntoView();
         setPage(page);
     };
 

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -55,7 +55,7 @@ export const Filters = ({
     totalPages,
     commentCount,
 }: Props) => (
-    <div className={filterBar}>
+    <div id="comment-filters" className={filterBar}>
         <div className={filterPadding}>
             <Dropdown
                 id="order-by-dropdown"


### PR DESCRIPTION
## What does this change?
When a reader navigates to a new page, the scroll position of the window is set to the top of the comments list

![2020-04-09 18 51 20](https://user-images.githubusercontent.com/1336821/78925450-57339180-7a93-11ea-9b8c-1e2a237e40df.gif)


## Why?
So the window position is reset to the first item in the list that the reader is navigating

## Link to supporting Trello card
https://trello.com/c/EZwWaRsV/1427-scroll-to-top-on-pagination