### PR TITLE
Add Initial OphanTrackingNames Type

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -351,13 +351,13 @@ export const App = ({
                     className={css`
                         width: 250px;
                     `}
-                    data-link-name="more-comments"
                 >
                     <PillarButton
                         pillar={pillar}
                         onClick={() => setIsExpanded(true)}
                         icon={<PlusSVG />}
                         iconSide="left"
+                        linkName="more-comments"
                     >
                         View more comments
                     </PillarButton>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -367,7 +367,7 @@ export const App = ({
 
     return (
         <Column>
-            <>
+            <div data-component="discussion">
                 {user && !isClosedForComments && (
                     <CommentForm
                         pillar={pillar}
@@ -445,7 +445,7 @@ export const App = ({
                         />
                     </footer>
                 )}
-            </>
+            </div>
         </Column>
     );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -351,6 +351,7 @@ export const App = ({
                     className={css`
                         width: 250px;
                     `}
+                    data-link-name="more-comments"
                 >
                     <PillarButton
                         pillar={pillar}

--- a/src/components/AbuseReportForm/AbuseReportForm.tsx
+++ b/src/components/AbuseReportForm/AbuseReportForm.tsx
@@ -274,6 +274,7 @@ export const AbuseReportForm: React.FC<{
                         iconSide="right"
                         icon={<SvgClose />}
                         onClick={toggleSetShowForm}
+                        data-link-name="cancel-report-abuse"
                     />
                 </div>
             </form>

--- a/src/components/AbuseReportForm/AbuseReportForm.tsx
+++ b/src/components/AbuseReportForm/AbuseReportForm.tsx
@@ -251,7 +251,11 @@ export const AbuseReportForm: React.FC<{
                 </div>
 
                 <div>
-                    <Button type="submit" size="small">
+                    <Button
+                        type="submit"
+                        size="small"
+                        data-link-name="Post report abuse"
+                    >
                         Report
                     </Button>
                 </div>

--- a/src/components/ButtonLink/ButtonLink.stories.tsx
+++ b/src/components/ButtonLink/ButtonLink.stories.tsx
@@ -24,7 +24,7 @@ export const Single = () => (
             alert('Clicked!');
         }}
         pillar="lifestyle"
-        linkName="ophanLink"
+        linkName=""
     >
         I'm a button but I look like a link. Click me
     </ButtonLink>
@@ -38,7 +38,7 @@ export const Small = () => (
         }}
         size="small"
         pillar="lifestyle"
-        linkName="ophanLink"
+        linkName=""
     >
         I'm small
     </ButtonLink>
@@ -47,15 +47,15 @@ Small.story = { name: 'a small button' };
 
 export const Group = () => (
     <Row>
-        <ButtonLink onClick={() => {}} pillar="culture" linkName="ophanLink">
+        <ButtonLink onClick={() => {}} pillar="culture" linkName="">
             Culture one
         </ButtonLink>
         <Space amount={3} />
-        <ButtonLink onClick={() => {}} pillar="news" linkName="ophanLink">
+        <ButtonLink onClick={() => {}} pillar="news" linkName="">
             News two
         </ButtonLink>
         <Space amount={3} />
-        <ButtonLink onClick={() => {}} pillar="sport" linkName="ophanLink">
+        <ButtonLink onClick={() => {}} pillar="sport" linkName="">
             Sport three
         </ButtonLink>
     </Row>
@@ -68,7 +68,7 @@ export const IconLeft = () => (
         pillar="news"
         icon={<SvgCheckmark />}
         iconSide="left"
-        linkName="ophanLink"
+        linkName=""
     >
         Check to the left
     </ButtonLink>
@@ -81,7 +81,7 @@ export const IconRight = () => (
         pillar="news"
         icon={<SvgCheckmark />}
         iconSide="right"
-        linkName="ophanLink"
+        linkName=""
     >
         Check to the right
     </ButtonLink>
@@ -93,7 +93,7 @@ export const Grey = () => (
         onClick={() => {
             alert('Clicked!');
         }}
-        linkName="ophanLink"
+        linkName=""
     >
         This is how I look when no pillar is passed
     </ButtonLink>
@@ -107,7 +107,7 @@ export const Background = () => (
             padding: 20px;
         `}
     >
-        <ButtonLink onClick={() => {}} pillar="lifestyle" linkName="ophanLink">
+        <ButtonLink onClick={() => {}} pillar="lifestyle" linkName="">
             How do I look on a grey background?
         </ButtonLink>
     </div>

--- a/src/components/ButtonLink/ButtonLink.stories.tsx
+++ b/src/components/ButtonLink/ButtonLink.stories.tsx
@@ -24,6 +24,7 @@ export const Single = () => (
             alert('Clicked!');
         }}
         pillar="lifestyle"
+        linkName="ophanLink"
     >
         I'm a button but I look like a link. Click me
     </ButtonLink>
@@ -37,6 +38,7 @@ export const Small = () => (
         }}
         size="small"
         pillar="lifestyle"
+        linkName="ophanLink"
     >
         I'm small
     </ButtonLink>
@@ -45,15 +47,15 @@ Small.story = { name: 'a small button' };
 
 export const Group = () => (
     <Row>
-        <ButtonLink onClick={() => {}} pillar="culture">
+        <ButtonLink onClick={() => {}} pillar="culture" linkName="ophanLink">
             Culture one
         </ButtonLink>
         <Space amount={3} />
-        <ButtonLink onClick={() => {}} pillar="news">
+        <ButtonLink onClick={() => {}} pillar="news" linkName="ophanLink">
             News two
         </ButtonLink>
         <Space amount={3} />
-        <ButtonLink onClick={() => {}} pillar="sport">
+        <ButtonLink onClick={() => {}} pillar="sport" linkName="ophanLink">
             Sport three
         </ButtonLink>
     </Row>
@@ -66,6 +68,7 @@ export const IconLeft = () => (
         pillar="news"
         icon={<SvgCheckmark />}
         iconSide="left"
+        linkName="ophanLink"
     >
         Check to the left
     </ButtonLink>
@@ -78,6 +81,7 @@ export const IconRight = () => (
         pillar="news"
         icon={<SvgCheckmark />}
         iconSide="right"
+        linkName="ophanLink"
     >
         Check to the right
     </ButtonLink>
@@ -89,6 +93,7 @@ export const Grey = () => (
         onClick={() => {
             alert('Clicked!');
         }}
+        linkName="ophanLink"
     >
         This is how I look when no pillar is passed
     </ButtonLink>
@@ -102,7 +107,7 @@ export const Background = () => (
             padding: 20px;
         `}
     >
-        <ButtonLink onClick={() => {}} pillar="lifestyle">
+        <ButtonLink onClick={() => {}} pillar="lifestyle" linkName="ophanLink">
             How do I look on a grey background?
         </ButtonLink>
     </div>

--- a/src/components/ButtonLink/ButtonLink.tsx
+++ b/src/components/ButtonLink/ButtonLink.tsx
@@ -14,6 +14,7 @@ type Props = {
     icon?: JSX.Element;
     iconSide?: 'left' | 'right';
     children: string | JSX.Element;
+    linkName: string;
 };
 
 const buttonOverrides = (size: 'small' | 'default', pillar?: Pillar) => css`
@@ -47,6 +48,7 @@ export const ButtonLink = ({
     icon,
     iconSide,
     children,
+    linkName,
 }: Props) => (
     <div className={cx(buttonOverrides(size, pillar))}>
         <Button
@@ -55,6 +57,7 @@ export const ButtonLink = ({
             onClick={onClick}
             icon={icon}
             iconSide={iconSide}
+            data-link-name={linkName}
         >
             {children}
         </Button>

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -577,6 +577,11 @@ export const Comment = ({
                                                             ? unPick
                                                             : pick
                                                     }
+                                                    linkName={
+                                                        isHighlighted
+                                                            ? 'unpick-comment'
+                                                            : 'pick-comment'
+                                                    }
                                                 >
                                                     {isHighlighted
                                                         ? 'Unpick'

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -613,6 +613,7 @@ export const Comment = ({
                                     <ButtonLink
                                         size="small"
                                         onClick={toggleSetShowForm}
+                                        linkName="Open report abuse"
                                     >
                                         Report
                                     </ButtonLink>

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -551,7 +551,9 @@ export const Comment = ({
                                                             iconSide="left"
                                                         >
                                                             {/* We use this span to scope the styling */}
-                                                            <span>Reply</span>
+                                                            <span data-link-name="reply to comment">
+                                                                Reply
+                                                            </span>
                                                         </Link>
                                                     </div>
                                                 )}

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -480,6 +480,7 @@ export const Comment = ({
                                             comment.userProfile.userId,
                                         )
                                     }
+                                    linkName="unmute-user"
                                 >
                                     Unmute?
                                 </ButtonLink>

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -530,6 +530,7 @@ export const Comment = ({
                                                                 <ReplyArrow />
                                                             }
                                                             iconSide="left"
+                                                            linkName="reply to comment"
                                                         >
                                                             Reply
                                                         </ButtonLink>

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -602,6 +602,7 @@ export const Comment = ({
                                                 )
                                             }
                                             size="small"
+                                            linkName="mute-user"
                                         >
                                             Mute
                                         </ButtonLink>

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -188,6 +188,7 @@ export const CommentContainer = ({
                                     <button
                                         onClick={() => expand(comment.id)}
                                         className={buttonStyles(pillar)}
+                                        data-link-name="Show more replies"
                                     >
                                         <Row>
                                             <Plus />

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -429,7 +429,11 @@ export const CommentForm = ({
                 <div className={bottomContainer}>
                     <Row>
                         <>
-                            <PillarButton pillar={pillar} type="submit">
+                            <PillarButton
+                                pillar={pillar}
+                                type="submit"
+                                linkName="post comment"
+                            >
                                 Post your comment
                             </PillarButton>
                             {(isActive || body) && (
@@ -439,6 +443,7 @@ export const CommentForm = ({
                                         pillar={pillar}
                                         onClick={fetchShowPreview}
                                         priority="secondary"
+                                        linkName="preview-comment"
                                     >
                                         Preview
                                     </PillarButton>
@@ -448,6 +453,7 @@ export const CommentForm = ({
                                         pillar={pillar}
                                         onClick={resetForm}
                                         priority="subdued"
+                                        linkName="cancel-post-comment"
                                     >
                                         Cancel
                                     </PillarButton>

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -469,6 +469,7 @@ export const CommentForm = ({
                                     transformText(boldString);
                                 }}
                                 className={commentAddOns}
+                                data-link-name="formatting-controls-bold"
                             >
                                 B
                             </button>
@@ -478,6 +479,7 @@ export const CommentForm = ({
                                     transformText(italicsString);
                                 }}
                                 className={commentAddOns}
+                                data-link-name="formatting-controls-italic"
                             >
                                 i
                             </button>
@@ -487,6 +489,7 @@ export const CommentForm = ({
                                     transformText(quoteString);
                                 }}
                                 className={commentAddOns}
+                                data-link-name="formatting-controls-quote"
                             >
                                 "
                             </button>
@@ -496,6 +499,7 @@ export const CommentForm = ({
                                     transformLink();
                                 }}
                                 className={commentAddOns}
+                                data-link-name="formatting-controls-link"
                             >
                                 Link
                             </button>

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -99,6 +99,7 @@ export const CommentReplyPreview = ({
                 <ButtonLink
                     pillar={pillar}
                     onClick={() => setDisplayReplyComment(!displayReplyComment)}
+                    linkName={displayReplyComment ? 'reply-comment-hide' : 'reply-comment-show'}}
                 >
                     {displayReplyComment ? 'Hide Comment' : 'Show comment'}
                 </ButtonLink>

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -143,6 +143,7 @@ export const Preview = ({
 
             <ButtonLink
                 onClick={() => setDisplayReplyComment(!displayReplyComment)}
+                linkName="hide-comment"
             >
                 <span className={blueLink}>Hide Comment</span>
             </ButtonLink>

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -99,7 +99,11 @@ export const CommentReplyPreview = ({
                 <ButtonLink
                     pillar={pillar}
                     onClick={() => setDisplayReplyComment(!displayReplyComment)}
-                    linkName={displayReplyComment ? 'reply-comment-hide' : 'reply-comment-show'}}
+                    linkName={
+                        displayReplyComment
+                            ? 'reply-comment-hide'
+                            : 'reply-comment-show'
+                    }
                 >
                     {displayReplyComment ? 'Hide Comment' : 'Show comment'}
                 </ButtonLink>

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -130,6 +130,7 @@ export const FirstCommentWelcome = ({
                     <PillarButton
                         pillar={pillar}
                         onClick={() => submitForm(userName)}
+                        linkName="post comment"
                     >
                         Post your comment
                     </PillarButton>
@@ -142,6 +143,7 @@ export const FirstCommentWelcome = ({
                         pillar={pillar}
                         priority="subdued"
                         onClick={cancelSubmit}
+                        linkName="cancel-post-comment"
                     >
                         Cancel
                     </PillarButton>

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Pagination } from './Pagination';
+import { render } from '@testing-library/react';
+
+const DEFAULT_FILTERS: FilterOptions = {
+    orderBy: 'newest',
+    pageSize: 25,
+};
+
+describe('Pagination', () => {
+    it('Render Ophan Data Components as expected', () => {
+        const { asFragment } = render(
+            <Pagination
+                totalPages={9}
+                currentPage={2}
+                setCurrentPage={() => {}}
+                filters={DEFAULT_FILTERS}
+                commentCount={56}
+            />,
+        );
+
+        expect(
+            asFragment().querySelectorAll(
+                '[data-link-name="Pagination view page 2"]',
+            ).length,
+        ).toBe(1); // The number is still a button
+
+        expect(
+            asFragment().querySelectorAll(
+                '[data-link-name="Pagination view page 1"]',
+            ).length,
+        ).toBe(2); // Both the number and the back button
+
+        expect(
+            asFragment().querySelectorAll(
+                '[data-link-name="Pagination view page 3"]',
+            ).length,
+        ).toBe(2); // Both the number and the forward button
+
+        expect(
+            asFragment().querySelectorAll(
+                '[data-link-name="Pagination view page 5"]',
+            ).length,
+        ).toBe(0); // Page five should be hidden
+
+        expect(
+            asFragment().querySelectorAll(
+                '[data-link-name="Pagination view page 9"]',
+            ).length,
+        ).toBe(1); // Page nine should be the last number
+
+        expect(
+            asFragment().querySelectorAll(
+                '[data-link-name="Pagination view page 10"]',
+            ).length,
+        ).toBe(0); // Page 10 doesn't exist
+    });
+});

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -121,6 +121,7 @@ const Forward = ({
         key={'last'}
         className={cx(chevronStyles(false), rotateSvg)}
         onClick={() => setCurrentPage(currentPage + 1)}
+        data-link-name={`Pagination view page ${currentPage + 1}`}
     >
         <ChevronBack />
     </button>
@@ -132,17 +133,20 @@ const Back = ({
 }: {
     currentPage: number;
     setCurrentPage: Function;
-}) => (
-    <button
-        key={'last'}
-        className={chevronStyles(false)}
-        onClick={() =>
-            setCurrentPage(currentPage - 1 < 0 ? 0 : currentPage - 1)
-        }
-    >
-        <ChevronBack />
-    </button>
-);
+}) => {
+    const newPage = currentPage - 1 < 0 ? 0 : currentPage - 1;
+
+    return (
+        <button
+            key={'last'}
+            className={chevronStyles(false)}
+            onClick={() => setCurrentPage(newPage)}
+            data-link-name={`Pagination view page ${newPage}`}
+        >
+            <ChevronBack />
+        </button>
+    );
+};
 
 const PageButton = ({
     currentPage,
@@ -157,6 +161,7 @@ const PageButton = ({
         key={currentPage}
         className={buttonStyles(isSelected)}
         onClick={() => setCurrentPage(currentPage)}
+        data-link-name={`Pagination view page ${currentPage}`}
     >
         {currentPage}
     </button>

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -134,7 +134,7 @@ const Back = ({
     currentPage: number;
     setCurrentPage: Function;
 }) => {
-    const newPage = currentPage - 1 < 0 ? 0 : currentPage - 1;
+    const newPage = Math.max(0, currentPage - 1);
 
     return (
         <button

--- a/src/components/PillarButton/PillarButton.stories.tsx
+++ b/src/components/PillarButton/PillarButton.stories.tsx
@@ -25,7 +25,7 @@ export const EachPillar = () => (
                 alert('Clicked!');
             }}
             pillar="lifestyle"
-            linkName="ophanLinkName"
+            linkName=""
         >
             Lifestyle
         </PillarButton>
@@ -35,7 +35,7 @@ export const EachPillar = () => (
                 alert('Clicked!');
             }}
             pillar="sport"
-            linkName="ophanLinkName"
+            linkName=""
         >
             Sport
         </PillarButton>
@@ -45,7 +45,7 @@ export const EachPillar = () => (
                 alert('Clicked!');
             }}
             pillar="news"
-            linkName="ophanLinkName"
+            linkName=""
         >
             News
         </PillarButton>
@@ -55,7 +55,7 @@ export const EachPillar = () => (
                 alert('Clicked!');
             }}
             pillar="opinion"
-            linkName="ophanLinkName"
+            linkName=""
         >
             Opinion
         </PillarButton>
@@ -65,7 +65,7 @@ export const EachPillar = () => (
                 alert('Clicked!');
             }}
             pillar="culture"
-            linkName="ophanLinkName"
+            linkName=""
         >
             Culture
         </PillarButton>
@@ -95,7 +95,7 @@ export const IconRight = () => (
         pillar="sport"
         icon={<SvgCheckmark />}
         iconSide="right"
-        linkName="ophanLinkName"
+        linkName=""
     >
         Right
     </PillarButton>
@@ -109,7 +109,7 @@ export const Secondary = () => (
             }}
             pillar="lifestyle"
             priority="secondary"
-            linkName="ophanLinkName"
+            linkName=""
         >
             Lifestyle
         </PillarButton>
@@ -120,7 +120,7 @@ export const Secondary = () => (
             }}
             pillar="sport"
             priority="secondary"
-            linkName="ophanLinkName"
+            linkName=""
         >
             Sport
         </PillarButton>
@@ -131,7 +131,7 @@ export const Secondary = () => (
             }}
             pillar="news"
             priority="secondary"
-            linkName="ophanLinkName"
+            linkName=""
         >
             News
         </PillarButton>
@@ -142,7 +142,7 @@ export const Secondary = () => (
             }}
             pillar="opinion"
             priority="secondary"
-            linkName="ophanLinkName"
+            linkName=""
         >
             Opinion
         </PillarButton>
@@ -153,7 +153,7 @@ export const Secondary = () => (
             }}
             pillar="culture"
             priority="secondary"
-            linkName="ophanLinkName"
+            linkName=""
         >
             Culture
         </PillarButton>
@@ -169,7 +169,7 @@ export const Subdued = () => (
             }}
             pillar="lifestyle"
             priority="subdued"
-            linkName="ophanLinkName"
+            linkName=""
         >
             Lifestyle
         </PillarButton>
@@ -180,7 +180,7 @@ export const Subdued = () => (
             }}
             pillar="sport"
             priority="subdued"
-            linkName="ophanLinkName"
+            linkName=""
         >
             Sport
         </PillarButton>
@@ -191,7 +191,7 @@ export const Subdued = () => (
             }}
             pillar="news"
             priority="subdued"
-            linkName="ophanLinkName"
+            linkName=""
         >
             News
         </PillarButton>
@@ -202,7 +202,7 @@ export const Subdued = () => (
             }}
             pillar="opinion"
             priority="subdued"
-            linkName="ophanLinkName"
+            linkName=""
         >
             Opinion
         </PillarButton>
@@ -213,7 +213,7 @@ export const Subdued = () => (
             }}
             pillar="culture"
             priority="subdued"
-            linkName="ophanLinkName"
+            linkName=""
         >
             Culture
         </PillarButton>

--- a/src/components/PillarButton/PillarButton.stories.tsx
+++ b/src/components/PillarButton/PillarButton.stories.tsx
@@ -25,6 +25,7 @@ export const EachPillar = () => (
                 alert('Clicked!');
             }}
             pillar="lifestyle"
+            linkName="ophanLinkName"
         >
             Lifestyle
         </PillarButton>
@@ -34,6 +35,7 @@ export const EachPillar = () => (
                 alert('Clicked!');
             }}
             pillar="sport"
+            linkName="ophanLinkName"
         >
             Sport
         </PillarButton>
@@ -43,6 +45,7 @@ export const EachPillar = () => (
                 alert('Clicked!');
             }}
             pillar="news"
+            linkName="ophanLinkName"
         >
             News
         </PillarButton>
@@ -52,6 +55,7 @@ export const EachPillar = () => (
                 alert('Clicked!');
             }}
             pillar="opinion"
+            linkName="ophanLinkName"
         >
             Opinion
         </PillarButton>
@@ -61,6 +65,7 @@ export const EachPillar = () => (
                 alert('Clicked!');
             }}
             pillar="culture"
+            linkName="ophanLinkName"
         >
             Culture
         </PillarButton>
@@ -90,6 +95,7 @@ export const IconRight = () => (
         pillar="sport"
         icon={<SvgCheckmark />}
         iconSide="right"
+        linkName="ophanLinkName"
     >
         Right
     </PillarButton>
@@ -103,6 +109,7 @@ export const Secondary = () => (
             }}
             pillar="lifestyle"
             priority="secondary"
+            linkName="ophanLinkName"
         >
             Lifestyle
         </PillarButton>
@@ -113,6 +120,7 @@ export const Secondary = () => (
             }}
             pillar="sport"
             priority="secondary"
+            linkName="ophanLinkName"
         >
             Sport
         </PillarButton>
@@ -123,6 +131,7 @@ export const Secondary = () => (
             }}
             pillar="news"
             priority="secondary"
+            linkName="ophanLinkName"
         >
             News
         </PillarButton>
@@ -133,6 +142,7 @@ export const Secondary = () => (
             }}
             pillar="opinion"
             priority="secondary"
+            linkName="ophanLinkName"
         >
             Opinion
         </PillarButton>
@@ -143,6 +153,7 @@ export const Secondary = () => (
             }}
             pillar="culture"
             priority="secondary"
+            linkName="ophanLinkName"
         >
             Culture
         </PillarButton>
@@ -158,6 +169,7 @@ export const Subdued = () => (
             }}
             pillar="lifestyle"
             priority="subdued"
+            linkName="ophanLinkName"
         >
             Lifestyle
         </PillarButton>
@@ -168,6 +180,7 @@ export const Subdued = () => (
             }}
             pillar="sport"
             priority="subdued"
+            linkName="ophanLinkName"
         >
             Sport
         </PillarButton>
@@ -178,6 +191,7 @@ export const Subdued = () => (
             }}
             pillar="news"
             priority="subdued"
+            linkName="ophanLinkName"
         >
             News
         </PillarButton>
@@ -188,6 +202,7 @@ export const Subdued = () => (
             }}
             pillar="opinion"
             priority="subdued"
+            linkName="ophanLinkName"
         >
             Opinion
         </PillarButton>
@@ -198,6 +213,7 @@ export const Subdued = () => (
             }}
             pillar="culture"
             priority="subdued"
+            linkName="ophanLinkName"
         >
             Culture
         </PillarButton>

--- a/src/components/PillarButton/PillarButton.tsx
+++ b/src/components/PillarButton/PillarButton.tsx
@@ -15,6 +15,7 @@ type Props = {
     priority?: 'primary' | 'secondary' | 'subdued';
     icon?: JSX.Element;
     iconSide?: 'left' | 'right';
+    linkName: string;
 };
 
 // Why key in Pillar? https://github.com/Microsoft/TypeScript/issues/24220#issuecomment-390063153
@@ -92,6 +93,7 @@ export const PillarButton = ({
     children,
     icon,
     iconSide,
+    linkName,
 }: Props) => (
     <div className={buttonOverrides(pillar, priority)}>
         <Button
@@ -101,6 +103,7 @@ export const PillarButton = ({
             type={type}
             icon={icon}
             iconSide={iconSide}
+            data-link-name={linkName}
         >
             {children}
         </Button>

--- a/src/components/RecommendationCount/RecommendationCount.tsx
+++ b/src/components/RecommendationCount/RecommendationCount.tsx
@@ -78,6 +78,7 @@ export const RecommendationCount = ({
                 className={buttonStyles(recommended, isSignedIn)}
                 onClick={() => tryToRecommend()}
                 disabled={recommended || !isSignedIn || userMadeComment}
+                data-link-name="Recommend comment"
             >
                 <div className={arrowStyles(recommended)}>
                     <ArrowUp />

--- a/src/components/Timestamp/Timestamp.tsx
+++ b/src/components/Timestamp/Timestamp.tsx
@@ -34,7 +34,11 @@ export const Timestamp = ({ isoDateTime, linkTo }: Props) => {
     }, 15000);
 
     return (
-        <a href={linkTo} className={linkStyles}>
+        <a
+            href={linkTo}
+            className={linkStyles}
+            data-link-name="jump-to-comment-timestamp"
+        >
             <time dateTime={isoDateTime.toString()} className={timeStyles}>
                 {timeAgo}
             </time>

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -161,3 +161,5 @@ export type DropdownOptionType = {
     disabled?: boolean;
     isActive?: boolean;
 };
+
+export type OphanTrackingNames = more-comments | x-navigation

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -161,5 +161,3 @@ export type DropdownOptionType = {
     disabled?: boolean;
     isActive?: boolean;
 };
-
-export type OphanTrackingNames = more-comments | x-navigation


### PR DESCRIPTION
## What does this change?

Adds the Ophan component and link names to the elements we want to track in discussion rendering.

## Why?

Existing tracking used to measure engagement + our requirement to measure the difference in engagement between DCR and Frontend.

## Types

Note: The inconsistencies in hyphenated, case and colon usage exists already so needs to be followed across for tracking reports. New tracking uses standardised lowercase, hyphenated format.

| Name *in code* | Done |
|-------------------------------|------|
| more-comments | ✅ | 
| Pagination view page 2 | ✅ | 
| Show more replies | ✅ |  
| Recommend comment | ✅ |  
| reply to comment | ✅ |  
| post comment | ✅ |  
| social-comment : facebook | 🚫 |  
| social-comment : twitter | 🚫 |  
| Open report abuse | ✅ |  
| Post report abuse | ✅ |  
| **NEW TRACKING** |  |  
| preview-comment | ✅ |  
| cancel-post-comment | ✅ |  
| formatting-controls-bold |  ✅ |  
| formatting-controls-italic |  ✅ |  
| formatting-controls-quote |  ✅ |  
| formatting-controls-link |  ✅ |  
| jump-to-comment-timestamp | ✅ |  
| commenter-profile-top-pick | ✅ |  
| mute-user | ✅|  
| unmute-user |✅ |  
| pick-comment |✅ |  
| unpick-comment |✅ |  
| reply-comment-hide |✅ | 
| reply-comment-show |✅ |  

## Link to supporting Trello card
https://trello.com/c/Xmg5bQcM