### PR TITLE
Preview

### DIFF
--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -10,6 +10,7 @@ import { comment, reply, preview, addUserName } from '../../lib/api';
 import { CommentResponse, UserProfile, CommentType, Pillar } from '../../types';
 
 import { FirstCommentWelcome } from '../FirstCommentWelcome/FirstCommentWelcome';
+import { Preview } from '../Preview/Preview';
 import { Row } from '../Row/Row';
 import { PillarButton } from '../PillarButton/PillarButton';
 
@@ -60,24 +61,6 @@ const blackPlaceholder = css`
         font-weight: bold;
         opacity: 1;
         color: ${neutral[0]};
-    }
-`;
-
-const arrowSize = 15;
-const bg = neutral[93];
-const previewStyle = css`
-    padding: ${space[2]}px;
-    background-color: ${bg};
-    border-radius: 5px;
-    margin-bottom: ${arrowSize + 5}px;
-    position: relative;
-
-    :before {
-        content: '';
-        position: absolute;
-        border-right: ${arrowSize}px solid transparent;
-        border-top: ${arrowSize}px solid ${bg};
-        bottom: -${arrowSize - 1}px;
     }
 `;
 
@@ -530,12 +513,7 @@ export const CommentForm = ({
                 </div>
             </form>
 
-            {showPreview && (
-                <p
-                    className={previewStyle}
-                    dangerouslySetInnerHTML={{ __html: previewBody || '' }}
-                />
-            )}
+            {showPreview && <Preview previewHtml={previewBody} />}
         </>
     );
 };

--- a/src/components/Preview/Preview.stories.tsx
+++ b/src/components/Preview/Preview.stories.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import { Preview } from './Preview';
+
+export default { component: Preview, title: 'Preview' };
+
+export const PreviewStory = () => (
+    <Preview previewHtml="<p>This is some preview text</p>" />
+);
+PreviewStory.story = { name: 'default' };

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { css } from 'emotion';
+
+import { space, neutral } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/typography';
+
+type Props = {
+    previewHtml: string;
+};
+
+const previewStyle = css`
+    ${textSans.small()}
+    padding: ${space[2]}px ${space[4]}px;
+    background-color: ${neutral[93]};
+    border-radius: 5px;
+    margin-top: 0;
+    margin-bottom: ${20}px;
+`;
+
+const spout = css`
+    display: block;
+    left: 0;
+    width: 0;
+    height: 0;
+    border-right: 1rem solid transparent;
+    border-bottom: 1rem solid ${neutral[93]};
+    margin-left: 12.5rem;
+    border-right-style: inset;
+`;
+
+export const Preview = ({ previewHtml }: Props) => (
+    <>
+        <div className={spout} />
+        <p
+            className={previewStyle}
+            dangerouslySetInnerHTML={{ __html: previewHtml || '' }}
+        />
+    </>
+);


### PR DESCRIPTION
## What does this change?

![Screenshot 2020-05-14 at 17 09 02](https://user-images.githubusercontent.com/1336821/81958386-d291e100-9605-11ea-9200-bcb5e64aae8d.jpg)
Adds a Preview component with the correct styles


## Why?
We had overlooked this because we weren't testing for it
