### PR TITLE
Add content type to api call

### DIFF
--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -242,6 +242,7 @@ export const pickComment = (commentId: number): Promise<CommentResponse> => {
     return fetch(url, {
         method: 'POST',
         headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
             ...options.headers,
         },
         credentials: 'include',
@@ -261,6 +262,7 @@ export const unPickComment = (commentId: number): Promise<CommentResponse> => {
     return fetch(url, {
         method: 'POST',
         headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
             ...options.headers,
         },
         credentials: 'include',


### PR DESCRIPTION
## What does this change?
Add content type for api call

## Why?
needed when you call `credentials: 'include'`

## Link to supporting Trello card
https://trello.com/c/RqiCft27/1490-add-credentials-to-pick-and-unpick-api-calls