### PR TITLE
Fix Report form

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "@testing-library/user-event": "^7.1.2",
         "@types/jest": "^25.1.0",
         "@types/node": "^13.5.0",
-        "@types/react": "^16.9.19",
+        "@types/react": "^16.9.34",
         "@types/react-dom": "^16.9.5",
         "emotion": "^10.0.27",
         "eslint-plugin-react-hooks": "^2.3.0",

--- a/src/components/AbuseReportForm/AbuseReportForm.test.tsx
+++ b/src/components/AbuseReportForm/AbuseReportForm.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+
+import {
+    render,
+    fireEvent,
+    // @ts-ignore : https://github.com/testing-library/react-testing-library/issues/610
+    waitFor,
+} from '@testing-library/react';
+
+import { AbuseReportForm } from './AbuseReportForm';
+
+import { mockFetchCalls } from '../../lib/mockFetchCalls';
+
+const fetchMock = mockFetchCalls();
+
+describe('Dropdown', () => {
+    it('Should show the expected label names', () => {
+        const { getByText } = render(
+            <AbuseReportForm
+                toggleSetShowForm={() => {}}
+                pillar={'sport'}
+                commentId={123}
+            />,
+        );
+
+        expect(getByText('Category')).toBeInTheDocument();
+        expect(getByText('Reason (optional)')).toBeInTheDocument();
+        expect(getByText('Email (optional)')).toBeInTheDocument();
+    });
+
+    it('Should show the category error message if not chosen on submit', () => {
+        const { getByText } = render(
+            <AbuseReportForm
+                toggleSetShowForm={() => {}}
+                pillar={'sport'}
+                commentId={123}
+            />,
+        );
+
+        fireEvent.click(getByText('Report'));
+        expect(
+            getByText('You must select a category before submitting'),
+        ).toBeInTheDocument();
+    });
+
+    it('Should show the success message category is selected', async () => {
+        const { getByText, getByLabelText, queryByText } = render(
+            <AbuseReportForm
+                toggleSetShowForm={() => {}}
+                pillar={'sport'}
+                commentId={123}
+            />,
+        );
+
+        fireEvent.change(getByLabelText('Category'), { target: { value: 3 } });
+
+        fireEvent.click(getByText('Report'));
+
+        let options = getByLabelText('Category');
+        expect(options[1].selected).toBeFalsy();
+        expect(options[3].selected).toBeTruthy();
+
+        expect(
+            queryByText('You must select a category before submitting'),
+        ).not.toBeInTheDocument();
+
+        await waitFor(() => {
+            expect(fetchMock.called(/reportAbuse/)).toBeTruthy();
+        });
+
+        await waitFor(() => {
+            expect(getByText('Report submitted')).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/AbuseReportForm/AbuseReportForm.tsx
+++ b/src/components/AbuseReportForm/AbuseReportForm.tsx
@@ -176,7 +176,7 @@ export const AbuseReportForm: React.FC<{
                         Category
                     </label>
                     <select
-                        name="categoryId"
+                        name="category"
                         id="category"
                         onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
                             setFormVariables({
@@ -214,6 +214,7 @@ export const AbuseReportForm: React.FC<{
                     </label>
                     <textarea
                         name="reason"
+                        id="reason"
                         onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
                             setFormVariables({
                                 ...formVariables,
@@ -236,6 +237,7 @@ export const AbuseReportForm: React.FC<{
                     <input
                         type="email"
                         name="email"
+                        id="email"
                         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                             setFormVariables({
                                 ...formVariables,

--- a/src/components/AbuseReportForm/AbuseReportForm.tsx
+++ b/src/components/AbuseReportForm/AbuseReportForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
@@ -135,16 +135,23 @@ export const AbuseReportForm: React.FC<{
         response: '',
     };
     const [errors, setErrors] = useState(defaultErrorTexts);
-    const onSubmit = async () => {
+    const [successMessage, setSuccessMessage] = useState();
+    const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
         const { categoryId, reason, email } = formVariables;
+
         // Reset error messages
         setErrors(defaultErrorTexts);
+
         // Error validation
         if (!categoryId) {
             setErrors({
                 ...errors,
                 categoryId: 'You must select a category before submitting',
             });
+
+            return false;
         }
         const response = await reportAbuse({
             categoryId,
@@ -152,11 +159,11 @@ export const AbuseReportForm: React.FC<{
             email,
             commentId,
         });
-        if (!response.ok) {
+        if (response.status !== 'ok') {
+            // Fallback to errors returned from the API
             setErrors({ ...errors, response: response.message });
         } else {
-            toggleSetShowForm();
-            // TODO: display sucess?
+            setSuccessMessage('Report submitted');
         }
     };
 
@@ -164,12 +171,6 @@ export const AbuseReportForm: React.FC<{
     return (
         <div aria-modal="true" ref={modalRef}>
             <form className={formWrapper} onSubmit={onSubmit}>
-                {errors.response && (
-                    <span className={errorMessageStyles}>
-                        {errors.response}
-                    </span>
-                )}
-
                 <div className={inputWrapper}>
                     <label className={labelStylesClass} htmlFor="category">
                         Category
@@ -258,6 +259,30 @@ export const AbuseReportForm: React.FC<{
                     >
                         Report
                     </Button>
+
+                    {errors.response && (
+                        <span
+                            className={cx(
+                                errorMessageStyles,
+                                css`
+                                    margin-left: 1em;
+                                `,
+                            )}
+                        >
+                            {errors.response}
+                        </span>
+                    )}
+
+                    {successMessage && (
+                        <span
+                            className={css`
+                                color: green;
+                                margin-left: 1em;
+                            `}
+                        >
+                            {successMessage}
+                        </span>
+                    )}
                 </div>
                 <div
                     className={css`

--- a/src/components/AbuseReportForm/AbuseReportForm.tsx
+++ b/src/components/AbuseReportForm/AbuseReportForm.tsx
@@ -71,7 +71,7 @@ export const AbuseReportForm: React.FC<{
         if (!modalRef.current) return;
         // eslint-disable-next-line react-hooks/exhaustive-deps
         firstElement = modalRef.current.querySelector(
-            'select[name="categoryId"]',
+            'select[name="category"]',
         );
         // eslint-disable-next-line react-hooks/exhaustive-deps
         lastElement = modalRef.current.querySelector(

--- a/src/lib/mockFetchCalls.js
+++ b/src/lib/mockFetchCalls.js
@@ -98,4 +98,6 @@ export const mockFetchCalls = () => {
                 message: mockedMessageID,
             },
         });
+
+    return fetchMock;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3099,10 +3099,18 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.9.19":
+"@types/react@*":
   version "16.9.19"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.19.tgz#c842aa83ea490007d29938146ff2e4d9e4360c40"
   integrity sha512-LJV97//H+zqKWMms0kvxaKYJDG05U2TtQB3chRLF8MPNs+MQh/H1aGlyDUxjaHvu08EAGerdX2z4LTBc7ns77A==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
+"@types/react@^16.9.34":
+  version "16.9.34"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.34.tgz#f7d5e331c468f53affed17a8a4d488cd44ea9349"
+  integrity sha512-8AJlYMOfPe1KGLKyHpflCg5z46n0b5DbRfqDksxBLBTUpB75ypDBAO9eCUcjNwE6LCUslwTz00yyG/X9gaVtow==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"


### PR DESCRIPTION
## What does this change?

- Prevents default on submission so that we don't page refresh
- Moves the API response error message so that it doesn't jolt the form
- Prevents going to API if the required field isn't complete
- Add success message

### Before

![2020-05-01 09 21 34](https://user-images.githubusercontent.com/638051/80792765-3ab7e000-8b8d-11ea-8d49-5cc87a0a0ff4.gif)

![2020-05-01 09 21 52](https://user-images.githubusercontent.com/638051/80792769-3db2d080-8b8d-11ea-959f-4c140ec16de8.gif)

### After

![2020-05-01 09 14 23](https://user-images.githubusercontent.com/638051/80792783-460b0b80-8b8d-11ea-8d54-5345c7a2e23d.gif)

