### PR TITLE
Fix show more replies

### DIFF
--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -130,7 +130,7 @@ export const CommentContainer = ({
         getMoreResponses(commentId)
             .then(json => {
                 setExpanded(true);
-                setResponses([...responses, ...(json.comment.responses || [])]);
+                setResponses(json.comment.responses || []);
             })
             .finally(() => {
                 setLoading(false);

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -130,7 +130,7 @@ export const CommentContainer = ({
         getMoreResponses(commentId)
             .then(json => {
                 setExpanded(true);
-                setResponses(json.comment.responses || []);
+                setResponses([...responses, ...(json.comment.responses || [])]);
             })
             .finally(() => {
                 setLoading(false);

--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -306,7 +306,7 @@ export const getMoreResponses = (
             ...defaultParams,
             ...{
                 displayThreaded: true,
-                displayResponse: true,
+                displayResponses: true,
             },
         });
 


### PR DESCRIPTION
## What does this change?
change `displayResponse` to `displayResponses` in the query param

## Why?
because responses do not get fetched if so

## Link to supporting Trello card
https://trello.com/c/MtfHvXLz/1654-show-more-replies-broken

## To Test
`displayResponses`
https://discussion.theguardian.com/discussion-api/comment/104345678?displayThreaded=true&displayResponses=true

`displayResponse`
https://discussion.theguardian.com/discussion-api/comment/104345678?displayThreaded=true&displayResponse=true