### PR TITLE
Permalink click

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ type Props = {
     user?: UserProfile;
     additionalHeaders: AdditionalHeadersType;
     expanded: boolean;
+    onPermalinkClick: (commentId: number) => void;
 };
 
 const footerStyles = css`
@@ -167,6 +168,7 @@ export const App = ({
     user,
     additionalHeaders,
     expanded,
+    onPermalinkClick,
 }: Props) => {
     const [filters, setFilters] = useState<FilterOptions>(
         initialiseFilters({
@@ -309,6 +311,7 @@ export const App = ({
                                 pillar={pillar}
                                 comments={picks.slice(0, 2)}
                                 isSignedIn={!!user}
+                                onPermalinkClick={onPermalinkClick}
                             />
                         )}
                     </div>
@@ -340,6 +343,7 @@ export const App = ({
                                             }
                                             mutes={mutes}
                                             toggleMuteStatus={toggleMuteStatus}
+                                            onPermalinkClick={onPermalinkClick}
                                         />
                                     </li>
                                 ))}
@@ -383,6 +387,7 @@ export const App = ({
                         pillar={pillar}
                         comments={picks}
                         isSignedIn={!!user}
+                        onPermalinkClick={onPermalinkClick}
                     />
                 )}
                 <Filters
@@ -428,6 +433,7 @@ export const App = ({
                                     commentToScrollTo={commentToScrollTo}
                                     mutes={mutes}
                                     toggleMuteStatus={toggleMuteStatus}
+                                    onPermalinkClick={onPermalinkClick}
                                 />
                             </li>
                         ))}

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -314,19 +314,8 @@ export const Comment = ({
                                         </div>
                                         <Timestamp
                                             isoDateTime={comment.isoDateTime}
-                                            linkTo={joinUrl([
-                                                // Remove the discussion-api path from the baseUrl
-                                                baseUrl
-                                                    .split('/')
-                                                    .filter(
-                                                        path =>
-                                                            path !==
-                                                            'discussion-api',
-                                                    )
-                                                    .join('/'),
-                                                'comment-permalink',
-                                                comment.id.toString(),
-                                            ])}
+                                            baseUrl={baseUrl}
+                                            commentId={comment.id}
                                         />
                                     </Column>
                                 </Row>
@@ -383,19 +372,8 @@ export const Comment = ({
                                     >
                                         <Timestamp
                                             isoDateTime={comment.isoDateTime}
-                                            linkTo={joinUrl([
-                                                // Remove the discussion-api path from the baseUrl
-                                                baseUrl
-                                                    .split('/')
-                                                    .filter(
-                                                        path =>
-                                                            path !==
-                                                            'discussion-api',
-                                                    )
-                                                    .join('/'),
-                                                'comment-permalink',
-                                                comment.id.toString(),
-                                            ])}
+                                            baseUrl={baseUrl}
+                                            commentId={comment.id}
                                         />
                                     </div>
                                 </Row>

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -32,6 +32,7 @@ type Props = {
     wasScrolledTo?: boolean;
     isMuted: boolean;
     toggleMuteStatus: (userId: string) => void;
+    onPermalinkClick: (commentId: number) => void;
 };
 
 const shiftLeft = css`
