### PR TITLE
Prevent long strings overflowing parent

### DIFF
--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -72,6 +72,7 @@ const commentCss = css`
   ${textSans.small()}
   margin-top: ${remSpace[2]};
   margin-bottom: ${remSpace[3]};
+  word-break: break-word;
 
   p {
     margin-top: 0;

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -103,6 +103,10 @@ const inheritColour = css`
     color: inherit;
 `;
 
+const wrapStyles = css`
+    word-break: break-word;
+`;
+
 const SpaceBetween = ({
     children,
 }: {
@@ -146,6 +150,7 @@ export const TopPick = ({
                 <Top>
                     <h3 className={titleStyles}>Guardian Pick</h3>
                     <p
+                        className={wrapStyles}
                         dangerouslySetInnerHTML={{
                             __html: truncateText(comment.body, 450),
                         }}

--- a/src/fixtures/discussion.ts
+++ b/src/fixtures/discussion.ts
@@ -47,7 +47,7 @@ export const discussion: DiscussionResponse = {
             {
                 id: 37678414,
                 body:
-                    '<p>This is how <code>code</code> looks. And this is how <del>strikethrough</del> looks</p><p><strong>strong</strong></p><p><i>italic</i></p><p><blockquote>blockquote</blockquote></p><p><a href="http://www.mydomain.com">link to mydomain.com</a></p><P>And this is what get withareallyreallyreallylonglonglongwordthatissupersuperlonglikelonnnnngggggggggImeanreallylong</P>',
+                    '<p>This is how <code>code</code> looks. And this is how <del>strikethrough</del> looks</p><p><strong>strong</strong></p><p><i>italic</i></p><p><blockquote>blockquote</blockquote></p><p><a href="http://www.mydomain.com">link to mydomain.com</a></p><p>And this is what get withareallyreallyreallylonglonglongwordthatissupersuperlonglikelonnnnngggggggggImeanreallylong</p></p>',
                 date: '02 July 2014 11:20am',
                 isoDateTime: '2014-07-02T10:20:56Z',
                 status: 'visible',
@@ -74,7 +74,8 @@ export const discussion: DiscussionResponse = {
             },
             {
                 id: 37772513,
-                body: '<p>Lovely chickens!</p>',
+                body:
+                    '<p>Lovely chickens! <a href="http://www.mydomain.com">https://www.supersupersuperlongdomainnameImeanitneverstopsatallevereveritmakesyouwonderiftheremightbealimittothesethings.com</a></p>',
                 date: '04 July 2014 1:57pm',
                 isoDateTime: '2014-07-04T12:57:48Z',
                 status: 'visible',

--- a/src/fixtures/discussion.ts
+++ b/src/fixtures/discussion.ts
@@ -47,7 +47,7 @@ export const discussion: DiscussionResponse = {
             {
                 id: 37678414,
                 body:
-                    '<p>This is how <code>code</code> looks. And this is how <del>strikethrough</del> looks</p><p><strong>strong</strong></p><p><i>italic</i></p><p><blockquote>blockquote</blockquote></p><p><a href="http://www.mydomain.com">link to mydomain.com</a></p>',
+                    '<p>This is how <code>code</code> looks. And this is how <del>strikethrough</del> looks</p><p><strong>strong</strong></p><p><i>italic</i></p><p><blockquote>blockquote</blockquote></p><p><a href="http://www.mydomain.com">link to mydomain.com</a></p><P>And this is what get withareallyreallyreallylonglonglongwordthatissupersuperlonglikelonnnnngggggggggImeanreallylong</P>',
                 date: '02 July 2014 11:20am',
                 isoDateTime: '2014-07-02T10:20:56Z',
                 status: 'visible',


### PR DESCRIPTION
## What does this change?
Adds `word-break: break-all` for force text to wrap before overflowing

### Before
![Screenshot 2020-04-20 at 22 06 04](https://user-images.githubusercontent.com/1336821/79799892-25ec7880-8353-11ea-8e20-727608dc4782.jpg)

### After
![Screenshot 2020-04-20 at 22 05 17](https://user-images.githubusercontent.com/1336821/79799844-0fdeb800-8353-11ea-9a62-5bf515b954de.jpg)

## Link to supporting Trello card
https://trello.com/c/Oz8MfsAZ/1477-long-strings-not-properly-wrapped-in-guardian-pick-comments