### PR TITLE
Scroll to form on reply

### DIFF
--- a/src/components/CommentContainer/CommentContainer.test.tsx
+++ b/src/components/CommentContainer/CommentContainer.test.tsx
@@ -57,6 +57,9 @@ describe('CommentContainer', () => {
             },
         );
 
+        // https://stackoverflow.com/a/52335414
+        Element.prototype.scrollIntoView = () => {};
+
         const { getByTestId, queryByText, getByText, rerender } = render(
             <CommentContainer
                 baseUrl=""
@@ -70,6 +73,7 @@ describe('CommentContainer', () => {
                 isClosedForComments={false}
                 mutes={[]}
                 toggleMuteStatus={() => {}}
+                onPermalinkClick={() => {}}
             />,
         );
 
@@ -108,6 +112,7 @@ describe('CommentContainer', () => {
                 isClosedForComments={false}
                 mutes={[]}
                 toggleMuteStatus={() => {}}
+                onPermalinkClick={() => {}}
             />,
         );
 
@@ -130,6 +135,9 @@ describe('CommentContainer', () => {
             },
         );
 
+        // https://stackoverflow.com/a/52335414
+        Element.prototype.scrollIntoView = () => {};
+
         const { getByTestId, queryByText, getByText, rerender } = render(
             <CommentContainer
                 baseUrl=""
@@ -143,6 +151,7 @@ describe('CommentContainer', () => {
                 isClosedForComments={false}
                 mutes={[]}
                 toggleMuteStatus={() => {}}
+                onPermalinkClick={() => {}}
             />,
         );
 
@@ -181,6 +190,7 @@ describe('CommentContainer', () => {
                 isClosedForComments={false}
                 mutes={[]}
                 toggleMuteStatus={() => {}}
+                onPermalinkClick={() => {}}
             />,
         );
 

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -218,7 +218,10 @@ export const CommentContainer = ({
                                 response.id === commentBeingRepliedTo.id,
                         )) &&
                     user && (
-                        <div className={nestingStyles}>
+                        <div
+                            id={`comment-reply-form-${commentBeingRepliedTo.id}`}
+                            className={nestingStyles}
+                        >
                             <CommentReplyPreview
                                 pillar={pillar}
                                 commentBeingRepliedTo={commentBeingRepliedTo}

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { css, cx } from 'emotion';
 
 import { palette, space } from '@guardian/src-foundations';
@@ -172,6 +172,15 @@ export const CommentForm = ({
     const [info, setInfo] = useState<string>('');
     const [showPreview, setShowPreview] = useState<boolean>(false);
     const textAreaRef = useRef<HTMLTextAreaElement>(null);
+
+    useEffect(() => {
+        if (commentBeingRepliedTo) {
+            const commentElement = document.getElementById(
+                `comment-reply-form-${commentBeingRepliedTo.id}`,
+            );
+            commentElement && commentElement.scrollIntoView();
+        }
+    }, [commentBeingRepliedTo]);
 
     const getHighlightedString = ():
         | {


### PR DESCRIPTION
## What does this change?
Now when you click reply, the form that gets shown is scrolled into view

## Why?
Because sometimes the list of replies can be quite long and the form can get lost
