### PR TITLE
Don't lint build folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,10 @@
         "rules": {
             "react-hooks/rules-of-hooks": "error",
             "react-hooks/exhaustive-deps": "warn"
-        }
+        },
+        "ignorePatterns": [
+            "build"
+        ]
     },
     "browserslist": {
         "production": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,5 @@
     },
     "files": ["src/types.tsx"],
     "include": ["src/"],
-    "exclude": ["fixtures", "**/*.test.tsx", "**/*.stories.tsx"]
+    "exclude": ["fixtures", "build", "**/*.test.tsx", "**/*.stories.tsx"]
 }


### PR DESCRIPTION
## What does this change?
Excludes the build folder from linting and typescript

## Why?
I kept getting lint errors when trying to push and had to delete the build to get past them
