### PR TITLE
onHeightChange is now optional

### DIFF
--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -96,7 +96,6 @@ export const Overrides = () => (
             expanded={true}
             onPermalinkClick={() => {}}
             apiKey=""
-            onHeightChange={() => {}}
         />
     </div>
 );
@@ -177,7 +176,6 @@ export const Closed = () => (
             expanded={true}
             onPermalinkClick={() => {}}
             apiKey=""
-            onHeightChange={() => {}}
         />
     </div>
 );

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -62,7 +62,6 @@ describe('App', () => {
                 }}
                 apiKey="discussion-rendering-test"
                 onPermalinkClick={() => {}}
-                onHeightChange={() => {}}
             />,
         );
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ type Props = {
     expanded: boolean;
     onPermalinkClick: (commentId: number) => void;
     apiKey: string;
-    onHeightChange: () => void;
+    onHeightChange?: () => void;
 };
 
 const footerStyles = css`
@@ -201,7 +201,7 @@ export const App = ({
     expanded,
     onPermalinkClick,
     apiKey,
-    onHeightChange,
+    onHeightChange = () => {},
 }: Props) => {
     const [filters, setFilters] = useState<FilterOptions>(
         initialiseFilters({

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,7 +16,6 @@ ReactDOM.render(
         expanded={false}
         onPermalinkClick={() => {}}
         apiKey="discussion-rendering"
-        onHeightChange={() => {}}
     />,
     document.getElementById('root'),
 );


### PR DESCRIPTION
## What does this change?
Makes the `onHeightChange` callback optional

## Why?
Because we don't want to be too proscriptive about how discussion should be used
