### PR TITLE
Trigger height on fetch

### DIFF
--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -96,6 +96,7 @@ export const Overrides = () => (
             expanded={true}
             onPermalinkClick={() => {}}
             apiKey=""
+            onHeightChange={() => {}}
         />
     </div>
 );
@@ -176,6 +177,7 @@ export const Closed = () => (
             expanded={true}
             onPermalinkClick={() => {}}
             apiKey=""
+            onHeightChange={() => {}}
         />
     </div>
 );

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -62,6 +62,7 @@ describe('App', () => {
                 }}
                 apiKey="discussion-rendering-test"
                 onPermalinkClick={() => {}}
+                onHeightChange={() => {}}
             />,
         );
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -229,10 +229,11 @@ export const App = ({
             if (json?.status !== 'error') {
                 setComments(json?.discussion?.comments);
                 setCommentCount(json?.discussion?.topLevelCommentCount);
+                onHeightChange();
             }
             setTotalPages(json?.pages);
         });
-    }, [filters, page, shortUrl]);
+    }, [filters, page, shortUrl, onHeightChange]);
 
     useEffect(() => {
         const fetchPicks = async () => {
@@ -297,19 +298,16 @@ export const App = ({
         rememberFilters(newFilterObject);
         // Filters also show when the view is not expanded but we want to expand when they're changed
         setIsExpanded(true);
-        onHeightChange();
         setFilters(newFilterObject);
     };
 
     const onPageChange = (page: number) => {
         document.getElementById('comment-filters')?.scrollIntoView();
         setPage(page);
-        onHeightChange();
     };
 
     const expandView = () => {
         setIsExpanded(true);
-        onHeightChange();
     };
 
     const toggleMuteStatus = (userId: string) => {


### PR DESCRIPTION
## What does this change?
This moves the point where the `onHeightChange` callback gets fired to directly after the discussion fetch call

## Why?
We need this callback to fire more often to correctly set the container height in all situations, in particular, when using the `#comments` link