### PR TITLE
Set module to plain source

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/guardian/discussion-rendering#readme",
     "license": "Apache",
     "main": "build/App.js",
-    "module": "build/App.esm.js",
+    "module": "src/App.tsx",
     "publishConfig": {
         "access": "public"
     },


### PR DESCRIPTION
## What does this change?

Sets the module field of discussion-rendering to the src app.

## Why?
So that consumers can bundle the code as per https://github.com/guardian/dotcom-rendering/pull/1368

## Link to supporting Trello card
https://trello.com/c/6wU2GKBP

