### PR TITLE
Use POST method in pick api calls

### DIFF
--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -240,6 +240,7 @@ export const pickComment = (commentId: number): Promise<CommentResponse> => {
     ]);
 
     return fetch(url, {
+        method: 'POST',
         headers: {
             ...options.headers,
         },
@@ -257,6 +258,7 @@ export const unPickComment = (commentId: number): Promise<CommentResponse> => {
     ]);
 
     return fetch(url, {
+        method: 'POST',
         headers: {
             ...options.headers,
         },


### PR DESCRIPTION
## What does this change?
Add post to pick and unpick API calls

## Why?
Fix API call fail

## Link to supporting Trello card
https://trello.com/c/n9LNqcFp/1488-use-post-for-pick-comment-api-calls