### PR TITLE
Bump discussion rendering to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guardian/discussion-rendering",
     "description": "This codebase started as a hack day project by @gtrufitt and @nicl. The purpose is parity of the existing discussion application on Frontend using the discussion API (search for Private Repo).",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "author": "",
     "homepage": "https://github.com/guardian/discussion-rendering#readme",
     "license": "Apache",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guardian/discussion-rendering",
     "description": "This codebase started as a hack day project by @gtrufitt and @nicl. The purpose is parity of the existing discussion application on Frontend using the discussion API (search for Private Repo).",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "author": "",
     "homepage": "https://github.com/guardian/discussion-rendering#readme",
     "license": "Apache",


### PR DESCRIPTION
## What does this change?

Bumps current version of discussion rendering. (Sorry already published)

## Why?

https://www.npmjs.com/package/@guardian/discussion-rendering


