### PR TITLE
Fix dependencies for discussion-rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "build/**/*"
     ],
     "dependencies": {
+        "react-focus-lock": "^2.2.1",
         "timeago.js": "^4.0.2"
     },
     "peerDependencies": {
@@ -32,8 +33,7 @@
         "@guardian/src-text-input": "^0.17.0",
         "emotion": "^10.0.27",
         "react": "^16.13.1",
-        "react-dom": "^16.12.0",
-        "regenerator-runtime": "^0.13.3"
+        "react-dom": "^16.12.0"
     },
     "devDependencies": {
         "@babel/core": "^7.5.5",
@@ -65,9 +65,7 @@
         "prettier": "^1.19.1",
         "pretty-quick": "^2.0.1",
         "react-dom": "^16.12.0",
-        "react-focus-lock": "^2.2.1",
         "react-scripts": "3.3.0",
-        "regenerator-runtime": "^0.13.3",
         "rollup": "^1.17.0",
         "rollup-plugin-babel": "^4.3.3",
         "rollup-plugin-clear": "^2.0.7",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
         "build/**/*"
     ],
     "dependencies": {
-        "rollup-plugin-clear": "^2.0.7",
-        "rollup-plugin-visualizer": "^4.0.4",
         "timeago.js": "^4.0.2"
     },
     "peerDependencies": {
@@ -72,8 +70,10 @@
         "regenerator-runtime": "^0.13.3",
         "rollup": "^1.17.0",
         "rollup-plugin-babel": "^4.3.3",
+        "rollup-plugin-clear": "^2.0.7",
         "rollup-plugin-commonjs": "^10.0.2",
         "rollup-plugin-node-resolve": "^5.2.0",
+        "rollup-plugin-visualizer": "^4.0.4",
         "storybook-chromatic": "^3.5.2",
         "typescript": "^3.7.5"
     },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,6 +24,10 @@ module.exports = {
         ...Object.keys(pkg.dependencies || {}),
         ...Object.keys(pkg.peerDependencies || {}),
         'prop-types',
+        // Nested src-foundations
+        '@guardian/src-foundations/mq',
+        '@guardian/src-foundations/palette',
+        '@guardian/src-foundations/typography',
     ],
     plugins: [
         clear({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { css } from 'emotion';
 
-import 'regenerator-runtime/runtime';
-
 import {
     CommentType,
     FilterOptions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1859,18 +1859,6 @@
     "@emotion/sheet" "0.9.4"
     "@emotion/utils" "0.11.3"
 
-"@emotion/core@^10.0.28":
-  version "10.0.28"
-  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.28.tgz#bb65af7262a234593a9e952c041d0f1c9b9bef3d"
-  integrity sha512-pH8UueKYO5jgg0Iq+AmCLxBsvuGtvlmiDCOuv8fGNYn3cowFpLN98L8zO56U0H1PjDIyAlXymgL3Wu7u7v6hbA==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    "@emotion/cache" "^10.0.27"
-    "@emotion/css" "^10.0.27"
-    "@emotion/serialize" "^0.11.15"
-    "@emotion/sheet" "0.9.4"
-    "@emotion/utils" "0.11.3"
-
 "@emotion/css@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"


### PR DESCRIPTION
## What does this change?

- Moves `react-focus-lock` to dependencies as it's not dev (and we don't expect it to be peer)
- Remove regnerator-runtime
- Add nested src-foundations to externals
- Move rollup plugins to dev dependencies

## Why?

Bundling the correct things
