### PR TITLE
Ensure comment styles are correct

### DIFF
--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -88,6 +88,20 @@ const commentCss = css`
     padding-left: ${space[2]}px;
     color: ${neutral[46]};
   }
+
+  i {
+      font-style: italic;
+  }
+
+  b {
+      font-weight: bold;
+  }
+
+  code {
+    font-family: monospace;
+    font-size: 1em;
+  }
+  
 `;
 
 const blockedCommentStyles = css`

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -25,7 +25,7 @@ type Props = {
 
 const boldString = (text: string) => `<b>${text}</b>`;
 const italicsString = (text: string) => `<i>${text}</i>`;
-const strikethroughString = (text: string) => `<strike>${text}</strike>`;
+const strikethroughString = (text: string) => `<del>${text}</del>`;
 const codeString = (text: string) => `<code>${text}</code>`;
 const quoteString = (text: string) => `<blockquote>${text}</blockquote>`;
 const linkStringFunc = (url: string, highlightedText?: string) =>

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -15,6 +15,34 @@ const previewStyle = css`
     border-radius: 5px;
     margin-top: 0;
     margin-bottom: ${20}px;
+    word-break: break-word;
+
+    p {
+        margin-top: 0;
+        margin-bottom: ${space[3]}px;
+    }
+
+    blockquote {
+        margin-top: ${space[3]}px;
+        margin-bottom: ${space[3]}px;
+        margin-left: ${space[5]}px;
+        margin-right: ${space[5]}px;
+        padding-left: ${space[2]}px;
+        color: ${neutral[46]};
+    }
+
+    i {
+        font-style: italic;
+    }
+
+    b {
+        font-weight: bold;
+    }
+
+    code {
+        font-family: monospace;
+        font-size: 1em;
+    }
 `;
 
 const spout = css`

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -17,11 +17,6 @@ const previewStyle = css`
     margin-bottom: ${20}px;
     word-break: break-word;
 
-    p {
-        margin-top: 0;
-        margin-bottom: ${space[3]}px;
-    }
-
     blockquote {
         margin-top: ${space[3]}px;
         margin-bottom: ${space[3]}px;


### PR DESCRIPTION
## What does this change?
Reviews and enforces specific styles for comments in both the comment and preview views

## Why?
A reader raised a problem where their comment text was not correctly being shown as italic. Upon investigation, I also noticed that some other aspects of formnatting were not always being set properly so here I fixed:

- strikethrough tag set wrongly (`strike`, not `del`)
- code formtting missing
- bold formtting missing
- italic formtting missing

### Preview before
![Screenshot 2020-05-22 at 14 56 15](https://user-images.githubusercontent.com/1336821/82675239-6da93d00-9c3c-11ea-9798-9cce93ef2a1f.jpg)
### Preview after
![Screenshot 2020-05-22 at 12 28 12](https://user-images.githubusercontent.com/1336821/82663765-3597ff00-9c28-11ea-9a32-1f992c8101e0.jpg)

### Comment before
![Screenshot 2020-05-22 at 14 48 51](https://user-images.githubusercontent.com/1336821/82674606-7baa8e00-9c3b-11ea-9fca-01b58c58a1dd.jpg)

### Comment after
![Screenshot 2020-05-22 at 15 37 26](https://user-images.githubusercontent.com/1336821/82678855-3fc6f700-9c42-11ea-84bf-047adc89e527.jpg)

