### PR TITLE
Upgrade emotion/core dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
         "timeago.js": "^4.0.2"
     },
     "peerDependencies": {
-        "@emotion/core": "^10.0.27",
-        "emotion": "^10.0.27",
+        "@emotion/core": "^10.0.28",
         "@guardian/src-button": "^0.17.0",
         "@guardian/src-foundations": "^0.17.0",
         "@guardian/src-link": "^0.17.0",
         "@guardian/src-svgs": "^0.17.0",
         "@guardian/src-text-input": "^0.17.0",
+        "emotion": "^10.0.27",
         "react-dom": "^16.12.0",
         "regenerator-runtime": "^0.13.3"
     },
@@ -41,7 +41,6 @@
         "@babel/preset-react": "^7.0.0",
         "@babel/preset-typescript": "^7.3.3",
         "@emotion/babel-preset-css-prop": "^10.0.14",
-        "@emotion/core": "^10.0.27",
         "@guardian/src-button": "^0.17.0",
         "@guardian/src-foundations": "^0.17.0",
         "@guardian/src-link": "^0.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1847,10 +1847,22 @@
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
 
-"@emotion/core@^10.0.20", "@emotion/core@^10.0.27":
+"@emotion/core@^10.0.20":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.27.tgz#7c3f78be681ab2273f3bf11ca3e2edc4a9dd1fdc"
   integrity sha512-XbD5R36pVbohQMnKfajHv43g8EbN4NHdF6Zh9zg/C0nr0jqwOw3gYnC07Xj3yG43OYSRyrGsoQ5qPwc8ycvLZw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/cache" "^10.0.27"
+    "@emotion/css" "^10.0.27"
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/sheet" "0.9.4"
+    "@emotion/utils" "0.11.3"
+
+"@emotion/core@^10.0.28":
+  version "10.0.28"
+  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.28.tgz#bb65af7262a234593a9e952c041d0f1c9b9bef3d"
+  integrity sha512-pH8UueKYO5jgg0Iq+AmCLxBsvuGtvlmiDCOuv8fGNYn3cowFpLN98L8zO56U0H1PjDIyAlXymgL3Wu7u7v6hbA==
   dependencies:
     "@babel/runtime" "^7.5.5"
     "@emotion/cache" "^10.0.27"


### PR DESCRIPTION
## What does this change?

Upgrades the `emotion/core` dependency to latest in `peerDependencies` (and removes from `devDependencies` as doesn't need to be in both). 

## Why?

Will upgrade in `dotcom-rendering` too, to dedupe dependency.