@@ -208,6 +209,7 @@ export const Comment = ({
     wasScrolledTo,
     isMuted,
     toggleMuteStatus,
+    onPermalinkClick,
 }: Props) => {
     const [isHighlighted, setIsHighlighted] = useState<boolean>(
         comment.isHighlighted,
@@ -316,6 +318,7 @@ export const Comment = ({
                                             isoDateTime={comment.isoDateTime}
                                             baseUrl={baseUrl}
                                             commentId={comment.id}
+                                            onPermalinkClick={onPermalinkClick}
                                         />
                                     </Column>
                                 </Row>
@@ -374,6 +377,7 @@ export const Comment = ({
                                             isoDateTime={comment.isoDateTime}
                                             baseUrl={baseUrl}
                                             commentId={comment.id}
+                                            onPermalinkClick={onPermalinkClick}
                                         />
                                     </div>
                                 </Row>

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -24,6 +24,7 @@ type Props = {
     commentToScrollTo?: number;
     mutes: string[];
     toggleMuteStatus: (userId: string) => void;
+    onPermalinkClick: (commentId: number) => void;
 };
 
 const nestingStyles = css`
@@ -103,6 +104,7 @@ export const CommentContainer = ({
     commentToScrollTo,
     mutes,
     toggleMuteStatus,
+    onPermalinkClick,
 }: Props) => {
     // Filter logic
     const [expanded, setExpanded] = useState<boolean>(threads === 'expanded');
@@ -147,6 +149,7 @@ export const CommentContainer = ({
                 isReply={false}
                 isMuted={mutes.includes(comment.userProfile.userId)}
                 toggleMuteStatus={toggleMuteStatus}
+                onPermalinkClick={onPermalinkClick}
             />
 
             <>
@@ -177,6 +180,7 @@ export const CommentContainer = ({
                                             responseComment.userProfile.userId,
                                         )}
                                         toggleMuteStatus={toggleMuteStatus}
+                                        onPermalinkClick={onPermalinkClick}
                                     />
                                 </li>
                             ))}

--- a/src/components/Timestamp/Timestamp.stories.tsx
+++ b/src/components/Timestamp/Timestamp.stories.tsx
@@ -11,6 +11,7 @@ export const TwoMonths = () => (
         isoDateTime={'2020-01-26T14:22:39Z'}
         baseUrl=""
         commentId={123}
+        onPermalinkClick={() => {}}
     />
 );
 TwoMonths.story = { name: 'Two months' };
@@ -20,6 +21,7 @@ export const OneHour = () => (
         isoDateTime={'2020-03-27T11:00:00Z'}
         baseUrl=""
         commentId={123}
+        onPermalinkClick={() => {}}
     />
 );
 OneHour.story = { name: 'One Hour' };
@@ -29,6 +31,7 @@ export const TwentyThreeHours = () => (
         isoDateTime={'2020-03-26T13:00:00Z'}
         baseUrl=""
         commentId={123}
+        onPermalinkClick={() => {}}
     />
 );
 TwentyThreeHours.story = { name: 'Twenty three hours' };
@@ -38,6 +41,7 @@ export const TwentyFiveHours = () => (
         isoDateTime={'2020-03-26T11:00:00Z'}
         baseUrl=""
         commentId={123}
+        onPermalinkClick={() => {}}
     />
 );
 TwentyFiveHours.story = { name: 'Twenty five hours' };

--- a/src/components/Timestamp/Timestamp.stories.tsx
+++ b/src/components/Timestamp/Timestamp.stories.tsx
@@ -7,21 +7,37 @@ export default { component: Timestamp, title: 'Timestamp' };
 // Date is mocked to "Fri March 27 2020 12:00:00 GMT+0000 (Greenwich Mean Time)" in config
 
 export const TwoMonths = () => (
-    <Timestamp isoDateTime={'2020-01-26T14:22:39Z'} linkTo="" />
+    <Timestamp
+        isoDateTime={'2020-01-26T14:22:39Z'}
+        baseUrl=""
+        commentId={123}
+    />
 );
 TwoMonths.story = { name: 'Two months' };
 
 export const OneHour = () => (
-    <Timestamp isoDateTime={'2020-03-27T11:00:00Z'} linkTo="" />
+    <Timestamp
+        isoDateTime={'2020-03-27T11:00:00Z'}
+        baseUrl=""
+        commentId={123}
+    />
 );
 OneHour.story = { name: 'One Hour' };
 
 export const TwentyThreeHours = () => (
-    <Timestamp isoDateTime={'2020-03-26T13:00:00Z'} linkTo="" />
+    <Timestamp
+        isoDateTime={'2020-03-26T13:00:00Z'}
+        baseUrl=""
+        commentId={123}
+    />
 );
 TwentyThreeHours.story = { name: 'Twenty three hours' };
 
 export const TwentyFiveHours = () => (
-    <Timestamp isoDateTime={'2020-03-26T11:00:00Z'} linkTo="" />
+    <Timestamp
+        isoDateTime={'2020-03-26T11:00:00Z'}
+        baseUrl=""
+        commentId={123}
+    />
 );
 TwentyFiveHours.story = { name: 'Twenty five hours' };

--- a/src/components/Timestamp/Timestamp.tsx
+++ b/src/components/Timestamp/Timestamp.tsx
@@ -6,10 +6,12 @@ import { palette } from '@guardian/src-foundations';
 
 import { dateFormatter } from '../../lib/dateFormatter';
 import { useInterval } from '../../lib/useInterval';
+import { joinUrl } from '../../lib/joinUrl';
 
 type Props = {
     isoDateTime: string;
-    linkTo: string;
+    baseUrl: string;
+    commentId: number;
 };
 
 const linkStyles = css`
@@ -26,8 +28,18 @@ const timeStyles = css`
     margin-right: 0.3125rem;
 `;
 
-export const Timestamp = ({ isoDateTime, linkTo }: Props) => {
+export const Timestamp = ({ isoDateTime, baseUrl, commentId }: Props) => {
     let [timeAgo, setTimeAgo] = useState(dateFormatter(isoDateTime));
+
+    const linkTo = joinUrl([
+        // Remove the discussion-api path from the baseUrl
+        baseUrl
+            .split('/')
+            .filter(path => path !== 'discussion-api')
+            .join('/'),
+        'comment-permalink',
+        commentId.toString(),
+    ]);
 
     useInterval(() => {
         setTimeAgo(dateFormatter(isoDateTime));

--- a/src/components/Timestamp/Timestamp.tsx
+++ b/src/components/Timestamp/Timestamp.tsx
@@ -12,6 +12,7 @@ type Props = {
     isoDateTime: string;
     baseUrl: string;
     commentId: number;
+    onPermalinkClick: (commentId: number) => void;
 };
 
 const linkStyles = css`
@@ -28,7 +29,12 @@ const timeStyles = css`
     margin-right: 0.3125rem;
 `;
 
-export const Timestamp = ({ isoDateTime, baseUrl, commentId }: Props) => {
+export const Timestamp = ({
+    isoDateTime,
+    baseUrl,
+    commentId,
+    onPermalinkClick,
+}: Props) => {
     let [timeAgo, setTimeAgo] = useState(dateFormatter(isoDateTime));
 
     const linkTo = joinUrl([
@@ -50,6 +56,10 @@ export const Timestamp = ({ isoDateTime, baseUrl, commentId }: Props) => {
             href={linkTo}
             className={linkStyles}
             data-link-name="jump-to-comment-timestamp"
+            onClick={e => {
+                onPermalinkClick(commentId);
+                e.preventDefault();
+            }}
         >
             <time dateTime={isoDateTime.toString()} className={timeStyles}>
                 {timeAgo}

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -22,6 +22,7 @@ type Props = {
     comment: CommentType;
     isSignedIn: boolean;
     userMadeComment: boolean;
+    onPermalinkClick: (commentId: number) => void;
 };
 
 const pickStyles = css`
@@ -143,6 +144,7 @@ export const TopPick = ({
     comment,
     isSignedIn,
     userMadeComment,
+    onPermalinkClick,
 }: Props) => (
     <div className={pickStyles}>
         <div className={pickComment}>
@@ -170,6 +172,10 @@ export const TopPick = ({
                                 'comment-permalink',
                                 comment.id.toString(),
                             ])}
+                            onClick={e => {
+                                onPermalinkClick(comment.id);
+                                e.preventDefault();
+                            }}
                         >
                             Jump to comment
                         </Link>
@@ -199,6 +205,7 @@ export const TopPick = ({
                         isoDateTime={comment.isoDateTime}
                         baseUrl={baseUrl}
                         commentId={comment.id}
+                        onPermalinkClick={onPermalinkClick}
                     />
                     {!!comment.userProfile.badge.filter(
                         obj => obj['name'] === 'Staff',

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -197,15 +197,8 @@ export const TopPick = ({
                     </span>
                     <Timestamp
                         isoDateTime={comment.isoDateTime}
-                        linkTo={joinUrl([
-                            // Remove the discussion-api path from the baseUrl
-                            baseUrl
-                                .split('/')
-                                .filter(path => path !== 'discussion-api')
-                                .join('/'),
-                            'comment-permalink',
-                            comment.id.toString(),
-                        ])}
+                        baseUrl={baseUrl}
+                        commentId={comment.id}
                     />
                     {!!comment.userProfile.badge.filter(
                         obj => obj['name'] === 'Staff',

--- a/src/components/TopPicks/TopPicks.tsx
+++ b/src/components/TopPicks/TopPicks.tsx
@@ -12,6 +12,7 @@ type Props = {
     user?: UserProfile;
     comments: CommentType[];
     isSignedIn: boolean;
+    onPermalinkClick: (commentId: number) => void;
 };
 
 const columWrapperStyles = css`
@@ -53,6 +54,7 @@ export const TopPicks = ({
     user,
     comments,
     isSignedIn,
+    onPermalinkClick,
 }: Props) => {
     const leftColComments: CommentType[] = [];
     const rightColComments: CommentType[] = [];
@@ -75,6 +77,7 @@ export const TopPicks = ({
                                 !!user &&
                                 user.userId === comment.userProfile.userId
                             }
+                            onPermalinkClick={onPermalinkClick}
                         />
                     ))}
                 </div>
@@ -89,6 +92,7 @@ export const TopPicks = ({
                                 !!user &&
                                 user.userId === comment.userProfile.userId
                             }
+                            onPermalinkClick={onPermalinkClick}
                         />
                     ))}
                 </div>
@@ -103,6 +107,7 @@ export const TopPicks = ({
                         userMadeComment={
                             !!user && user.userId === comment.userProfile.userId
                         }
+                        onPermalinkClick={onPermalinkClick}
                     />
                 ))}
             </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ ReactDOM.render(
             'GU-Client': 'testClientHeader',
         }}
         expanded={false}
+        onPermalinkClick={() => {}}
     />,
     document.getElementById('root'),
 );


### PR DESCRIPTION
## What does this change?
Adds an `onPermalinkClick` function to `App` which is passed in from the calling container and used to override permalinks

## Why?
If we allow the default action for permalinks then the page will be reloaded, causing the scroll position to move to the top of the page. By using javascript we can prevent this. There's still a delay while we wait for:

- A context call
- Getting the discussion (based on context)
- Rendering the discussion

but the scroll position does not reset to the top

## Requires
That the calling component pass in a this function and that it set the `commentToScrollTo` prop appropriately, and then `return false`

## Link to supporting Trello card
https://trello.com/c/o95XCIxg/1509-jump-to-comment-causes-page-refresh
