### PR TITLE
Ensure page updates on permalink click

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -225,7 +225,10 @@ export const App = ({
     // Keep initialPage prop in sync with page
     useEffect(() => {
         if (initialPage) setPage(initialPage);
-    }, [initialPage]);
+        // We added commentToScrollTo to the deps here because the initialPage alone wasn't triggered the effect
+        // and we want to ensure the discussion rerenders with the right page when the reader clicks Jump To Comment
+        // for a comment on a different page
+    }, [initialPage, commentToScrollTo]);
 
     // Check if there is a comment to scroll to and if
     // so, scroll to the div with this id.


### PR DESCRIPTION
## What does this change?
Makes sure the `page` value gets updated if the user clicks on Jump To COmment so they are taken to the new page

## Why?
To fix a bug reported where Jump To Comment wasn't working well

## Link to supporting Trello card
https://trello.com/c/nVuC7f3k/1533-jump-to-comment-bug