### PR TITLE
Add credentials to pick API call

### DIFF
--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -244,6 +244,7 @@ export const pickComment = (commentId: number): Promise<CommentResponse> => {
         headers: {
             ...options.headers,
         },
+        credentials: 'include',
     })
         .then(resp => resp.json())
         .catch(error => console.error(`Error fetching ${url}`, error));
@@ -262,6 +263,7 @@ export const unPickComment = (commentId: number): Promise<CommentResponse> => {
         headers: {
             ...options.headers,
         },
+        credentials: 'include',
     })
         .then(resp => resp.json())
         .catch(error => console.error(`Error fetching ${url}`, error));


### PR DESCRIPTION
## What does this change?
Add `credentials: 'include' to API calls for pick and unpick to include cookie credentials 

## Why?
User cannot call API with these credentials

## Link to supporting Trello card
https://trello.com/c/RqiCft27/1490-add-credentials-to-pick-and-unpick-api-calls