### PR TITLE
Expand on post

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -322,6 +322,14 @@ export const App = ({
         comments.pop(); // Remove last item from our local array
         // Replace it with this new comment at the start
         setComments([comment, ...comments]);
+
+        if (!isExpanded) {
+            // It's possible to post a comment without the view being expanded
+            expandView();
+        }
+
+        const commentElement = document.getElementById(`comment-${comment.id}`);
+        commentElement && commentElement.scrollIntoView();
     };
 
     initialiseApi({ additionalHeaders, baseUrl, apiKey });


### PR DESCRIPTION
## What does this change?
If the view is not expanded then when a reader posts we now expand.

At the same time,  we also scroll the page to show the post just made.

## Why?
Because if a reader is signed in and the view not yet expanded they are still able to post and at this point they are engaged and we should take them to the main content.
