### PR TITLE
Add nofollow to all links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guardian/discussion-rendering",
     "description": "This codebase started as a hack day project by @gtrufitt and @nicl. The purpose is parity of the existing discussion application on Frontend using the discussion API (search for Private Repo).",
-    "version": "2.2.22",
+    "version": "2.2.23",
     "author": "",
     "homepage": "https://github.com/guardian/discussion-rendering#readme",
     "license": "Apache",

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -326,6 +326,7 @@ export const Comment = ({
                                                     comment.userProfile.webUrl
                                                 }
                                                 subdued={true}
+                                                rel="nofollow"
                                             >
                                                 {
                                                     comment.userProfile
@@ -358,6 +359,7 @@ export const Comment = ({
                                         <Link
                                             href={comment.userProfile.webUrl}
                                             subdued={true}
+                                            rel="nofollow"
                                         >
                                             {comment.userProfile.displayName}
                                         </Link>
@@ -375,6 +377,7 @@ export const Comment = ({
                                                 subdued={true}
                                                 icon={<SvgIndent />}
                                                 iconSide="left"
+                                                rel="nofollow"
                                             >
                                                 {comment.responseTo.displayName}
                                             </Link>
@@ -536,6 +539,7 @@ export const Comment = ({
                                                             subdued={true}
                                                             icon={<SvgIndent />}
                                                             iconSide="left"
+                                                            rel="nofollow"
                                                         >
                                                             {/* We use this span to scope the styling */}
                                                             <span data-link-name="reply to comment">

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -29,7 +29,9 @@ const strikethroughString = (text: string) => `<del>${text}</del>`;
 const codeString = (text: string) => `<code>${text}</code>`;
 const quoteString = (text: string) => `<blockquote>${text}</blockquote>`;
 const linkStringFunc = (url: string, highlightedText?: string) =>
-    `<a href="${url}">${highlightedText ? highlightedText : url}</a>`;
+    `<a href="${url}" rel="nofollow">${
+        highlightedText ? highlightedText : url
+    }</a>`;
 
 const formWrapper = css`
     display: flex;
@@ -392,6 +394,7 @@ export const CommentForm = ({
                                     <a
                                         href="/community-faqs#311"
                                         target="_blank"
+                                        rel="nofollow"
                                     >
                                         why?
                                     </a>

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -108,6 +108,7 @@ export const FirstCommentWelcome = ({
                             href="/community-standards"
                             priority="primary"
                             subdued={true}
+                            rel="nofollow"
                         >
                             <span className={textStyling}>
                                 community guidelines

--- a/src/components/Timestamp/Timestamp.tsx
+++ b/src/components/Timestamp/Timestamp.tsx
@@ -49,6 +49,7 @@ export const Timestamp = ({
                 onPermalinkClick(commentId);
                 e.preventDefault();
             }}
+            rel="nofollow"
         >
             <time dateTime={isoDateTime.toString()} className={timeStyles}>
                 {timeAgo}

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -196,6 +196,7 @@ export const TopPick = ({
                         <a
                             href={comment.userProfile.webUrl}
                             className={cx(linkStyles, inheritColour)}
+                            rel="nofollow"
                         >
                             {comment.userProfile.displayName}
                         </a>

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -176,6 +176,7 @@ export const TopPick = ({
                             onPermalinkClick(comment.id);
                             e.preventDefault();
                         }}
+                        rel="nofollow"
                     >
                         Jump to comment
                     </Link>


### PR DESCRIPTION
## What does this change?

Adds `rel="nofollow"` to all comment links.

## Why?

In Frontend we block these links with robots.txt. We haven't replicated that in DCR.

## Link to supporting Trello card
https://trello.com/c/jgohtyEQ