### PR TITLE
Add API key for discussion-rendering GET requests

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -36,6 +36,7 @@ describe('App', () => {
                     'D2-X-UID': 'testD2Header',
                     'GU-Client': 'testClientHeader',
                 }}
+                apiKey="discussion-rendering-test"
             />,
         );
 
@@ -58,6 +59,7 @@ describe('App', () => {
                     'D2-X-UID': 'testD2Header',
                     'GU-Client': 'testClientHeader',
                 }}
+                apiKey="discussion-rendering-test"
             />,
         );
 
@@ -78,6 +80,7 @@ describe('App', () => {
                     'D2-X-UID': 'testD2Header',
                     'GU-Client': 'testClientHeader',
                 }}
+                apiKey="discussion-rendering-test"
             />,
         );
         expect(getByPlaceholderText('Join the discussion')).toBeInTheDocument();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ type Props = {
     additionalHeaders: AdditionalHeadersType;
     expanded: boolean;
     onPermalinkClick: (commentId: number) => void;
+    apiKey: string;
 };
 
 const footerStyles = css`
@@ -198,6 +199,7 @@ export const App = ({
     additionalHeaders,
     expanded,
     onPermalinkClick,
+    apiKey,
 }: Props) => {
     const [filters, setFilters] = useState<FilterOptions>(
         initialiseFilters({
@@ -320,7 +322,7 @@ export const App = ({
         setComments([comment, ...comments]);
     };
 
-    initialiseApi({ additionalHeaders, baseUrl });
+    initialiseApi({ additionalHeaders, baseUrl, apiKey });
 
     const showPagination = totalPages > 1;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ ReactDOM.render(
         }}
         expanded={false}
         onPermalinkClick={() => {}}
+        apiKey="discussion-rendering"
     />,
     document.getElementById('root'),
 );

--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -126,7 +126,7 @@ export const comment = (
 ): Promise<CommentResponse> => {
     const url =
         joinUrl([options.baseUrl, 'discussion', shortUrl, 'comment']) +
-        `?api-key=${options.apiKey}`;
+        objAsParams(defaultParams);
     const data = new URLSearchParams();
     data.append('body', body);
 
@@ -154,7 +154,7 @@ export const reply = (
             'comment',
             parentCommentId.toString(),
             'reply',
-        ]) + `?api-key=${options.apiKey}`;
+        ]) + objAsParams(defaultParams);
     const data = new URLSearchParams();
     data.append('body', body);
 
@@ -172,7 +172,7 @@ export const reply = (
 export const getPicks = (shortUrl: string): Promise<CommentType[]> => {
     const url =
         joinUrl([options.baseUrl, 'discussion', shortUrl, 'topcomments']) +
-        `?api-key=${options.apiKey}`;
+        objAsParams(defaultParams);
 
     return fetch(url, {
         headers: {

--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -32,9 +32,9 @@ export const initialiseApi = ({
     additionalHeaders: AdditionalHeadersType;
     apiKey: string;
 }) => {
-    options.baseUrl = baseUrl;
-    options.headers = additionalHeaders;
-    options.apiKey = apiKey;
+    options.baseUrl = baseUrl || options.baseUrl;
+    options.headers = additionalHeaders || options.headers;
+    options.apiKey = apiKey || options.apiKey;
 
     defaultParams['api-key'] = options.apiKey;
 };

--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -15,18 +15,22 @@ import {
 let options = {
     // Defaults
     baseUrl: 'https://discussion.theguardian.com/discussion-api',
+    apiKey: 'discussion-rendering',
     headers: {},
 };
 
 export const initialiseApi = ({
     baseUrl,
     additionalHeaders,
+    apiKey,
 }: {
     baseUrl: string;
     additionalHeaders: AdditionalHeadersType;
+    apiKey: string;
 }) => {
     options.baseUrl = baseUrl;
     options.headers = additionalHeaders;
+    options.apiKey = apiKey;
 };
 
 const objAsParams = (obj: any): string => {
@@ -59,6 +63,7 @@ export const getDiscussion = (
         displayThreaded: opts.threads !== 'unthreaded',
         maxResponses: opts.threads === 'collapsed' ? 3 : 100,
         page: opts.page,
+        'api-key': options.apiKey,
     };
     const params = objAsParams(apiOpts);
 
@@ -151,12 +156,9 @@ export const reply = (
 };
 
 export const getPicks = (shortUrl: string): Promise<CommentType[]> => {
-    const url = joinUrl([
-        options.baseUrl,
-        'discussion',
-        shortUrl,
-        'topcomments',
-    ]);
+    const url =
+        joinUrl([options.baseUrl, 'discussion', shortUrl, 'topcomments']) +
+        `?api-key=${options.apiKey}`;
 
     return fetch(url, {
         headers: {
@@ -197,12 +199,13 @@ export const reportAbuse = ({
 };
 
 export const recommend = (commentId: number): Promise<boolean> => {
-    const url = joinUrl([
-        options.baseUrl,
-        'comment',
-        commentId.toString(),
-        'recommend',
-    ]);
+    const url =
+        joinUrl([
+            options.baseUrl,
+            'comment',
+            commentId.toString(),
+            'recommend',
+        ]) + `?api-key=${options.apiKey}`;
 
     return fetch(url, {
         method: 'POST',
@@ -279,7 +282,7 @@ export const getMoreResponses = (
 }> => {
     const url =
         joinUrl([options.baseUrl, 'comment', commentId.toString()]) +
-        '?displayThreaded=true&displayResponses=true';
+        `?displayThreaded=true&displayResponses=true&api-key=${options.apiKey}`;
 
     return fetch(url, {
         headers: {

--- a/src/lib/mockFetchCalls.js
+++ b/src/lib/mockFetchCalls.js
@@ -37,7 +37,7 @@ export const mockFetchCalls = () => {
             body: discussion,
         })
         .get(
-            /.*\/discussion\?orderBy=newest&pageSize=25&displayThreaded=true&maxResponses=3&page=1/,
+            /.*\/discussion\?api-key=discussion-rendering-test&orderBy=newest&pageSize=25&displayThreaded=true&maxResponses=3&page=1/,
             {
                 status: 200,
                 body: discussion,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -151,6 +151,7 @@ export interface DiscussionOptions {
     displayThreaded: boolean;
     maxResponses: number;
     page: number;
+    'api-key': string;
 }
 
 export type AdditionalHeadersType = { [key: string]: string };


### PR DESCRIPTION
## What does this change?

Adds the API key param (default `discussion-rendering` but lets platform set it) to GET requests. 

## Why?

Better tracking of GET request volume and errors.

![Screen Shot 2020-04-29 at 15 11 07](https://user-images.githubusercontent.com/638051/80607341-4c827180-8a2d-11ea-8047-71a1a1c82ded.png)

![Screen Shot 2020-04-29 at 15 23 38](https://user-images.githubusercontent.com/638051/80607452-6cb23080-8a2d-11ea-95ff-3da143445151.png)


## Dotcom Rendering PR when released

https://github.com/guardian/dotcom-rendering/pull/1425
