### PR TITLE
Default to 100 comments per page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,7 @@ const picksWrapper = css`
 
 const DEFAULT_FILTERS: FilterOptions = {
     orderBy: 'newest',
-    pageSize: 25,
+    pageSize: 100,
     threads: 'collapsed',
 };
 


### PR DESCRIPTION
## What does this change?
Changes the default count of comments to show from 25 to 100

## Why?
We don't want to hide content and force readers to needlessly scroll