### PR TITLE
Only show last page when page count over 4

### DIFF
--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -493,7 +493,7 @@ export const CommentForm = ({
                                 className={commentAddOns}
                                 data-link-name="formatting-controls-strikethrough"
                             >
-                                {`S̶`}
+                                Del
                             </button>
                             <button
                                 onClick={e => {

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -493,7 +493,7 @@ export const CommentForm = ({
                                 className={commentAddOns}
                                 data-link-name="formatting-controls-strikethrough"
                             >
-                                Del
+                                {`S̶`}
                             </button>
                             <button
                                 onClick={e => {

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -39,6 +39,76 @@ export const NoPages = () => {
 };
 NoPages.story = { name: 'with two pages' };
 
+export const ThreePages = () => {
+    const [page, setCurrentPage] = useState(1);
+    return (
+        <Pagination
+            totalPages={3}
+            currentPage={page}
+            setCurrentPage={setCurrentPage}
+            filters={DEFAULT_FILTERS}
+            commentCount={75}
+        />
+    );
+};
+ThreePages.story = { name: 'with three pages' };
+
+export const FourPages = () => {
+    const [page, setCurrentPage] = useState(1);
+    return (
+        <Pagination
+            totalPages={4}
+            currentPage={page}
+            setCurrentPage={setCurrentPage}
+            filters={DEFAULT_FILTERS}
+            commentCount={100}
+        />
+    );
+};
+FourPages.story = { name: 'with four pages' };
+
+export const FivePages = () => {
+    const [page, setCurrentPage] = useState(1);
+    return (
+        <Pagination
+            totalPages={5}
+            currentPage={page}
+            setCurrentPage={setCurrentPage}
+            filters={DEFAULT_FILTERS}
+            commentCount={124}
+        />
+    );
+};
+FivePages.story = { name: 'with five pages' };
+
+export const SixPages = () => {
+    const [page, setCurrentPage] = useState(1);
+    return (
+        <Pagination
+            totalPages={6}
+            currentPage={page}
+            setCurrentPage={setCurrentPage}
+            filters={DEFAULT_FILTERS}
+            commentCount={149}
+        />
+    );
+};
+SixPages.story = { name: 'with six pages' };
+
+export const SevenPages = () => {
+    const [page, setCurrentPage] = useState(1);
+    return (
+        <Pagination
+            totalPages={7}
+            currentPage={page}
+            setCurrentPage={setCurrentPage}
+            filters={DEFAULT_FILTERS}
+            commentCount={159}
+        />
+    );
+};
+SevenPages.story = { name: 'with seven pages' };
+
 export const LotsOfPages = () => {
     const [page, setCurrentPage] = useState(1);
     return (

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -218,7 +218,7 @@ export const Pagination = ({
     const forthPage = decideForthPage({ currentPage, totalPages });
     const showThirdPage = totalPages > 2;
     const showForthPage = totalPages > 3;
-    const showLastPage = currentPage < totalPages - 1;
+    const showLastPage = totalPages > 4 && currentPage < totalPages - 1;
     const lastPage = totalPages;
     const showSecondElipsis = totalPages > 4 && currentPage < totalPages - 2;
     const showForwardButton = totalPages > 4 && currentPage !== totalPages;


### PR DESCRIPTION
## What does this change?
Only show last page if page count over 4

I also threw in a bunch of extra stories to capture the different states `Pagination` can be in, guarding against this kind of bug in future

## Why?
We were showing the last page too often before, causing double pages

## Link to supporting Trello card
https://trello.com/c/p8keDBFV/1491-duplicate-pages
