### PR TITLE
Fix link addresses

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -360,7 +360,6 @@ export const App = ({
                     <div className={picksWrapper}>
                         {!!picks.length && (
                             <TopPicks
-                                baseUrl={baseUrl}
                                 pillar={pillar}
                                 comments={picks.slice(0, 2)}
                                 isSignedIn={!!user}
@@ -397,7 +396,6 @@ export const App = ({
                                 {comments.slice(0, 2).map(comment => (
                                     <li key={comment.id}>
                                         <CommentContainer
-                                            baseUrl={baseUrl}
                                             comment={comment}
                                             pillar={pillar}
                                             isClosedForComments={
@@ -454,7 +452,6 @@ export const App = ({
                 )}
                 {!!picks.length && (
                     <TopPicks
-                        baseUrl={baseUrl}
                         pillar={pillar}
                         comments={picks}
                         isSignedIn={!!user}
@@ -488,7 +485,6 @@ export const App = ({
                         {comments.map(comment => (
                             <li key={comment.id}>
                                 <CommentContainer
-                                    baseUrl={baseUrl}
                                     comment={comment}
                                     pillar={pillar}
                                     isClosedForComments={isClosedForComments}

--- a/src/components/Comment/Comment.stories.tsx
+++ b/src/components/Comment/Comment.stories.tsx
@@ -85,7 +85,6 @@ const staffUser: UserProfile = {
 
 export const Root = () => (
     <Comment
-        baseUrl="https://discussion.theguardian.com/discussion-api"
         comment={commentData}
         pillar={'news'}
         isClosedForComments={false}
@@ -105,7 +104,6 @@ Root.story = {
 
 export const RootMobile = () => (
     <Comment
-        baseUrl="https://discussion.theguardian.com/discussion-api"
         comment={commentData}
         pillar={'sport'}
         setCommentBeingRepliedTo={() => {}}
@@ -125,7 +123,6 @@ RootMobile.story = {
 
 export const ReplyComment = () => (
     <Comment
-        baseUrl="https://discussion.theguardian.com/discussion-api"
         comment={replyCommentData}
         pillar={'lifestyle'}
         isClosedForComments={false}
@@ -145,7 +142,6 @@ ReplyComment.story = {
 
 export const MobileReply = () => (
     <Comment
-        baseUrl="https://discussion.theguardian.com/discussion-api"
         comment={replyCommentData}
         pillar={'culture'}
         setCommentBeingRepliedTo={() => {}}
@@ -165,7 +161,6 @@ MobileReply.story = {
 
 export const PickedComment = () => (
     <Comment
-        baseUrl="https://discussion.theguardian.com/discussion-api"
         comment={{
             ...commentData,
             isHighlighted: true,
@@ -182,7 +177,6 @@ PickedComment.story = { name: 'Picked Comment' };
 
 export const StaffUserComment = () => (
     <Comment
-        baseUrl="https://discussion.theguardian.com/discussion-api"
         comment={commentStaffData}
         pillar={'opinion'}
         isClosedForComments={false}
@@ -196,7 +190,6 @@ StaffUserComment.story = { name: 'Staff User Comment' };
 
 export const PickedStaffUserComment = () => (
     <Comment
-        baseUrl="https://discussion.theguardian.com/discussion-api"
         comment={{
             ...commentStaffData,
             isHighlighted: true,
@@ -219,7 +212,6 @@ PickedStaffUserComment.story = {
 
 export const PickedStaffUserCommentMobile = () => (
     <Comment
-        baseUrl="https://discussion.theguardian.com/discussion-api"
         comment={{
             ...commentStaffData,
             isHighlighted: true,
@@ -242,7 +234,6 @@ PickedStaffUserCommentMobile.story = {
 
 export const LoggedInAsModerator = () => (
     <Comment
-        baseUrl="https://discussion.theguardian.com/discussion-api"
         comment={commentData}
         pillar={'lifestyle'}
         isClosedForComments={false}
@@ -257,7 +248,6 @@ LoggedInAsModerator.story = { name: 'Logged in as moderator' };
 
 export const BlockedComment = () => (
     <Comment
-        baseUrl="https://discussion.theguardian.com/discussion-api"
         comment={blockedCommentData}
         pillar={'culture'}
         isClosedForComments={false}
@@ -271,7 +261,6 @@ BlockedComment.story = { name: 'Blocked comment' };
 
 export const MutedComment = () => (
     <Comment
-        baseUrl="https://discussion.theguardian.com/discussion-api"
         comment={blockedCommentData}
         pillar={'sport'}
         isClosedForComments={false}
@@ -285,7 +274,6 @@ MutedComment.story = { name: 'Muted comment' };
 
 export const ClosedForComments = () => (
     <Comment
-        baseUrl="https://discussion.theguardian.com/discussion-api"
         comment={commentData}
         pillar={'news'}
         isClosedForComments={true}

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -19,10 +19,8 @@ import { ButtonLink } from '../ButtonLink/ButtonLink';
 
 import { Pillar, CommentType, UserProfile } from '../../types';
 import { pickComment, unPickComment } from '../../lib/api';
-import { joinUrl } from '../../lib/joinUrl';
 
 type Props = {
-    baseUrl: string;
     user?: UserProfile;
     comment: CommentType;
     pillar: Pillar;
@@ -222,7 +220,6 @@ const Space = ({ amount }: { amount: 1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24 }) => (
 );
 
 export const Comment = ({
-    baseUrl,
     comment,
     pillar,
     isClosedForComments,
@@ -338,7 +335,7 @@ export const Comment = ({
                                         </div>
                                         <Timestamp
                                             isoDateTime={comment.isoDateTime}
-                                            baseUrl={baseUrl}
+                                            webUrl={comment.webUrl}
                                             commentId={comment.id}
                                             onPermalinkClick={onPermalinkClick}
                                         />
@@ -394,7 +391,7 @@ export const Comment = ({
                                     >
                                         <Timestamp
                                             isoDateTime={comment.isoDateTime}
-                                            baseUrl={baseUrl}
+                                            webUrl={comment.webUrl}
                                             commentId={comment.id}
                                             onPermalinkClick={onPermalinkClick}
                                         />
@@ -535,7 +532,7 @@ export const Comment = ({
                                                         )}
                                                     >
                                                         <Link
-                                                            href={`https://profile.theguardian.com/signin?returnUrl=https://discussion.theguardian.com/comment-permalink/${comment.id}`}
+                                                            href={`https://profile.theguardian.com/signin?returnUrl=${comment.webUrl}`}
                                                             subdued={true}
                                                             icon={<SvgIndent />}
                                                             iconSide="left"

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -325,10 +325,9 @@ export const Comment = ({
                                             )}
                                         >
                                             <Link
-                                                href={joinUrl([
-                                                    'https://profile.theguardian.com/user',
-                                                    comment.userProfile.userId,
-                                                ])}
+                                                href={
+                                                    comment.userProfile.webUrl
+                                                }
                                                 subdued={true}
                                             >
                                                 {
@@ -360,10 +359,7 @@ export const Comment = ({
                                         )}
                                     >
                                         <Link
-                                            href={joinUrl([
-                                                'https://profile.theguardian.com/user',
-                                                comment.userProfile.userId,
-                                            ])}
+                                            href={comment.userProfile.webUrl}
                                             subdued={true}
                                         >
                                             {comment.userProfile.displayName}

--- a/src/components/CommentContainer/CommentContainer.stories.tsx
+++ b/src/components/CommentContainer/CommentContainer.stories.tsx
@@ -99,7 +99,6 @@ const commentDataThreaded: CommentType = {
 
 export const defaultStory = () => (
     <CommentContainer
-        baseUrl="https://discussion.theguardian.com/discussion-api"
         comment={commentData}
         pillar={'sport'}
         isClosedForComments={false}
@@ -116,7 +115,6 @@ defaultStory.story = { name: 'default' };
 
 export const threadedComment = () => (
     <CommentContainer
-        baseUrl="https://discussion.theguardian.com/discussion-api"
         comment={commentDataThreaded}
         pillar={'lifestyle'}
         isClosedForComments={false}

--- a/src/components/CommentContainer/CommentContainer.test.tsx
+++ b/src/components/CommentContainer/CommentContainer.test.tsx
@@ -62,7 +62,6 @@ describe('CommentContainer', () => {
 
         const { getByTestId, queryByText, getByText, rerender } = render(
             <CommentContainer
-                baseUrl=""
                 shortUrl=""
                 comment={commentWithoutReply} //TODO: should be comments with reponses
                 pillar="news"
@@ -101,7 +100,6 @@ describe('CommentContainer', () => {
         // rerender with updated commentBeingRepliedTo
         rerender(
             <CommentContainer
-                baseUrl=""
                 shortUrl=""
                 comment={commentWithoutReply} //TODO: should be comments with reponses
                 pillar="news"
@@ -140,7 +138,6 @@ describe('CommentContainer', () => {
 
         const { getByTestId, queryByText, getByText, rerender } = render(
             <CommentContainer
-                baseUrl=""
                 shortUrl=""
                 comment={commentWithReply} //TODO: should be comments with reponses
                 pillar="news"
@@ -179,7 +176,6 @@ describe('CommentContainer', () => {
         // rerender with updated commentBeingRepliedTo
         rerender(
             <CommentContainer
-                baseUrl=""
                 shortUrl=""
                 comment={commentWithoutReply} //TODO: should be comments with reponses
                 pillar="news"

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -12,7 +12,6 @@ import { CommentReplyPreview } from '../CommentReplyPreview/CommentReplyPreview'
 import { getMoreResponses } from '../../lib/api';
 
 type Props = {
-    baseUrl: string;
     comment: CommentType;
     pillar: Pillar;
     isClosedForComments: boolean;
@@ -92,7 +91,6 @@ const Plus = () => (
 );
 
 export const CommentContainer = ({
-    baseUrl,
     comment,
     pillar,
     isClosedForComments,
@@ -140,7 +138,6 @@ export const CommentContainer = ({
     return (
         <div className={cx(commentToScrollTo === comment.id && selectedStyles)}>
             <Comment
-                baseUrl={baseUrl}
                 comment={comment}
                 pillar={pillar}
                 isClosedForComments={isClosedForComments}
@@ -161,7 +158,6 @@ export const CommentContainer = ({
                             {responses.map(responseComment => (
                                 <li key={responseComment.id}>
                                     <Comment
-                                        baseUrl={baseUrl}
                                         comment={responseComment}
                                         pillar={pillar}
                                         isClosedForComments={

--- a/src/components/Timestamp/Timestamp.stories.tsx
+++ b/src/components/Timestamp/Timestamp.stories.tsx
@@ -9,7 +9,7 @@ export default { component: Timestamp, title: 'Timestamp' };
 export const TwoMonths = () => (
     <Timestamp
         isoDateTime={'2020-01-26T14:22:39Z'}
-        baseUrl=""
+        webUrl=""
         commentId={123}
         onPermalinkClick={() => {}}
     />
@@ -19,7 +19,7 @@ TwoMonths.story = { name: 'Two months' };
 export const OneHour = () => (
     <Timestamp
         isoDateTime={'2020-03-27T11:00:00Z'}
-        baseUrl=""
+        webUrl=""
         commentId={123}
         onPermalinkClick={() => {}}
     />
@@ -29,7 +29,7 @@ OneHour.story = { name: 'One Hour' };
 export const TwentyThreeHours = () => (
     <Timestamp
         isoDateTime={'2020-03-26T13:00:00Z'}
-        baseUrl=""
+        webUrl=""
         commentId={123}
         onPermalinkClick={() => {}}
     />
@@ -39,7 +39,7 @@ TwentyThreeHours.story = { name: 'Twenty three hours' };
 export const TwentyFiveHours = () => (
     <Timestamp
         isoDateTime={'2020-03-26T11:00:00Z'}
-        baseUrl=""
+        webUrl=""
         commentId={123}
         onPermalinkClick={() => {}}
     />

--- a/src/components/Timestamp/Timestamp.tsx
+++ b/src/components/Timestamp/Timestamp.tsx
@@ -6,11 +6,10 @@ import { palette } from '@guardian/src-foundations';
 
 import { dateFormatter } from '../../lib/dateFormatter';
 import { useInterval } from '../../lib/useInterval';
-import { joinUrl } from '../../lib/joinUrl';
 
 type Props = {
     isoDateTime: string;
-    baseUrl: string;
+    webUrl: string;
     commentId: number;
     onPermalinkClick: (commentId: number) => void;
 };
@@ -31,21 +30,11 @@ const timeStyles = css`
 
 export const Timestamp = ({
     isoDateTime,
-    baseUrl,
+    webUrl,
     commentId,
     onPermalinkClick,
 }: Props) => {
     let [timeAgo, setTimeAgo] = useState(dateFormatter(isoDateTime));
-
-    const linkTo = joinUrl([
-        // Remove the discussion-api path from the baseUrl
-        baseUrl
-            .split('/')
-            .filter(path => path !== 'discussion-api')
-            .join('/'),
-        'comment-permalink',
-        commentId.toString(),
-    ]);
 
     useInterval(() => {
         setTimeAgo(dateFormatter(isoDateTime));
@@ -53,7 +42,7 @@ export const Timestamp = ({
 
     return (
         <a
-            href={linkTo}
+            href={webUrl}
             className={linkStyles}
             data-link-name="jump-to-comment-timestamp"
             onClick={e => {

--- a/src/components/TopPick/TopPick.stories.tsx
+++ b/src/components/TopPick/TopPick.stories.tsx
@@ -57,7 +57,6 @@ export const LongPick = () => (
         `}
     >
         <TopPick
-            baseUrl="https://discussion.guardianapis.com/discussion-api"
             pillar="news"
             comment={comment}
             isSignedIn={false}
@@ -75,7 +74,6 @@ export const ShortPick = () => (
         `}
     >
         <TopPick
-            baseUrl="https://discussion.guardianapis.com/discussion-api"
             pillar="opinion"
             comment={commentWithShortBody}
             isSignedIn={true}

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -206,7 +206,7 @@ export const TopPick = ({
                 <Column>
                     <span className={userNameStyles(pillar)}>
                         <a
-                            href={`https://profile.theguardian.com/user/${comment.userProfile.userId}`}
+                            href={comment.userProfile.webUrl}
                             className={cx(linkStyles, inheritColour)}
                         >
                             {comment.userProfile.displayName}

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -14,10 +14,7 @@ import { Timestamp } from '../Timestamp/Timestamp';
 import { Row } from '../Row/Row';
 import { Column } from '../Column/Column';
 
-import { joinUrl } from '../../lib/joinUrl';
-
 type Props = {
-    baseUrl: string;
     pillar: Pillar;
     comment: CommentType;
     isSignedIn: boolean;
@@ -152,7 +149,6 @@ const truncateText = (input: string, limit: number) => {
 };
 
 export const TopPick = ({
-    baseUrl,
     pillar,
     comment,
     isSignedIn,
@@ -175,15 +171,7 @@ export const TopPick = ({
                     <Link
                         priority="primary"
                         subdued={true}
-                        href={joinUrl([
-                            // Remove the discussion-api path from the baseUrl
-                            baseUrl
-                                .split('/')
-                                .filter(path => path !== 'discussion-api')
-                                .join('/'),
-                            'comment-permalink',
-                            comment.id.toString(),
-                        ])}
+                        href={comment.webUrl}
                         onClick={e => {
                             onPermalinkClick(comment.id);
                             e.preventDefault();
@@ -214,7 +202,7 @@ export const TopPick = ({
                     </span>
                     <Timestamp
                         isoDateTime={comment.isoDateTime}
-                        baseUrl={baseUrl}
+                        webUrl={comment.webUrl}
                         commentId={comment.id}
                         onPermalinkClick={onPermalinkClick}
                     />

--- a/src/components/TopPicks/TopPicks.stories.tsx
+++ b/src/components/TopPicks/TopPicks.stories.tsx
@@ -57,7 +57,6 @@ const commentWithShortBody: CommentType = {
 
 export const SingleComment = () => (
     <TopPicks
-        baseUrl="https://discussion.guardianapis.com/discussion-api"
         pillar="news"
         comments={[commentWithShortBody]}
         isSignedIn={true}
@@ -67,7 +66,6 @@ SingleComment.story = { name: 'Single Comment' };
 
 export const MulitColumn = () => (
     <TopPicks
-        baseUrl="https://discussion.guardianapis.com/discussion-api"
         pillar="culture"
         comments={[
             commentWithLongBody,
@@ -82,7 +80,6 @@ MulitColumn.story = { name: 'Mulitple Columns Comments' };
 
 export const SingleColumn = () => (
     <TopPicks
-        baseUrl="https://discussion.guardianapis.com/discussion-api"
         pillar="sport"
         comments={[
             commentWithLongBody,

--- a/src/components/TopPicks/TopPicks.tsx
+++ b/src/components/TopPicks/TopPicks.tsx
@@ -7,7 +7,6 @@ import { CommentType, Pillar, UserProfile } from '../../types';
 import { TopPick } from '../TopPick/TopPick';
 
 type Props = {
-    baseUrl: string;
     pillar: Pillar;
     user?: UserProfile;
     comments: CommentType[];
@@ -49,7 +48,6 @@ const oneColCommentsStyles = css`
 `;
 
 export const TopPicks = ({
-    baseUrl,
     pillar,
     user,
     comments,
@@ -69,7 +67,6 @@ export const TopPicks = ({
                 <div className={cx(columWrapperStyles, paddingRight)}>
                     {leftColComments.map(comment => (
                         <TopPick
-                            baseUrl={baseUrl}
                             pillar={pillar}
                             comment={comment}
                             isSignedIn={isSignedIn}
@@ -84,7 +81,6 @@ export const TopPicks = ({
                 <div className={cx(columWrapperStyles, paddingLeft)}>
                     {rightColComments.map(comment => (
                         <TopPick
-                            baseUrl={baseUrl}
                             pillar={pillar}
                             comment={comment}
                             isSignedIn={isSignedIn}
@@ -100,7 +96,6 @@ export const TopPicks = ({
             <div className={oneColCommentsStyles}>
                 {comments.map(comment => (
                     <TopPick
-                        baseUrl={baseUrl}
                         pillar={pillar}
                         comment={comment}
                         isSignedIn={isSignedIn}

--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -196,9 +196,12 @@ export const reportAbuse = ({
     email?: string;
 }) => {
     const url =
-        options.baseUrl +
-        `/comment/${commentId}/reportAbuse` +
-        objAsParams(defaultParams);
+        joinUrl([
+            options.baseUrl,
+            'comment',
+            commentId.toString(),
+            'reportAbuse',
+        ]) + objAsParams(defaultParams);
 
     const data = new URLSearchParams();
     data.append('categoryId', categoryId.toString());


### PR DESCRIPTION
## What does this change?
Fixes the way we construct link addresses.

Instead of creating the strings manually we now just use the urls that are passed in as part of the `comment` object. As a consequence, we can mostly remove the use of the `baseUrl` property

## Why?
This is the intended purpose of these urls. We want to centralise the config so that any changes are automatically carried through.
