### PR TITLE
Publish config should define access as public

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Once you've cloned the repo, run
 ### Publishing changes to NPM
 
 You need a @guardian scoped NPM user account to be able to publish changes. You then will need to login to this NPM account locally on your maching. Once authenticated, run:
-`yarn build && yarn publish --access public` updating the version number as required
+`yarn build && yarn publish` updating the version number as required. It will publish as `public` as The Guardian Organisation does not have private repos.
 
 ### Connection this package to DCR/Frontend to test local changes
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "main": "build/App.js",
     "module": "build/App.esm.js",
     "publishConfig": {
-        "access": "restricted"
+        "access": "public"
     },
     "bugs": {
         "url": "https://github.com/guardian/discussion-rendering/issues"


### PR DESCRIPTION
## What does this change?
Sets publishConfig `access` as `public`.

https://docs.npmjs.com/misc/config#access

**Access**
**Default: restricted**
**Type: Access**
_When publishing scoped packages, the access level defaults to restricted. If you want your scoped package to be publicly viewable (and installable) set --access=public. The only valid values for access are public and restricted. Unscoped packages always have an access level of public._

## Why?

Means we don't have to set `--access public` when publishing.
