### PR TITLE
Comments are unpicked by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guardian/discussion-rendering",
     "description": "This codebase started as a hack day project by @gtrufitt and @nicl. The purpose is parity of the existing discussion application on Frontend using the discussion API (search for Private Repo).",
-    "version": "2.2.16",
+    "version": "2.2.17",
     "author": "",
     "homepage": "https://github.com/guardian/discussion-rendering#readme",
     "license": "Apache",

--- a/src/lib/simulateNewComment.ts
+++ b/src/lib/simulateNewComment.ts
@@ -22,7 +22,7 @@ export const simulateNewComment = (
         webUrl: `https://discussion.theguardian.com/comment-permalink/${commentId}`,
         apiUrl: `https://discussion.guardianapis.com/discussion-api/comment/${commentId}`,
         numRecommends: 0,
-        isHighlighted: true,
+        isHighlighted: false,
         userProfile: {
             userId: user.userId,
             displayName: user.displayName,

--- a/src/lib/simulateNewComment.ts
+++ b/src/lib/simulateNewComment.ts
@@ -19,8 +19,8 @@ export const simulateNewComment = (
         date: Date(),
         isoDateTime: new Date().toISOString(),
         status: 'visible',
-        webUrl: '', //TODO:
-        apiUrl: '', //TODO:
+        webUrl: `https://discussion.theguardian.com/comment-permalink/${commentId}`,
+        apiUrl: `https://discussion.guardianapis.com/discussion-api/comment/${commentId}`,
         numRecommends: 0,
         isHighlighted: true,
         userProfile: {
@@ -37,11 +37,11 @@ export const simulateNewComment = (
                   responseTo: {
                       displayName:
                           commentBeingRepliedTo.userProfile.displayName,
-                      commentApiUrl: '', //TODO:
+                      commentApiUrl: `https://discussion.guardianapis.com/discussion-api/comment/${commentBeingRepliedTo.id}`,
                       isoDateTime: commentBeingRepliedTo.isoDateTime,
                       date: commentBeingRepliedTo.date,
                       commentId: String(commentBeingRepliedTo.id),
-                      commentWebUrl: '', //TODO:
+                      commentWebUrl: `https://discussion.theguardian.com/comment-permalink/${commentBeingRepliedTo.id}`,
                   },
               }
             : {


### PR DESCRIPTION
## What does this change?
Ensures that new comments do not appear as picked when they are first posted (When simulating a comment to display optimistically, the `isHighlighted` property was being set to true).

## Why?
Because they're not
