### PR TITLE
No view more if there's no more to view

### DIFF
--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -182,3 +182,30 @@ export const Closed = () => (
     </div>
 );
 Closed.story = { name: 'Logged in but closed for comments' };
+
+export const NoComments = () => (
+    <div
+        className={css`
+            width: 100%;
+            max-width: 620px;
+        `}
+    >
+        <App
+            shortUrl="p/39f5x" // A discussion with zero comments
+            baseUrl="https://discussion.theguardian.com/discussion-api"
+            pillar="culture"
+            isClosedForComments={false}
+            additionalHeaders={{
+                'D2-X-UID': 'testD2Header',
+                'GU-Client': 'testClientHeader',
+            }}
+            expanded={false}
+            onPermalinkClick={() => {}}
+            apiKey=""
+            onHeightChange={() => {}}
+        />
+    </div>
+);
+NoComments.story = {
+    name: 'when no comments have been made',
+};

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import { render, fireEvent } from '@testing-library/react';
+import {
+    render,
+    fireEvent,
+    waitForElementToBeRemoved,
+    screen,
+} from '@testing-library/react';
 
 import { mockFetchCalls } from './lib/mockFetchCalls';
 
@@ -24,8 +29,8 @@ const aUser = {
 };
 
 describe('App', () => {
-    it('should expand when view more button is clicked', () => {
-        const { getByText, queryByText } = render(
+    it('should expand when view more button is clicked', async () => {
+        render(
             <App
                 baseUrl=""
                 shortUrl="p/39f5z"
@@ -42,36 +47,47 @@ describe('App', () => {
             />,
         );
 
-        expect(queryByText('View more comments')).toBeInTheDocument();
-        fireEvent.click(getByText('View more comments'));
-        expect(queryByText('View more comments')).not.toBeInTheDocument();
-        expect(getByText('Display threads')).toBeInTheDocument();
+        await waitForElementToBeRemoved(() =>
+            screen.getByTestId('loading-comments'),
+        );
+
+        expect(screen.queryByText('View more comments')).toBeInTheDocument();
+        fireEvent.click(screen.getByText('View more comments'));
+        expect(
+            screen.queryByText('View more comments'),
+        ).not.toBeInTheDocument();
+        expect(screen.getByText('Display threads')).toBeInTheDocument();
     });
 
-    it('should not render the comment form if user is logged out', () => {
-        const { queryByText, queryByPlaceholderText } = render(
+    it('should not render the comment form if user is logged out', async () => {
+        render(
             <App
-                baseUrl=""
                 shortUrl="p/39f5z"
-                pillar="news"
+                baseUrl="https://discussion.theguardian.com/discussion-api"
+                pillar="culture"
                 isClosedForComments={false}
-                expanded={false}
                 additionalHeaders={{
                     'D2-X-UID': 'testD2Header',
                     'GU-Client': 'testClientHeader',
                 }}
-                apiKey="discussion-rendering-test"
+                expanded={false}
                 onPermalinkClick={() => {}}
+                apiKey=""
                 onHeightChange={() => {}}
             />,
         );
 
-        expect(queryByText('View more comments')).toBeInTheDocument();
-        expect(queryByPlaceholderText('Join the discussion')).toBeNull();
+        await waitForElementToBeRemoved(() =>
+            screen.getByTestId('loading-comments'),
+        );
+
+        expect(screen.getByText('View more comments')).toBeInTheDocument();
+        expect(screen.queryAllByText('jamesgorrie').length).toBeGreaterThan(0);
+        expect(screen.queryByPlaceholderText('Join the discussion')).toBeNull();
     });
 
-    it('should render two comment forms when user is logged in', () => {
-        const { queryAllByPlaceholderText } = render(
+    it('should render two comment forms when user is logged in', async () => {
+        render(
             <App
                 baseUrl=""
                 shortUrl="p/39f5z"
@@ -88,6 +104,13 @@ describe('App', () => {
                 onHeightChange={() => {}}
             />,
         );
-        expect(queryAllByPlaceholderText('Join the discussion').length).toBe(2);
+
+        await waitForElementToBeRemoved(() =>
+            screen.getByTestId('loading-comments'),
+        );
+
+        expect(
+            screen.queryAllByPlaceholderText('Join the discussion').length,
+        ).toBe(2);
     });
 });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -113,4 +113,32 @@ describe('App', () => {
             screen.queryAllByPlaceholderText('Join the discussion').length,
         ).toBe(2);
     });
+
+    it('should not render the view more button if there are < 2 comments', async () => {
+        render(
+            <App
+                baseUrl=""
+                shortUrl="p/39f5x" // A discussion with no comments
+                pillar="news"
+                isClosedForComments={false}
+                expanded={false}
+                additionalHeaders={{
+                    'D2-X-UID': 'testD2Header',
+                    'GU-Client': 'testClientHeader',
+                }}
+                apiKey="discussion-rendering-test"
+                onPermalinkClick={() => {}}
+                onHeightChange={() => {}}
+            />,
+        );
+
+        await waitForElementToBeRemoved(() =>
+            screen.getByTestId('loading-comments'),
+        );
+
+        expect(screen.getByText('Display threads')).toBeInTheDocument();
+        expect(
+            screen.queryByText('View more comments'),
+        ).not.toBeInTheDocument();
+    });
 });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -114,11 +114,39 @@ describe('App', () => {
         ).toBe(2);
     });
 
-    it('should not render the view more button if there are < 2 comments', async () => {
+    it('should not render the view more button if there are zero comments', async () => {
         render(
             <App
                 baseUrl=""
                 shortUrl="p/39f5x" // A discussion with no comments
+                pillar="news"
+                isClosedForComments={false}
+                expanded={false}
+                additionalHeaders={{
+                    'D2-X-UID': 'testD2Header',
+                    'GU-Client': 'testClientHeader',
+                }}
+                apiKey="discussion-rendering-test"
+                onPermalinkClick={() => {}}
+                onHeightChange={() => {}}
+            />,
+        );
+
+        await waitForElementToBeRemoved(() =>
+            screen.getByTestId('loading-comments'),
+        );
+
+        expect(screen.getByText('Display threads')).toBeInTheDocument();
+        expect(
+            screen.queryByText('View more comments'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('should not render the view more button if there are only two comments', async () => {
+        render(
+            <App
+                baseUrl=""
+                shortUrl="p/39f5a" // A discussion with only two comments
                 pillar="news"
                 isClosedForComments={false}
                 expanded={false}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -438,21 +438,23 @@ export const App = ({
                         )}
                     </>
                 )}
-                <div
-                    className={css`
-                        width: 250px;
-                    `}
-                >
-                    <PillarButton
-                        pillar={pillar}
-                        onClick={() => expandView()}
-                        icon={<PlusSVG />}
-                        iconSide="left"
-                        linkName="more-comments"
+                {commentCount > 2 && (
+                    <div
+                        className={css`
+                            width: 250px;
+                        `}
                     >
-                        View more comments
-                    </PillarButton>
-                </div>
+                        <PillarButton
+                            pillar={pillar}
+                            onClick={() => expandView()}
+                            icon={<PlusSVG />}
+                            iconSide="left"
+                            linkName="more-comments"
+                        >
+                            View more comments
+                        </PillarButton>
+                    </div>
+                )}
             </div>
         );
     }

--- a/src/components/Comment/Comment.stories.tsx
+++ b/src/components/Comment/Comment.stories.tsx
@@ -92,6 +92,7 @@ export const Root = () => (
         isReply={false}
         isMuted={false}
         toggleMuteStatus={() => {}}
+        onPermalinkClick={() => {}}
     />
 );
 Root.story = {
@@ -111,6 +112,7 @@ export const RootMobile = () => (
         isClosedForComments={false}
         isMuted={false}
         toggleMuteStatus={() => {}}
+        onPermalinkClick={() => {}}
     />
 );
 RootMobile.story = {
@@ -130,6 +132,7 @@ export const ReplyComment = () => (
         isReply={true}
         isMuted={false}
         toggleMuteStatus={() => {}}
+        onPermalinkClick={() => {}}
     />
 );
 ReplyComment.story = {
@@ -149,6 +152,7 @@ export const MobileReply = () => (
         isClosedForComments={false}
         isMuted={false}
         toggleMuteStatus={() => {}}
+        onPermalinkClick={() => {}}
     />
 );
 MobileReply.story = {
@@ -171,6 +175,7 @@ export const PickedComment = () => (
         isReply={false}
         isMuted={false}
         toggleMuteStatus={() => {}}
+        onPermalinkClick={() => {}}
     />
 );
 PickedComment.story = { name: 'Picked Comment' };
@@ -184,6 +189,7 @@ export const StaffUserComment = () => (
         isReply={false}
         isMuted={false}
         toggleMuteStatus={() => {}}
+        onPermalinkClick={() => {}}
     />
 );
 StaffUserComment.story = { name: 'Staff User Comment' };
@@ -200,6 +206,7 @@ export const PickedStaffUserComment = () => (
         isReply={false}
         isMuted={false}
         toggleMuteStatus={() => {}}
+        onPermalinkClick={() => {}}
     />
 );
 PickedStaffUserComment.story = {
@@ -222,6 +229,7 @@ export const PickedStaffUserCommentMobile = () => (
         isReply={false}
         isMuted={false}
         toggleMuteStatus={() => {}}
+        onPermalinkClick={() => {}}
     />
 );
 PickedStaffUserCommentMobile.story = {
@@ -242,6 +250,7 @@ export const LoggedInAsModerator = () => (
         isReply={false}
         isMuted={false}
         toggleMuteStatus={() => {}}
+        onPermalinkClick={() => {}}
     />
 );
 LoggedInAsModerator.story = { name: 'Logged in as moderator' };
@@ -255,6 +264,7 @@ export const BlockedComment = () => (
         isReply={false}
         isMuted={false}
         toggleMuteStatus={() => {}}
+        onPermalinkClick={() => {}}
     />
 );
 BlockedComment.story = { name: 'Blocked comment' };
@@ -268,6 +278,7 @@ export const MutedComment = () => (
         isReply={false}
         isMuted={true}
         toggleMuteStatus={() => {}}
+        onPermalinkClick={() => {}}
     />
 );
 MutedComment.story = { name: 'Muted comment' };
@@ -281,6 +292,7 @@ export const ClosedForComments = () => (
         isReply={false}
         isMuted={false}
         toggleMuteStatus={() => {}}
+        onPermalinkClick={() => {}}
     />
 );
 ClosedForComments.story = {

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 
 import { DropdownOptionType } from '../../types';
 import { Dropdown } from './Dropdown';
@@ -30,7 +30,7 @@ const noActiveOptions: DropdownOptionType[] = threadOptions.map(option => ({
 describe('Dropdown', () => {
     it('should display the given label', () => {
         const label = 'I should show';
-        const { getByText } = render(
+        render(
             <Dropdown
                 id="abc"
                 pillar="news"
@@ -40,11 +40,11 @@ describe('Dropdown', () => {
             />,
         );
 
-        expect(getByText(label)).toBeInTheDocument();
+        expect(screen.getByText(label)).toBeInTheDocument();
     });
 
     it('should display option titles', () => {
-        const { getByText } = render(
+        render(
             <Dropdown
                 id="abc"
                 pillar="news"
@@ -54,9 +54,9 @@ describe('Dropdown', () => {
             />,
         );
 
-        expect(getByText(threadOptions[0].title)).toBeInTheDocument();
-        expect(getByText(threadOptions[1].title)).toBeInTheDocument();
-        expect(getByText(threadOptions[2].title)).toBeInTheDocument();
+        expect(screen.getByText(threadOptions[0].title)).toBeInTheDocument();
+        expect(screen.getByText(threadOptions[1].title)).toBeInTheDocument();
+        expect(screen.getByText(threadOptions[2].title)).toBeInTheDocument();
     });
 
     it('should render the correct number of options', () => {
@@ -75,7 +75,7 @@ describe('Dropdown', () => {
     });
 
     it('should expand the menu when the label is clicked', () => {
-        const { container, getByRole } = render(
+        const { container } = render(
             <Dropdown
                 id="abc"
                 pillar="news"
@@ -87,12 +87,12 @@ describe('Dropdown', () => {
 
         const ulElement = container.querySelector('ul');
         expect(ulElement).toHaveStyle('display: none');
-        fireEvent.click(getByRole('button'));
+        fireEvent.click(screen.getByRole('button'));
         expect(ulElement).toHaveStyle('display: block');
     });
 
     it('should close the expanded menu when readers click away', () => {
-        const { container, getByRole } = render(
+        const { container } = render(
             <Dropdown
                 id="abc"
                 pillar="news"
@@ -103,14 +103,14 @@ describe('Dropdown', () => {
         );
 
         const ulElement = container.querySelector('ul');
-        fireEvent.click(getByRole('button'));
+        fireEvent.click(screen.getByRole('button'));
         expect(ulElement).toHaveStyle('display: block');
-        container.click();
+        fireEvent.click(container);
         expect(ulElement).toHaveStyle('display: none');
     });
 
     it('should close the expanded menu when blurred', () => {
-        const { container, getByRole } = render(
+        const { container } = render(
             <Dropdown
                 id="abc"
                 pillar="news"
@@ -121,7 +121,7 @@ describe('Dropdown', () => {
         );
 
         const ulElement = container.querySelector('ul');
-        fireEvent.click(getByRole('button'));
+        fireEvent.click(screen.getByRole('button'));
         expect(ulElement).toHaveStyle('display: block');
         fireEvent.keyDown(container, { key: 'Escape', code: 'Escape' });
         expect(ulElement).toHaveStyle('display: none');
@@ -130,7 +130,7 @@ describe('Dropdown', () => {
 
 it('should trigger the correct onSelect callbacks when an option is clicked', () => {
     const mockCallback = jest.fn();
-    const { getByRole, getByText } = render(
+    render(
         <Dropdown
             id="abc"
             pillar="news"
@@ -140,12 +140,12 @@ it('should trigger the correct onSelect callbacks when an option is clicked', (
         />,
     );
 
-    fireEvent.click(getByRole('button'));
-    fireEvent.click(getByText(threadOptions[2].title));
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByText(threadOptions[2].title));
     expect(mockCallback).toHaveBeenCalled();
     expect(mockCallback.mock.calls[0][0]).toBe('unthreaded');
-    fireEvent.click(getByRole('button'));
-    fireEvent.click(getByText(threadOptions[1].title));
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByText(threadOptions[1].title));
     expect(mockCallback).toHaveBeenCalled();
     expect(mockCallback.mock.calls[1][0]).toBe('expanded');
 });

--- a/src/components/LoadingComments/LoadingComments.tsx
+++ b/src/components/LoadingComments/LoadingComments.tsx
@@ -71,7 +71,7 @@ const Grey = ({
 );
 
 export const LoadingComments = () => (
-    <div className={containerStyles}>
+    <div className={containerStyles} data-testid="loading-comments">
         <div className={avatarStyles(48)} />
         <Column>
             <Row>

--- a/src/components/TopPicks/TopPicks.tsx
+++ b/src/components/TopPicks/TopPicks.tsx
@@ -67,6 +67,7 @@ export const TopPicks = ({
                 <div className={cx(columWrapperStyles, paddingRight)}>
                     {leftColComments.map(comment => (
                         <TopPick
+                            key={comment.id}
                             pillar={pillar}
                             comment={comment}
                             isSignedIn={isSignedIn}
@@ -81,6 +82,7 @@ export const TopPicks = ({
                 <div className={cx(columWrapperStyles, paddingLeft)}>
                     {rightColComments.map(comment => (
                         <TopPick
+                            key={comment.id}
                             pillar={pillar}
                             comment={comment}
                             isSignedIn={isSignedIn}
@@ -96,6 +98,7 @@ export const TopPicks = ({
             <div className={oneColCommentsStyles}>
                 {comments.map(comment => (
                     <TopPick
+                        key={comment.id}
                         pillar={pillar}
                         comment={comment}
                         isSignedIn={isSignedIn}

--- a/src/fixtures/discussionWithNoComments.ts
+++ b/src/fixtures/discussionWithNoComments.ts
@@ -1,0 +1,24 @@
+import { DiscussionResponse } from '../types';
+
+export const discussionWithNoComments: DiscussionResponse = {
+    status: 'ok',
+    page: 1,
+    pages: 0,
+    pageSize: 100,
+    orderBy: 'oldest',
+    discussion: {
+        key: '/p/39f5x',
+        webUrl:
+            'https://www.theguardian.com/science/grrlscientist/2012/aug/07/3',
+        apiUrl:
+            'https://discussion.guardianapis.com/discussion-api/discussion//p/39f5x',
+        commentCount: 0,
+        topLevelCommentCount: 0,
+        isClosedForComments: false,
+        isClosedForRecommendation: false,
+        isThreaded: true,
+        title:
+            'Mystery bird: black-and-red broadbill, Cymbirhynchus macrorhynchos story',
+        comments: [],
+    },
+};

--- a/src/fixtures/discussionWithTwoComments.ts
+++ b/src/fixtures/discussionWithTwoComments.ts
@@ -1,0 +1,76 @@
+import { DiscussionResponse } from '../types';
+
+export const discussionWithTwoComments: DiscussionResponse = {
+    status: 'ok',
+    page: 1,
+    pages: 0,
+    pageSize: 100,
+    orderBy: 'oldest',
+    discussion: {
+        key: '/p/39f5x',
+        webUrl:
+            'https://www.theguardian.com/science/grrlscientist/2012/aug/07/3',
+        apiUrl:
+            'https://discussion.guardianapis.com/discussion-api/discussion//p/39f5x',
+        commentCount: 0,
+        topLevelCommentCount: 0,
+        isClosedForComments: false,
+        isClosedForRecommendation: false,
+        isThreaded: true,
+        title:
+            'Mystery bird: black-and-red broadbill, Cymbirhynchus macrorhynchos story',
+        comments: [
+            {
+                id: 37772513,
+                body:
+                    '<p>Lovely chickens! <a href="http://www.mydomain.com">https://www.supersupersuperlongdomainnameImeanitneverstopsatallevereveritmakesyouwonderiftheremightbealimittothesethings.com</a></p>',
+                date: '04 July 2014 1:57pm',
+                isoDateTime: '2014-07-04T12:57:48Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/37772513',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/37772513',
+                numRecommends: 1,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '2310959',
+                    displayName: 'jamesgorrie',
+                    webUrl: 'https://profile.theguardian.com/user/id/2310959',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/2310959',
+                    avatar: 'https://avatar.guim.co.uk/user/2310959',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/2310959',
+                    badge: [
+                        {
+                            name: 'Staff',
+                        },
+                    ],
+                },
+            },
+            {
+                id: 42979860,
+                body: '<p>test</p>',
+                date: '30 October 2014 5:24pm',
+                isoDateTime: '2014-10-30T17:24:16Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/42979860',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/42979860',
+                numRecommends: 0,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '1186733',
+                    displayName: 'GideonGoldberg',
+                    webUrl: 'https://profile.theguardian.com/user/id/1186733',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/1186733',
+                    avatar: 'https://avatar.guim.co.uk/user/1186733',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/1186733',
+                    badge: [],
+                },
+            },
+        ],
+    },
+};

--- a/src/lib/mockFetchCalls.js
+++ b/src/lib/mockFetchCalls.js
@@ -4,6 +4,7 @@ import { discussion } from '../fixtures/discussion';
 import { comment } from '../fixtures/comment';
 import { topPicks } from '../fixtures/topPicks';
 import { noTopPicks } from '../fixtures/noTopPicks';
+import { discussionWithNoComments } from '../fixtures/discussionWithNoComments';
 
 export const mockedMessageID = '123456';
 
@@ -44,6 +45,19 @@ export const mockFetchCalls = () => {
         .get(/.*\/discussion\/p\/39f5z\/topcomments.*/, {
             status: 200,
             body: topPicks,
+        })
+
+        // Get discussion 39f5x
+        .get(
+            /.*\/discussion.theguardian.com\/discussion-api\/discussion\/p\/39f5x\?.*/,
+            {
+                status: 200,
+                body: discussionWithNoComments,
+            },
+        )
+        .get(/.*\/discussion\/p\/39f5x\/topcomments.*/, {
+            status: 200,
+            body: noTopPicks,
         })
 
         // Get discussion abc123

--- a/src/lib/mockFetchCalls.js
+++ b/src/lib/mockFetchCalls.js
@@ -5,6 +5,7 @@ import { comment } from '../fixtures/comment';
 import { topPicks } from '../fixtures/topPicks';
 import { noTopPicks } from '../fixtures/noTopPicks';
 import { discussionWithNoComments } from '../fixtures/discussionWithNoComments';
+import { discussionWithTwoComments } from '../fixtures/discussionWithTwoComments';
 
 export const mockedMessageID = '123456';
 
@@ -56,6 +57,19 @@ export const mockFetchCalls = () => {
             },
         )
         .get(/.*\/discussion\/p\/39f5x\/topcomments.*/, {
+            status: 200,
+            body: noTopPicks,
+        })
+
+        // Get discussion 39f5a
+        .get(
+            /.*\/discussion.theguardian.com\/discussion-api\/discussion\/p\/39f5a\?.*/,
+            {
+                status: 200,
+                body: discussionWithTwoComments,
+            },
+        )
+        .get(/.*\/discussion\/p\/39f5a\/topcomments.*/, {
             status: 200,
             body: noTopPicks,
         })


### PR DESCRIPTION
## What does this change?
Hides the View More Comments button when there are no more comments to see

### Before
![Screenshot 2020-06-08 at 10 56 45](https://user-images.githubusercontent.com/1336821/84018727-3f379b80-a978-11ea-8185-d362220acbe9.jpg)

### After
![Screenshot 2020-06-08 at 10 57 21](https://user-images.githubusercontent.com/1336821/84018714-39da5100-a978-11ea-8d81-2d1cdd77829d.jpg)

## Why?
Because don't show buttons that do nothing

### Also
I refactored the tests to fix the annoying act warning and realised at the same time that the act warning was right, and that we should have listened to it! Based on this I've added some additional test scope.