### PR TITLE
Is a discussion is closed, default orderBy to oldest

### DIFF
--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -85,7 +85,7 @@ export const Overrides = () => (
             shortUrl="p/39f5z"
             initialPage={3}
             pageSizeOverride={50}
-            orderByOverride={'oldest'}
+            orderByOverride="recommendations"
             baseUrl="https://discussion.theguardian.com/discussion-api"
             pillar="opinion"
             isClosedForComments={false}


### PR DESCRIPTION
## What does this change?
Changes the default `orderBy` value from always `newest` to use a function based on if the discussion is cloded or not

## Why?
Because  this is how frontend does this and readers will be used to this
