### PR TITLE
Smaller unmute text

### DIFF
--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -453,6 +453,7 @@ export const Comment = ({
                                         )
                                     }
                                     linkName="unmute-user"
+                                    size="small"
                                 >
                                     Unmute?
                                 </ButtonLink>


### PR DESCRIPTION
## What does this change?
Makes the unmute text the same size as the rest of the mute message

### Before
![Screenshot 2020-04-25 at 00 17 34](https://user-images.githubusercontent.com/1336821/80263929-3588fb80-868a-11ea-8e49-a8f05b873c2e.jpg)

### After
![Screenshot 2020-04-25 at 00 17 09](https://user-images.githubusercontent.com/1336821/80263933-391c8280-868a-11ea-8518-5a9a977ccd89.jpg)

## Why?
Consistency

## Link to supporting Trello card
https://trello.com/c/Z7tzwyCL/1522-unmute-text-size