### PR TITLE
Update to test page & bug fix for legacy discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This codebase started as a hack day project by @gtrufitt and @nicl. The purpose 
 Once you've cloned the repo, run
 `yarn` to install and then
 `yarn storybook` to display the components
+`yarn start` will show the full discussion app with query parameter options
 
 ### Publishing changes to NPM
 

--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -209,3 +209,30 @@ export const NoComments = () => (
 NoComments.story = {
     name: 'when no comments have been made',
 };
+
+export const LegacyDiscussion = () => (
+    <div
+        className={css`
+            width: 100%;
+            max-width: 620px;
+        `}
+    >
+        <App
+            shortUrl="p/32255" // A 'legacy' discussion that doesn't allow threading
+            baseUrl="https://discussion.theguardian.com/discussion-api"
+            pillar="culture"
+            isClosedForComments={false}
+            additionalHeaders={{
+                'D2-X-UID': 'testD2Header',
+                'GU-Client': 'testClientHeader',
+            }}
+            expanded={false}
+            onPermalinkClick={() => {}}
+            apiKey=""
+            onHeightChange={() => {}}
+        />
+    </div>
+);
+LegacyDiscussion.story = {
+    name: "a legacy discussion that doesn't allow threading",
+};

--- a/src/fixtures/legacyDiscussionWithoutThreading.ts
+++ b/src/fixtures/legacyDiscussionWithoutThreading.ts
@@ -1,0 +1,1152 @@
+import { DiscussionResponse } from '../types';
+
+export const legacyDiscussionWithoutThreading: DiscussionResponse = {
+    status: 'ok',
+    page: 1,
+    pages: 1,
+    pageSize: 100,
+    orderBy: 'oldest',
+    discussion: {
+        key: '/p/32255',
+        webUrl:
+            'https://www.theguardian.com/environment/2011/sep/19/richard-benyon-ragwort',
+        apiUrl:
+            'https://discussion.guardianapis.com/discussion-api/discussion//p/32255',
+        commentCount: 45,
+        topLevelCommentCount: 45,
+        isClosedForComments: true,
+        isClosedForRecommendation: false,
+        isThreaded: false,
+        title:
+            "Richard Benyon's Facebook 'war on ragwort' sparks spat with ecologists",
+        comments: [
+            {
+                id: 12468508,
+                body:
+                    '<p>He is not being lobbied by a herbicide company is he?</p>',
+                date: '19 September 2011 1:01pm',
+                isoDateTime: '2011-09-19T12:01:11Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12468508',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12468508',
+                numResponses: 0,
+                numRecommends: 13,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '2479941',
+                    displayName: 'madmonty',
+                    webUrl: 'https://profile.theguardian.com/user/id/2479941',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/2479941',
+                    avatar: 'https://avatar.guim.co.uk/user/2479941',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/2479941',
+                    badge: [],
+                },
+            },
+            {
+                id: 12468646,
+                body: '<p>The very thought!</p>',
+                date: '19 September 2011 1:08pm',
+                isoDateTime: '2011-09-19T12:08:12Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12468646',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12468646',
+                numResponses: 0,
+                numRecommends: 5,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '2870517',
+                    displayName: 'GSC82',
+                    webUrl: 'https://profile.theguardian.com/user/id/2870517',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/2870517',
+                    avatar: 'https://avatar.guim.co.uk/user/2870517',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/2870517',
+                    badge: [],
+                },
+            },
+            {
+                id: 12469052,
+                body:
+                    "<p>The Minister for huntin' and shootin' strikes again... </p><p>On an aside though, I am also interested to see how often the 'folk knowledge' of those who work on the land (or in the city or anywhere else) is so often wrong...</p>",
+                date: '19 September 2011 1:29pm',
+                isoDateTime: '2011-09-19T12:29:05Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12469052',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12469052',
+                numResponses: 0,
+                numRecommends: 12,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '794075',
+                    displayName: 'Alasdairca',
+                    webUrl: 'https://profile.theguardian.com/user/id/794075',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/794075',
+                    avatar: 'https://avatar.guim.co.uk/user/794075',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/794075',
+                    badge: [],
+                },
+            },
+            {
+                id: 12469251,
+                body:
+                    "<p><i>I am also interested to see how often the 'folk knowledge' of those who work on the land (or in the city or anywhere else) is so often wrong...</i><br>Indeed. <br>http://www.ragwortfacts.com/ragwort-myths.html</p>",
+                date: '19 September 2011 1:39pm',
+                isoDateTime: '2011-09-19T12:39:22Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12469251',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12469251',
+                numResponses: 0,
+                numRecommends: 2,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '3111076',
+                    displayName: 'philstyle',
+                    webUrl: 'https://profile.theguardian.com/user/id/3111076',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/3111076',
+                    avatar: 'https://avatar.guim.co.uk/user/3111076',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/3111076',
+                    badge: [],
+                },
+            },
+            {
+                id: 12469484,
+                body:
+                    "<blockquote><p>Newbury MP Benyon, whose family's estates earn around £200,000 a year in EU farm subsidies...</p></blockquote><p>Not earn. Are paid.</p>",
+                date: '19 September 2011 1:49pm',
+                isoDateTime: '2011-09-19T12:49:37Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12469484',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12469484',
+                numResponses: 0,
+                numRecommends: 9,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '1331497',
+                    displayName: 'DoctorDark',
+                    webUrl: 'https://profile.theguardian.com/user/id/1331497',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/1331497',
+                    avatar: 'https://avatar.guim.co.uk/user/1331497',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/1331497',
+                    badge: [],
+                },
+            },
+            {
+                id: 12469659,
+                body:
+                    '<p>when I was farming I had one field which was  full of ragwort.   It is dangerous to cattle and horses.     At the end of the school holidays I got hold of six or seven boys of about 10 or 11, gave them an empty fertilizer sack and promised to pay them a half-penny for every plant they pulled up. (this was in 1962 or 3).<br>             Ragwort cannot be killled by any known selective weed-killer,   It has to be pulled up by the roots.<br>            Thwe boys got an average of 40 plants each and we werre very happy to be given 1/8d.</p>',
+                date: '19 September 2011 1:57pm',
+                isoDateTime: '2011-09-19T12:57:11Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12469659',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12469659',
+                numResponses: 0,
+                numRecommends: 5,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4279254',
+                    displayName: 'bordighera1',
+                    webUrl: 'https://profile.theguardian.com/user/id/4279254',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4279254',
+                    avatar: 'https://avatar.guim.co.uk/user/4279254',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4279254',
+                    badge: [],
+                },
+            },
+            {
+                id: 12469806,
+                body:
+                    "<p>Ragwort is everywhere. It can be  a problem, but is also a part of our habitat.</p><p>There. All sorted.</p><p>Do we have to have this typical English hype,rant and posturing?</p><p>The English press whip everything up for copy and the public lap up the phoney drama.Then  people wonder why politicians are so phoney and insincere. They daren't be anything else.<br>Political correctness rules.</p>",
+                date: '19 September 2011 2:03pm',
+                isoDateTime: '2011-09-19T13:03:27Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12469806',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12469806',
+                numResponses: 0,
+                numRecommends: 0,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4530494',
+                    displayName: 'jobrian',
+                    webUrl: 'https://profile.theguardian.com/user/id/4530494',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4530494',
+                    avatar: 'https://avatar.guim.co.uk/user/4530494',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4530494',
+                    badge: [],
+                },
+            },
+            {
+                id: 12469934,
+                body:
+                    '<blockquote><p>And they attacked his ecological knowledge</p></blockquote><p>This is the sort of thing that happens when ministers have to be picked from among MPs. It is amazing that almost nobody treats this as a problem. </p><p>There might be one or two Westminister MPs in total with the necessary knowledge of ecology. It is mad we expect MPs to be appointed ministers and within a year to be speaking with the expertise of people with several years of university study plus years on the job. </p><p>There are many European countries where ministers are appointed by the prime minister and are usually so choosen because of recognised expertise in the field. Cases like this show the UK needs to change. This sort of amateurism might have been fine for the Victorians but it is out of place today.</p>',
+                date: '19 September 2011 2:09pm',
+                isoDateTime: '2011-09-19T13:09:36Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12469934',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12469934',
+                numResponses: 0,
+                numRecommends: 11,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '1954291',
+                    displayName: 'drabacus',
+                    webUrl: 'https://profile.theguardian.com/user/id/1954291',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/1954291',
+                    avatar: 'https://avatar.guim.co.uk/user/1954291',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/1954291',
+                    badge: [],
+                },
+            },
+            {
+                id: 12469981,
+                body:
+                    '<p>I\'ve long been aware of this attitude to Ragwort, and other so called "weeds". It is irrational thinking of a similar nature to racism and all the other stupid irrational hatreds people have.</p><blockquote><p>Within hours of the post about the "vile weed", more than 30 people had complained that he was <b>ecologically illiterate</b>, plain wrong or perpetuating myths put out about the plant by herbicide companies.</p></blockquote><p>This is precisely the problem, "ecological illiteracy". That it is the government\'s Minister for the Natural Environment and Fisheries, Richard Benyon expressing these views is nothing short of incredible. After all, presumably his department have enough advisers who could have quickly explained that he was a being a buffoon expressing his ignorance, before putting both feet in it - highlighting his ignorance and unsuitability for the position.</p><p>From what I understand the main problem with Ragwort poisoning in horses is being fed hay with dried Ragwort in it. They normally avoid eating live Ragwort in pastures.<br></p><blockquote><p>Benyon struck back, saying his critics were being "unnecessarily aggressive", and that he wasn\'t advocating ethnic cleansing of ragwort but that he wanted to deal with "a severe infestation of a poisonous plant".</p></blockquote><p><br>This is laughable, and clearly Richard Benyon has a problem with joined up thinking. He uses aggressive phrases like "vile weed" and "a severe infestation of a poisonous plant", whilst risibly accusing other of being "unnecessarily aggressive".</p><p>Matt Shardlow, the director of Buglife is very right when he says "a critically important nectar source for hundreds of species of butterflies, bees, moths, flies and other invertebrates". I tend to specialise in photographing feeding insects feeding in flowers, and I can confirm that Ragwort is an extremely important plant in sustaining pollinators. It is important not only because it is an attractive plant to pollinators, but because of the volume of it. I would describe it as one of our most important native plants for sustaining pollinator populations.</p><p>It is bizarre in the extreme, that there is a well recognised problem with the decline of pollinators, not just in the UK, but internationally. And here we have an uneducated buffoon, who has somehow found himself Minister for the Natural Environment and Fisheries, declaring war on an important native wildflower, which is of major importance in sustaining these species in serious decline. Species which are actually very important to farmers. This is why Richard Benyon is clearly "ecological illiteracy". I suggest that if Richard Benyon wants to do this job, then he urgently needs to educate himself about the subject.</p>',
+                date: '19 September 2011 2:12pm',
+                isoDateTime: '2011-09-19T13:12:32Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12469981',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12469981',
+                numResponses: 0,
+                numRecommends: 12,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4311896',
+                    displayName: 'SteB1',
+                    webUrl: 'https://profile.theguardian.com/user/id/4311896',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4311896',
+                    avatar: 'https://avatar.guim.co.uk/user/4311896',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4311896',
+                    badge: [],
+                },
+            },
+            {
+                id: 12470128,
+                body:
+                    "<p>Shame he can't get so aerated about the Rhododendron  that invades and destroys anywhere its shoots spread or seeds land and his voters keep planting in their large gardens.</p>",
+                date: '19 September 2011 2:18pm',
+                isoDateTime: '2011-09-19T13:18:36Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12470128',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12470128',
+                numResponses: 0,
+                numRecommends: 8,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '1301439',
+                    displayName: 'WaitForPete',
+                    webUrl: 'https://profile.theguardian.com/user/id/1301439',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/1301439',
+                    avatar: 'https://avatar.guim.co.uk/user/1301439',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/1301439',
+                    badge: [],
+                },
+            },
+            {
+                id: 12470152,
+                body:
+                    '<p>@ bordighera:<br></p><blockquote><p>Ragwort cannot be killled by any known selective weed-killer, It has to be pulled up by the roots.</p></blockquote><p>Not necessarily true. Pulling up by the roots can be one of the worst things you can do - remember this is a plant that loves to colonise bare ground, which is what you create when pulling existing plants up. This creates perfect oportunities for seed in the soil, or new seed rain to colonise those areas making it seem like the ragwort never went away. I have seen this happen many times.</p><p>As for other control methods, I am not an expert on herbicides, but it would appear there are numerous to choose from that will do the job - see the Defra code of practice, or for example the Centre for ecology and Hydrology information sheet on ragwort <a href="http://www.ceh.ac.uk/sci_programmes/documents/Ragwort.pdf" rel="nofollow">http://www.ceh.ac.uk/sci_programmes/documents/Ragwort.pdf</a> (to name but two sources) for more info.</p>',
+                date: '19 September 2011 2:20pm',
+                isoDateTime: '2011-09-19T13:20:06Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12470152',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12470152',
+                numResponses: 0,
+                numRecommends: 1,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '3596779',
+                    displayName: 'Ecoboy1980',
+                    webUrl: 'https://profile.theguardian.com/user/id/3596779',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/3596779',
+                    avatar: 'https://avatar.guim.co.uk/user/3596779',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/3596779',
+                    badge: [],
+                },
+            },
+            {
+                id: 12470272,
+                body: '<p>@SteB1 </p><p>Right as rain as usual :)</p>',
+                date: '19 September 2011 2:25pm',
+                isoDateTime: '2011-09-19T13:25:45Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12470272',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12470272',
+                numResponses: 0,
+                numRecommends: 4,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4387033',
+                    displayName: 'Atomant77',
+                    webUrl: 'https://profile.theguardian.com/user/id/4387033',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4387033',
+                    avatar: 'https://avatar.guim.co.uk/user/4387033',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4387033',
+                    badge: [],
+                },
+            },
+            {
+                id: 12471548,
+                body:
+                    "<p>The stupid thing about using hebicides on ragwort is that the weed is easy to control by pulling.</p><p>Like bordighera1 I had a field full of ragwort with cattle and horses on it. </p><p>As vets warn it is a poison, I used to go out and pull a sackful every day when out walking.</p><p>They are easy to pull, especially after rain. </p><p>Ragworts are now a rarity in that field.  Other weeds are caused by overfertilising.</p><p>When we went  organic and stopped using mineral fertiliser,  one surprising side effect was that weeds died out and clovers flourished. The mineral imbalance causes the weeds. A coating of dried seaweed fertiliser worked wonders. The meadow is full of bees, dragon flys butterflys and all kinds of insect life, a joy to visit on a summer's day.</p>",
+                date: '19 September 2011 3:34pm',
+                isoDateTime: '2011-09-19T14:34:07Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12471548',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12471548',
+                numResponses: 0,
+                numRecommends: 2,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '1268926',
+                    displayName: 'kvms',
+                    webUrl: 'https://profile.theguardian.com/user/id/1268926',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/1268926',
+                    avatar: 'https://avatar.guim.co.uk/user/1268926',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/1268926',
+                    badge: [],
+                },
+            },
+            {
+                id: 12471828,
+                body:
+                    '<p>Government minister shown to be clueless, ignorant of portfolio, reactionary and protectionist idiot shocker. What an absolute prick and sadly so full of hubris he is unlikely to be embarrassed.</p><p>@SteB1 and @drabacus - spot on by the way.</p>',
+                date: '19 September 2011 3:52pm',
+                isoDateTime: '2011-09-19T14:52:35Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12471828',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12471828',
+                numResponses: 0,
+                numRecommends: 5,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '3874929',
+                    displayName: 'carnaptious99',
+                    webUrl: 'https://profile.theguardian.com/user/id/3874929',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/3874929',
+                    avatar: 'https://avatar.guim.co.uk/user/3874929',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/3874929',
+                    badge: [],
+                },
+            },
+            {
+                id: 12471872,
+                body:
+                    '<p>Another ill informed, arrogant minster who gets found out when he actually tries to interact with voters.</p>',
+                date: '19 September 2011 3:54pm',
+                isoDateTime: '2011-09-19T14:54:54Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12471872',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12471872',
+                numResponses: 0,
+                numRecommends: 2,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4568262',
+                    displayName: 'JimmerInManila',
+                    webUrl: 'https://profile.theguardian.com/user/id/4568262',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4568262',
+                    avatar: 'https://avatar.guim.co.uk/user/4568262',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4568262',
+                    badge: [],
+                },
+            },
+            {
+                id: 12472026,
+                body:
+                    '<p>@kvms ragwort is *not* "controlled" by pulling. First, you can\'t pull the rosette stage. Second, pulling the plant simply means that next year you\'ll have loads more plants to pull. The root system is quite complex even above ground. If you like pulling up ragwort, congratulations - you\'ve kept yourself in a job.</p><p>I wouldn\'t trust that "ragwort facts" site as it doesn\'t link out. Instead use PubMed where you can find some raw data, such as from <a href="http://www.ncbi.nlm.nih.gov/pubmed?term=ragwort%20poison%20equine" rel="nofollow">this search</a>. </p><p>@SteB1 "From what I understand the main problem with Ragwort poisoning in horses is being fed hay with dried Ragwort in it. They normally avoid eating live Ragwort in pastures."</p><p>That\'s because the ragwort has a bitter taste (because of the alkalinoids). Once dried, the taste is lost. So the argument really is about controlling ragwort in fields that will be used for hay, and perhaps also for human food (I don\'t think you really want phlebotoxic contaminants in your basic food supply).</p><p>Ragwort quickly colonises bare ground (another reason why pulling, which leaves bare patches, isn\'t so clever); I think that\'s why Benyon is so frustrated with the Highways Agency, which is great at digging up roads but no so good at chucking grass seed over the bits once repaired.</p>',
+                date: '19 September 2011 4:02pm',
+                isoDateTime: '2011-09-19T15:02:57Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12472026',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12472026',
+                numResponses: 0,
+                numRecommends: 5,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '2427181',
+                    displayName: 'CharlesArthur',
+                    webUrl: 'https://profile.theguardian.com/user/id/2427181',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/2427181',
+                    avatar: 'https://avatar.guim.co.uk/user/2427181',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/2427181',
+                    badge: [
+                        {
+                            name: 'Staff',
+                        },
+                    ],
+                },
+            },
+            {
+                id: 12472059,
+                body:
+                    '<p>Richard Benyon shoots himself in the foot, good, saves others the bother of doing it for him.</p><p>Scary to think someone ignorant is in this Government position of power, though.</p>',
+                date: '19 September 2011 4:04pm',
+                isoDateTime: '2011-09-19T15:04:19Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12472059',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12472059',
+                numResponses: 0,
+                numRecommends: 3,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4188282',
+                    displayName: 'sparclear',
+                    webUrl: 'https://profile.theguardian.com/user/id/4188282',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4188282',
+                    avatar: 'https://avatar.guim.co.uk/user/4188282',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4188282',
+                    badge: [],
+                },
+            },
+            {
+                id: 12473125,
+                body:
+                    '<p>Just be sure you are not confusing Senecio jacobaea with Tanacetum vulgare.</p>',
+                date: '19 September 2011 5:03pm',
+                isoDateTime: '2011-09-19T16:03:22Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12473125',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12473125',
+                numResponses: 0,
+                numRecommends: 1,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4573193',
+                    displayName: 'PanYanPickle',
+                    webUrl: 'https://profile.theguardian.com/user/id/4573193',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4573193',
+                    avatar: 'https://avatar.guim.co.uk/user/4573193',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4573193',
+                    badge: [],
+                },
+            },
+            {
+                id: 12473463,
+                body:
+                    "<p>@CharlesArthur<br></p><blockquote><p><i>\"From what I understand the main problem with Ragwort poisoning in horses is being fed hay with dried Ragwort in it. They normally avoid eating live Ragwort in pastures.\"\n</i><br>That's because the ragwort has a bitter taste (because of the alkalinoids). Once dried, the taste is lost. So the argument really is about controlling ragwort in fields that will be used for hay, and perhaps also for human food (I don't think you really want phlebotoxic contaminants in your basic food supply).</p><p>Ragwort quickly colonises bare ground (another reason why pulling, which leaves bare patches, isn't so clever); I think that's why Benyon is so frustrated with the Highways Agency, which is great at digging up roads but no so good at chucking grass seed over the bits once repaired.</p></blockquote><p>Yes I'm well aware of some of the compounds in Ragwort and why horses supposedly avoid Ragwort in fields, but may eat it in hay. Although I think much of it is to do with the difference between the way horses selectively browse in fields, and the way they eat hay. Horses simply do not have the equipment to disentangle different plants from hay they are fed, so they are forced to eat whole, and not selectively as when thy browse. I should also add that I have formally studied herbivory, how some toxins operate biologically, and the secondary metabolites which inhibit herbivory. I was bought up in a rural area and I have known horsey people for most of my life. So I appreciate these aspects and have a good grasp of the rural attitude to Ragwort. I also understand the ecological prefererences of Ragwort, which is also important in understanding it's ecological importance in the modern era.</p><p>The main bit you miss out is that the wish to control Ragwort everywhere is because it has wind blown seed. In the countryside there is a traditional annoyance with landowners who don't control Ragwort as it is perceived that the seed from the Ragwort in their fields spreads elsewhere.</p><p>I admit it's quite some time since I have done specific reading on the toxicity of Ragwort. However, from what I can remember most of the literature appeared to imply that the dangers of Ragwort toxicity were somewhat exaggerated. This backs up my own experience. where I can't even think of an example of Ragwort toxicity in a horse. Although I have been personally aware of quite a few examples where people's horses have died or become ill with acorn poisoning. This has always what has struck me, horse owners are a bit obsessed with Ragwort, even though most of the things that effect horses aren't Ragwort poisoning.</p><p>I find that there is a very distorted view about \"poisonous plants\". Those that have these concerns often do not realise what a huge variety of our native plants species have pretty potent toxins in them. This tends to result in hysteria about some plants, where most people are not even aware that other plants they consider safe, are even more toxic.</p><p>Without doing a fair bit of reading to get up to date, my impression is that the toxicity of Ragwort is an overblown concern. The pre-occupation with Ragwort appears to be because it is a named plant in the 1959 Weeds Act. But the other named weeds are 2 Dock species and 2 Thistle species. This was a time of the green revolution and where our pasture was being turned into \"improved grassland\". In such grassland normally only one species of  grass (usually a Ryegrass sp.) is welcome, and 2 Clover species. Typically such grassland only contains about 5 species. The other species being those named in the Weeds Act, which farmers want to eliminate to increase yield. Species rich grassland can contain 80 species. We have lost over 90% of our species rich grassland. In other words, I personally think it's far more about Ragwort being one of the few species to invade \"improved grassland\", than it is about toxicity or danger.</p><p>The notion that there are good species, and bad species which need to be demomized, and war waged on them has done massive damage to the biodiversity our countryside. To see our countryside as containing bad, or enemy species, which have to be controlled at all costs is really a bit of an uninformed Victorian attitude. As I explained before, Ragwort is an important native plant for sustaining pollinator populations, which have been in serious decline. This is what makes these simplistic views about good and bad species problematic. Often the species seen as bad, had an unacknowledged positive role to play in the ecology of our countryside.</p><p>I have also seen little evidence to suggest Ragwort is any sort of real threat to human health.</p>",
+                date: '19 September 2011 5:22pm',
+                isoDateTime: '2011-09-19T16:22:08Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12473463',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12473463',
+                numResponses: 0,
+                numRecommends: 1,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4311896',
+                    displayName: 'SteB1',
+                    webUrl: 'https://profile.theguardian.com/user/id/4311896',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4311896',
+                    avatar: 'https://avatar.guim.co.uk/user/4311896',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4311896',
+                    badge: [],
+                },
+            },
+            {
+                id: 12473866,
+                body:
+                    '<p>This site appears to provide proper sources for its statements:<br><a href="http://www.ragwort.org.uk/" rel="nofollow">http://www.ragwort.org.uk/</a></p>',
+                date: '19 September 2011 5:50pm',
+                isoDateTime: '2011-09-19T16:50:45Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12473866',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12473866',
+                numResponses: 0,
+                numRecommends: 3,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4368868',
+                    displayName: 'kitenet',
+                    webUrl: 'https://profile.theguardian.com/user/id/4368868',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4368868',
+                    avatar: 'https://avatar.guim.co.uk/user/4368868',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4368868',
+                    badge: [],
+                },
+            },
+            {
+                id: 12473958,
+                body:
+                    '<p>To most of us, there is no story at all here, just a photo of a man pulling up some weeds and having a rant about them. My neighbours, colleagues, friends,... do the same thing every single weekend.</p><p>And he even has the sense of humour to laugh at himself in the comments on that facebook page.</p><p>But a few people want to make a fuss and vandalise his facebook page. Unfortunately that is all to common these days too. That says more about those people though than it does about the Minister.</p>',
+                date: '19 September 2011 5:57pm',
+                isoDateTime: '2011-09-19T16:57:16Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12473958',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12473958',
+                numResponses: 0,
+                numRecommends: 1,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '3699054',
+                    displayName: 'NeverMindTheBollocks',
+                    webUrl: 'https://profile.theguardian.com/user/id/3699054',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/3699054',
+                    avatar: 'https://avatar.guim.co.uk/user/3699054',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/3699054',
+                    badge: [],
+                },
+            },
+            {
+                id: 12473992,
+                body:
+                    '<p>cinnebar moths are beautiful pink moths and are a natural way of reducing ragwort since the caterpillars can be seen in abundance feeding on them, little yellow and balck striped beauties that can decimate a whole plant in hours apparently.  </p><p>ignorant people irritate when they talk about stuff they know nothing about. me i try and enjoy the beauty that is there.<a href="http://www.flickr.com/photos/martin_black/5967445057/in/set-72157622416904918" rel="nofollow">http://www.flickr.com/photos/martin_black/5967445057/in/set-72157622416904918</a></p>',
+                date: '19 September 2011 5:59pm',
+                isoDateTime: '2011-09-19T16:59:24Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12473992',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12473992',
+                numResponses: 0,
+                numRecommends: 2,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4212243',
+                    displayName: 'grumpygrowlygirlie',
+                    webUrl: 'https://profile.theguardian.com/user/id/4212243',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4212243',
+                    avatar: 'https://avatar.guim.co.uk/user/4212243',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4212243',
+                    badge: [],
+                },
+            },
+            {
+                id: 12474633,
+                body:
+                    '<p>@kitenet<br></p><blockquote><p>This site appears to provide proper sources for its statements:<br><a href="http://www.ragwort.org.uk/" rel="nofollow">http://www.ragwort.org.uk/</a></p></blockquote><p>Thanks very much for this useful link. It confirms many of my impressions. I\'ve have been baffled by Ragwort hysteria for a long time. Whilst it is a bit of a pre-occupation in equine circles, I was always a bit baffled because I wasn\'t aware of any specific cases where horses had definitely become ill due to Ragwort poisoning. Whereas I was aware of many examples of other types of poisoning such as horses eating large amounts of acorns. Although I am wary of these diagnoses, because often it appears to be more of a guess, and is often not confirmed by a post-morten.</p><p>A particular problem with concerns about plant toxicity, is that just because compounds are in plants, does not necessarily mean that they will be ingested in high enough levels to cause illness.</p>',
+                date: '19 September 2011 6:56pm',
+                isoDateTime: '2011-09-19T17:56:40Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12474633',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12474633',
+                numResponses: 0,
+                numRecommends: 1,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4311896',
+                    displayName: 'SteB1',
+                    webUrl: 'https://profile.theguardian.com/user/id/4311896',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4311896',
+                    avatar: 'https://avatar.guim.co.uk/user/4311896',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4311896',
+                    badge: [],
+                },
+            },
+            {
+                id: 12474814,
+                body:
+                    '<p>I am the author of the <a href="http://www.ragwort.org.uk/" rel="nofollow">http://www.ragwort.org.uk/</a> , I did a lot research because I was made scared by press and repeated misinformation and I am a horse owner, I asked experts to help my cause some didn\'t look right for me, this expersts did help me with my website to discover facts and/or myths. ( most was myths) <br>I also  made a picture gallery of the importance for biodiversity  ( that is only visible on my Dutch website)<br>There are a lot of insects, butterflys etc feeding at ragwort, I think a lot more than catlle <a href="http://www.jakobskruiskruid.com/website/index.php?option=com_rsgallery2&amp;Itemid=48" rel="nofollow">http://www.jakobskruiskruid.com/website/index.php?option=com_rsgallery2&amp;Itemid=48</a><br>On the gallery tehere are also a lot of yellow  plants where people make mistakes, some very common plant, but also some rare. Not any yellow is ragwort.</p>',
+                date: '19 September 2011 7:15pm',
+                isoDateTime: '2011-09-19T18:15:28Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12474814',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12474814',
+                numResponses: 0,
+                numRecommends: 6,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4741862',
+                    displayName: 'EstherHegt',
+                    webUrl: 'https://profile.theguardian.com/user/id/4741862',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4741862',
+                    avatar: 'https://avatar.guim.co.uk/user/4741862',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4741862',
+                    badge: [],
+                },
+            },
+            {
+                id: 12475107,
+                body:
+                    "<p>@NMTB<br></p><blockquote><p>To most of us, there is no story at all here, just a photo of a man pulling up some weeds and having a rant about them. My neighbours, colleagues, friends,... do the same thing every single weekend.</p></blockquote><p>That's not really accurate is it? The man pulling up the \"weeds\" happened to be the Minister resonsible for biodiversity, and here he was calling a native wildflower, which supports a significant amount of biodiversity, a \"vile weed\" - saying \"I hate ragwort. It may not be the issue of the moment but I am on the warpath for those who let this vile weed spread\". These comments were made in a public context on his facebook page which makes his ministerial role clear.</p><p>Additionally, both my experience, and what I have read in the scientific literature in the past, indicates that the supposed problems Ragwort causes are grossly over-exaggerated, with there being little evidence for the widespread problems attributed to it.</p><blockquote><p>But a few people want to make a fuss and vandalise his facebook page. Unfortunately that is all to common these days too. That says more about those people though than it does about the Minister.</p></blockquote><p>You don't explain exactly what you mean by vandalise his facebook page. We can't cross check this because he removed the thread, presumably to hide his embarrassment. Do you just mean people pointed out that Richard Benyon doesn't appear to have any understanding of the ecological role Ragwort plays in supporting biodiversity? As he is the Minister responsible for biodiversity it was incumbent on those who understand the subject to point out that the Minister's comments were ill-informed, and showed an incredible degree ecological illiteracy for someone in such a role - a clear matter of public concern. Your comment is more like spin for the Minister than anything else. After all you've not said anything to support the validity of the Minister's ill-informed rant.</p>",
+                date: '19 September 2011 7:44pm',
+                isoDateTime: '2011-09-19T18:44:27Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12475107',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12475107',
+                numResponses: 0,
+                numRecommends: 4,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4311896',
+                    displayName: 'SteB1',
+                    webUrl: 'https://profile.theguardian.com/user/id/4311896',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4311896',
+                    avatar: 'https://avatar.guim.co.uk/user/4311896',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4311896',
+                    badge: [],
+                },
+            },
+            {
+                id: 12475117,
+                body:
+                    '<p>If, as has been suggests that 2000+ horse suffered from liver failure last year and died due to Ragwort consumption then someone needs to drop this chap a <a href="http://www.liv.ac.uk/equine/staff/derekknottenbelt.htm" rel="nofollow">line</a> for the facts.. </p><p>If ragwort is poisonous and horses eat it and die that is not a good thing.</p><p>This is not hysteria. </p><p>The horses and their owners will be very grateful if someone gets to the truth here.<br>I haven\'t set up a website. But the equation would seem to be,</p><p>Ragwort + ragwort munching horse = dead horse not munching anything.</p>',
+                date: '19 September 2011 7:45pm',
+                isoDateTime: '2011-09-19T18:45:49Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12475117',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12475117',
+                numResponses: 0,
+                numRecommends: 3,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4641408',
+                    displayName: 'MrRatfan1976',
+                    webUrl: 'https://profile.theguardian.com/user/id/4641408',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4641408',
+                    avatar: 'https://avatar.guim.co.uk/user/4641408',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4641408',
+                    badge: [],
+                },
+            },
+            {
+                id: 12475461,
+                body:
+                    '<p>"There is very very clear science on meta-population dynamics that shows that habitat loss with in a patchwork of habitats has a very severe effect"</p><p>YAWN.</p>',
+                date: '19 September 2011 8:25pm',
+                isoDateTime: '2011-09-19T19:25:51Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12475461',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12475461',
+                numResponses: 0,
+                numRecommends: 0,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4487660',
+                    displayName: 'MrPiggles',
+                    webUrl: 'https://profile.theguardian.com/user/id/4487660',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4487660',
+                    avatar: 'https://avatar.guim.co.uk/user/4487660',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4487660',
+                    badge: [],
+                },
+            },
+            {
+                id: 12475751,
+                body:
+                    '<p>Ragwort is a noxious weed in agricultural situations.</p><p><a href="http://www.sac.ac.uk/mainrep/pdfs/tn570ragwortpoisoning.pdf" rel="nofollow">http://www.sac.ac.uk/mainrep/pdfs/tn570ragwortpoisoning.pdf</a></p><p>Although it is also important for biodiversity, its not exactly a rare plant.</p><p>I would far rather pull it, as Benyon is doing, when infestations in problem areas are light and easily controlled, rather than allow things to get out of hand and then use herbicides which will needlessly cause huge collateral damage on many harmless and beneficial grassland species.</p>',
+                date: '19 September 2011 8:58pm',
+                isoDateTime: '2011-09-19T19:58:20Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12475751',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12475751',
+                numResponses: 0,
+                numRecommends: 1,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '2411079',
+                    displayName: 'antipodean1',
+                    webUrl: 'https://profile.theguardian.com/user/id/2411079',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/2411079',
+                    avatar: 'https://avatar.guim.co.uk/user/2411079',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/2411079',
+                    badge: [],
+                },
+            },
+            {
+                id: 12475801,
+                body:
+                    '<p>@    MrRatfan1976</p><p>  If, as has been suggests that 2000+ horse suffered from liver failure last year and died due to Ragwort consumption then someone needs to drop this chap a line for the facts.. </p><p>We did, we wrote the chap a email and that is our page about the myth of skin absorption <a href="http://www.ragwort.org.uk/facts-or-myths/7-i/13-ragwort-poisoning-through-skin-absorption-fact-or-fiction" rel="nofollow">http://www.ragwort.org.uk/facts-or-myths/7-i/13-ragwort-poisoning-through-skin-absorption-fact-or-fiction</a></p>',
+                date: '19 September 2011 9:02pm',
+                isoDateTime: '2011-09-19T20:02:42Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12475801',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12475801',
+                numResponses: 0,
+                numRecommends: 4,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4741862',
+                    displayName: 'EstherHegt',
+                    webUrl: 'https://profile.theguardian.com/user/id/4741862',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4741862',
+                    avatar: 'https://avatar.guim.co.uk/user/4741862',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4741862',
+                    badge: [],
+                },
+            },
+            {
+                id: 12475922,
+                body:
+                    "<p>I was one of those who posted comments on the minister's Facebook page. I don't believe I was 'aggressive' but I was most certainly was alarmed by Mr Benyon's total lack of knowledge.</p><p>One of the worst problems with ragwort is that people don't read the code of practice. Since his own department is responsible for the COP it is not unreasonable to expect Mr Benyon to have read it.</p><p>The photograph makes it clear he hasn't because there are five ways in which what he is doing is not in accordance with the advice in the COP. I blogged about all five the other day.</p>",
+                date: '19 September 2011 9:14pm',
+                isoDateTime: '2011-09-19T20:14:33Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12475922',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12475922',
+                numResponses: 0,
+                numRecommends: 4,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4323663',
+                    displayName: 'thepoisongarden',
+                    webUrl: 'https://profile.theguardian.com/user/id/4323663',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4323663',
+                    avatar: 'https://avatar.guim.co.uk/user/4323663',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4323663',
+                    badge: [],
+                },
+            },
+            {
+                id: 12476305,
+                body:
+                    "<p>At first , I'm a horse owner and have no fear for ragwort at all !!</p><p>&lt;quote&gt;<br><i>MrRatfan1976\n\n19 September 2011 7:45PM\n\nIf, as has been suggests that 2000+ horse suffered from liver failure last year and died due to Ragwort consumption then someone needs to drop this chap a line for the facts.. </i>&lt;/quote&gt;</p><p>That's done as you can see above...by EstherHegt and her experts</p><p>By the way...<br>Did you know , in those time's and also today there is still NO test that can make you sure it is ragwort that has killed a horse? <br>Besides... the guy Knottenbelt in you're link isn't even a toxicologist, and the same guy admitted in an other site that those numbers where.... a gamble.</p>",
+                date: '19 September 2011 9:47pm',
+                isoDateTime: '2011-09-19T20:47:08Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12476305',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12476305',
+                numResponses: 0,
+                numRecommends: 2,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4742115',
+                    displayName: 'NickAltena',
+                    webUrl: 'https://profile.theguardian.com/user/id/4742115',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4742115',
+                    avatar: 'https://avatar.guim.co.uk/user/4742115',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4742115',
+                    badge: [],
+                },
+            },
+            {
+                id: 12476413,
+                body:
+                    "<p>It's just another myth that any flowering Ragwortplant wil grow overnight, the majority of ragwortplants needs 2 full growing seasons to get in a flowering state, it takes a bit more of skills to regognise the vegetative state , but an important one, because this is also the most effective state to use succesfully in destroying the plant,  bij apropiate  chemical herbicides.</p><p><br>it will allways be the horseowners who puts a horse in a certain field, horses can't speak for themselfs, keep them safe from contact with poisionous plants is just one of many, many horsemanship tasks to put in good practice!<br>Ragwort is just one of many not to tollerate plants in a horsefield or paddock, and it is one of many you don't want in hay or other feed.</p>",
+                date: '19 September 2011 9:57pm',
+                isoDateTime: '2011-09-19T20:57:51Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12476413',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12476413',
+                numResponses: 0,
+                numRecommends: 1,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4741862',
+                    displayName: 'EstherHegt',
+                    webUrl: 'https://profile.theguardian.com/user/id/4741862',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4741862',
+                    avatar: 'https://avatar.guim.co.uk/user/4741862',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4741862',
+                    badge: [],
+                },
+            },
+            {
+                id: 12476758,
+                body:
+                    '<p>@antipodean1<br></p><blockquote><p>Ragwort is a noxious weed in agricultural situations.</p><p><a href="http://www.sac.ac.uk/mainrep/pdfs/tn570ragwortpoisoning.pdf" rel="nofollow">http://www.sac.ac.uk/mainrep/pdfs/tn570ragwortpoisoning.pdf</a><br>Although it is also important for biodiversity, its not exactly a rare plant.</p><p>I would far rather pull it, as Benyon is doing, when infestations in problem areas are light and easily controlled, rather than allow things to get out of hand and then use herbicides which will needlessly cause huge collateral damage on many harmless and beneficial grassland species.<br></p></blockquote><p>I don\'t often find myself disagreeing with you. The reference you gave just gives a series of assertions and doesn\'t support or reference them.</p><p>I\'ve known about the supposed toxicity of Ragwort throughout most of my life. Several people in my family have been horse owners, and it is a big pre-occupation in the equine world. Also I knew about it because the caterpillars of Cinnabar moths supposedly were unpalatable because of a concentration of the Ragworts toxins. Initially I just accepted this as fact because it was repeated so much. However I started become sceptical because despite the equine world\'s pre-occupation with Ragwort I never knew of a definite Ragwort poisoning case. Yet I knew of other cases of horses being poisoned by eating other things, but not Ragwort. This was baffling given the prevalence of Ragwort in fields grazed by horses and in pasture cut for hay. I started to become suspicious that this was a "factoid" - an inaccurate assertion that gains credence over time by its repetition.</p><p>When I tried reading up on it some while back when I had access to an academic library I could find very little direct information about the supposed problem of Ragwort toxicity. Most of it just appeared to be unsupported assertions, and the anecdotal accounts weren\'t backed up by post-morten results. However, it was not enough of an issue for me to pursue it any further.</p><p>This is why I find @EstherHegt\'s comments and website so interesting, because it confirms my suspicions. At the very least the problem appears to be somewhat overstated.<br><a href="http://www.ragwort.org.uk/" rel="nofollow">http://www.ragwort.org.uk/</a></p><p>On the subject of Ragwort\'s importance for supporting biodiversity. Yes you are right that it is not a rare plant. However, the groups of pollinating insects, to which Ragwort is important, are in serious decline. So it is the volume of food sources (flowers) important to this biodiversity component, and not just whether it is there or not. Photographing flower feeding insects has given me a lot of insight into which flower food sources are the most popular with feeding insects, and which are the most widespread and used. In my experience Ragwort is one of the most important single plants. In my experience perhaps only Hogweed supports more feeding insects, and is more widespread. I think the shot below is of a hoverfly on Ragwort. Although I don\'t use Ragwort too much for my photography as I use flash, and the smaller flowers mean you tend to get a black background. Here I managed to get a few flowers behind to prevent this.<br><a href="http://farm5.static.flickr.com/4018/4396328430_78f4045739_o.jpg" rel="nofollow">http://farm5.static.flickr.com/4018/4396328430_78f4045739_o.jpg</a></p>',
+                date: '19 September 2011 10:31pm',
+                isoDateTime: '2011-09-19T21:31:48Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12476758',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12476758',
+                numResponses: 0,
+                numRecommends: 3,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4311896',
+                    displayName: 'SteB1',
+                    webUrl: 'https://profile.theguardian.com/user/id/4311896',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4311896',
+                    avatar: 'https://avatar.guim.co.uk/user/4311896',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4311896',
+                    badge: [],
+                },
+            },
+            {
+                id: 12476847,
+                body:
+                    '<p>I have no fear of ragwort but for the sake of the nice old <a href="http://img.dailymail.co.uk/i/pix/2007/12_03/065redrum_468x344.jpg" rel="nofollow">horses</a> i ask the key question.</p><p>Is ragwort a risk for horses?</p><p>Can someone <a href="http://www.bristol.ac.uk/vetscience/" rel="nofollow">qualified </a>pitch in with an answer. Otherwise we\'ll be chewing on the question for days, unlike the horses who wont know.</p><p>I don\'t really give a monkey\'s about this old boy tory and his facebook troll hell. However 30 years ago i was removing ragwort from fields so the old horsie wasn\'t at any risk, i was brought up with "Ragwort is poisonous for the horse"</p><p>@Esher "horses can\'t speak for themselves, keep them safe". Spot on.</p><p>Can we have some science please. Is Ragwort a danger to a horse and if it is what are we going to do about it. Defra, NFU, BHF, Mr Toxicologist. What is your best guideline?</p>',
+                date: '19 September 2011 10:41pm',
+                isoDateTime: '2011-09-19T21:41:03Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12476847',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12476847',
+                numResponses: 0,
+                numRecommends: 0,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4641408',
+                    displayName: 'MrRatfan1976',
+                    webUrl: 'https://profile.theguardian.com/user/id/4641408',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4641408',
+                    avatar: 'https://avatar.guim.co.uk/user/4641408',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4641408',
+                    badge: [],
+                },
+            },
+            {
+                id: 12477021,
+                body:
+                    "<p>Just to clarify the point I am making. I'm not suggesting that those with livestock and who want to take precautions shouldn't control Ragwort in their pastures. What I am concerned about is the demonization of plants like Ragwort. This can lead to pointless wars waged against certain plants everywhere, with little thought about what this is meant to achieve, or the effect it has on other biodiversity. I often find interesting places to photograph insects. I return and everything has been cut down or sprayed (not particularly Ragwort). There doesn't appear to be any clear rationale for this, as often these places have no other purpose to serve, that the vegetation cut down or sprayed prevents. When I have asked about this, I often get puzzled looks, and told they are weeds, or need to be tidied up. A weed is only a plant growing where someone doesn't want it to grow. Unfortunately, many people who don't understand this concept appear to believe that being a weed, makes a plant inherently bad wherever it is, and it is necessary to wage constant war on weeds, regardless of where they are growing.</p>",
+                date: '19 September 2011 10:59pm',
+                isoDateTime: '2011-09-19T21:59:44Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12477021',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12477021',
+                numResponses: 0,
+                numRecommends: 3,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4311896',
+                    displayName: 'SteB1',
+                    webUrl: 'https://profile.theguardian.com/user/id/4311896',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4311896',
+                    avatar: 'https://avatar.guim.co.uk/user/4311896',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4311896',
+                    badge: [],
+                },
+            },
+            {
+                id: 12477166,
+                body:
+                    '<p>Common ragwort (Senecio jacobaea), a risk to the livers of both horses and cows too folks. </p><p>Keep it away from them and them away from it would seem to be a wise move. </p><p>Here\'s the <a href="http://www.merckvetmanual.com/mvm/index.jsp?cfile=htm/bc/212800.htm&amp;hide=1" rel="nofollow">science</a> <a href="http://www.vet.uga.edu/VPP/clerk/elliott/index.php" rel="nofollow">- bit.</a></p><p>A wise move from Mr Benyon here and that cow up there is moost grateful.</p>',
+                date: '19 September 2011 11:14pm',
+                isoDateTime: '2011-09-19T22:14:23Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12477166',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12477166',
+                numResponses: 0,
+                numRecommends: 1,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4641408',
+                    displayName: 'MrRatfan1976',
+                    webUrl: 'https://profile.theguardian.com/user/id/4641408',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4641408',
+                    avatar: 'https://avatar.guim.co.uk/user/4641408',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4641408',
+                    badge: [],
+                },
+            },
+            {
+                id: 12477257,
+                body:
+                    '<p>There are 6000 plantspecies who produce PAs (3 % of all flowering plants.</p>',
+                date: '19 September 2011 11:23pm',
+                isoDateTime: '2011-09-19T22:23:06Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12477257',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12477257',
+                numResponses: 0,
+                numRecommends: 3,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4741862',
+                    displayName: 'EstherHegt',
+                    webUrl: 'https://profile.theguardian.com/user/id/4741862',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4741862',
+                    avatar: 'https://avatar.guim.co.uk/user/4741862',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4741862',
+                    badge: [],
+                },
+            },
+            {
+                id: 12477258,
+                body:
+                    '<p>Ragwort can be poison for a horse! <br>It should not be in the pasture...it should not be in de hey....<br>However,...the horse also should not get both of it from the owner ;)</p><p>This "minister" is a joker, but not responsible.<br>The only person who is responsible (in MY eye\'s)  is the owner of the horse who puts the horse in a pasture with a lot of ragwort or giving them hay with this ragwort in it !<br>A piece of ragwort doesn\'t hurt...but a lot of it or regular is dangerous.</p>',
+                date: '19 September 2011 11:23pm',
+                isoDateTime: '2011-09-19T22:23:12Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12477258',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12477258',
+                numResponses: 0,
+                numRecommends: 1,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4742115',
+                    displayName: 'NickAltena',
+                    webUrl: 'https://profile.theguardian.com/user/id/4742115',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4742115',
+                    avatar: 'https://avatar.guim.co.uk/user/4742115',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4742115',
+                    badge: [],
+                },
+            },
+            {
+                id: 12477552,
+                body:
+                    '<p>@SteB1</p><blockquote><p>I don\'t often find myself disagreeing with you.</p></blockquote><p><br>If you read my post carefully - I dont think we actually disagree much on this.<br>The link i gave was merely illustrative of the agricultural approach.</p><p>Farmers and horse-keepers understandably wish to control ragwort on their land, so that their valuable animals, their source of income (and often their lifetimes work) are not put in jeopardy by an unfortunate poisoning incident. </p><p>Yes - demonisation of plants is silly.</p><p>The code of practise is detailed &amp; IMHO pretty good.</p><p><a href="http://www.defra.gov.uk/publications/files/pb9840-cop-ragwort.pdf" rel="nofollow">http://www.defra.gov.uk/publications/files/pb9840-cop-ragwort.pdf</a></p><p>A careful eye and judicious pulling of ragwort where there are low populations, can prevent a major issue arising and unnecessary herbicide use.</p>',
+                date: '19 September 2011 11:55pm',
+                isoDateTime: '2011-09-19T22:55:39Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12477552',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12477552',
+                numResponses: 0,
+                numRecommends: 1,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '2411079',
+                    displayName: 'antipodean1',
+                    webUrl: 'https://profile.theguardian.com/user/id/2411079',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/2411079',
+                    avatar: 'https://avatar.guim.co.uk/user/2411079',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/2411079',
+                    badge: [],
+                },
+            },
+            {
+                id: 12478723,
+                body:
+                    "<p>I'm no supporter of Benyon, but at least, I assume, he thinks he is doing the right thing? Seems harsh from Dusty, et al, given it is still a widespread practice.</p><p>Many conservation organisations are still pulling ragwort on SSSIs so DEFRA will know that this is happening. If it is unnecessary why isn't the guidance flitering down to on the ground staff?</p><p>There may also be an issue that in order to get grazing, you have to remove ragwort otherwise grazers won't allow their stock on site.</p>",
+                date: '20 September 2011 6:30am',
+                isoDateTime: '2011-09-20T05:30:36Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12478723',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12478723',
+                numResponses: 0,
+                numRecommends: 1,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '3237256',
+                    displayName: 'PizzaRe',
+                    webUrl: 'https://profile.theguardian.com/user/id/3237256',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/3237256',
+                    avatar: 'https://avatar.guim.co.uk/user/3237256',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/3237256',
+                    badge: [],
+                },
+            },
+            {
+                id: 12479039,
+                body:
+                    '<p>MrRatfan1976</p><p>You say you want the science and then link to two sites offering <b>some</b> of the information.</p><p>It\'s far easier to get the <a href="http://www.defra.gov.uk/publications/files/pb9840-cop-ragwort.pdf" rel="nofollow">DEFRA Code of Practice</a> and follow the advice given there.</p><p>That is what Mr Benyon <b>didn\'t</b> do and that is why he has been criticised.</p>',
+                date: '20 September 2011 8:13am',
+                isoDateTime: '2011-09-20T07:13:14Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12479039',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12479039',
+                numResponses: 0,
+                numRecommends: 1,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4323663',
+                    displayName: 'thepoisongarden',
+                    webUrl: 'https://profile.theguardian.com/user/id/4323663',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4323663',
+                    avatar: 'https://avatar.guim.co.uk/user/4323663',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4323663',
+                    badge: [],
+                },
+            },
+            {
+                id: 12480749,
+                body:
+                    '<p>His advisor probably thought that killing Japanese knotweed might be perceived as racist? Putting it on Facebook, eh? Oh yes, that <a href="http://mitigatingapathy.blogspot.com/2011/09/cultural-branding-of-climate-change.html" rel="nofollow">viral branding</a> stuff central office is always going on about.</p>',
+                date: '20 September 2011 10:44am',
+                isoDateTime: '2011-09-20T09:44:50Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12480749',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12480749',
+                numResponses: 0,
+                numRecommends: 0,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '2456210',
+                    displayName: 'paulhs',
+                    webUrl: 'https://profile.theguardian.com/user/id/2456210',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/2456210',
+                    avatar: 'https://avatar.guim.co.uk/user/2456210',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/2456210',
+                    badge: [],
+                },
+            },
+            {
+                id: 12482898,
+                body:
+                    "<p><b>SteB1</b></p><p><br></p><blockquote><p>    To most of us, there is no story at all here, just a photo of a man pulling up some weeds and having a rant about them. My neighbours, colleagues, friends,... do the same thing every single weekend.</p><p>That's not really accurate is it?<br></p></blockquote><p>Which bit isn't accurate?</p><p>It is a photo of a man pulling up weeds<br>He did have a rant about them.<br>And lots of people do the same thing every single weekend.</p><blockquote><p>You don't explain exactly what you mean by vandalise his facebook page. We can't cross check this because he removed the thread, presumably to hide his embarrassment<br></p></blockquote><p>How ironic!</p><p>So my comment, following on examples from above, is incorrect, whereas your \"presumption\" that he removed (some of) the comments because you allege he was embarrassed and wanted to hide this has some validity.</p>",
+                date: '20 September 2011 12:45pm',
+                isoDateTime: '2011-09-20T11:45:20Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12482898',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12482898',
+                numResponses: 0,
+                numRecommends: 0,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '3699054',
+                    displayName: 'NeverMindTheBollocks',
+                    webUrl: 'https://profile.theguardian.com/user/id/3699054',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/3699054',
+                    avatar: 'https://avatar.guim.co.uk/user/3699054',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/3699054',
+                    badge: [],
+                },
+            },
+            {
+                id: 12483012,
+                body:
+                    '<p>Can we have a campaign against Japanese Knotweed. <br>This stuff is a real pest and many people are unaware of the damage it causes, taking over whole areas of land, wiping out other plants.</p><p>Fortunately a few of us locally who know of the issue, spray and cut it down where we find it, helped by the local children who also have some fun trampling it down.</p>',
+                date: '20 September 2011 12:50pm',
+                isoDateTime: '2011-09-20T11:50:38Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12483012',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12483012',
+                numResponses: 0,
+                numRecommends: 2,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '3938636',
+                    displayName: 'lxy001',
+                    webUrl: 'https://profile.theguardian.com/user/id/3938636',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/3938636',
+                    avatar: 'https://avatar.guim.co.uk/user/3938636',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/3938636',
+                    badge: [],
+                },
+            },
+            {
+                id: 12491080,
+                body:
+                    "<p>As a horse owner I would say o the minister and horse owners<br>Ragwort seeding from joining fields have their own excellent law in the UK, that's what the act of parliament is about. but don't blame this when it isn't the solution, your own fields could have a seedbank from the years beyond. even then there is a good posibility to make this a lesser problem for new growth of ragwort.<br>So taken care of your neighbours land doesn't mean allways your problem is over, covering every empty spot and reseeding with grass is a good working way to go.<br>There are excellent ways to use spot on chemicals to spare any other plants. don't look for excuses, spend your energy in solutions!</p><p>When you blame only ragwort for all causes of liverproblems in horses, you taken a risk with the horses that stay behind, what if it is just one of many other causes or options you could treat. Knowledge could spare other animals, assumptions can let others die unnecessary.   <br>With ragwort there is a easy way out, don't let it go near a horse or other grazing animals, where it can be eaten!</p>",
+                date: '20 September 2011 9:55pm',
+                isoDateTime: '2011-09-20T20:55:45Z',
+                status: 'visible',
+                webUrl:
+                    'https://discussion.theguardian.com/comment-permalink/12491080',
+                apiUrl:
+                    'https://discussion.guardianapis.com/discussion-api/comment/12491080',
+                numResponses: 0,
+                numRecommends: 2,
+                isHighlighted: false,
+                userProfile: {
+                    userId: '4741862',
+                    displayName: 'EstherHegt',
+                    webUrl: 'https://profile.theguardian.com/user/id/4741862',
+                    apiUrl:
+                        'https://discussion.guardianapis.com/discussion-api/profile/4741862',
+                    avatar: 'https://avatar.guim.co.uk/user/4741862',
+                    secureAvatarUrl: 'https://avatar.guim.co.uk/user/4741862',
+                    badge: [],
+                },
+            },
+        ],
+    },
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,7 +33,10 @@ const IndexPageWrapper = () => {
             <h1>Example Discussion</h1>
             <p>
                 Set a specific discussion using the id in a query param like{' '}
-                <a href="/?id=32255">?id=32255</a>.
+                <a href="?id=32255&closedForComments=true&pillar=opinion">
+                    ?id=32255&closedForComments=true&pillar=opinion
+                </a>
+                .
             </p>
             <App
                 baseUrl="https://discussion.theguardian.com/discussion-api"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,21 +1,55 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 
 import { App } from './App';
+import { Pillar } from './types';
 
-ReactDOM.render(
-    <App
-        baseUrl="https://discussion.theguardian.com/discussion-api"
-        pillar="news"
-        isClosedForComments={false}
-        shortUrl="/p/39f5z"
-        additionalHeaders={{
-            'D2-X-UID': 'testD2Header',
-            'GU-Client': 'testClientHeader',
-        }}
-        expanded={false}
-        onPermalinkClick={() => {}}
-        apiKey="discussion-rendering"
-    />,
-    document.getElementById('root'),
-);
+const IndexPageWrapper = () => {
+    const [options, setOptions] = useState({
+        shortUrl: '',
+        closedForComments: false,
+        pillar: 'news' as Pillar,
+    });
+
+    const getQueryParam = (queryParam: string, defaultValue: string): string =>
+        new URLSearchParams(window.location.search).get(queryParam) ||
+        defaultValue;
+
+    useEffect(() => {
+        setOptions({
+            shortUrl: getQueryParam('id', '39f5z'),
+            closedForComments: !!getQueryParam('closedForComments', 'false'),
+            pillar: getQueryParam('pillar', 'news') as Pillar,
+        });
+    }, [options.closedForComments]);
+
+    // Only render when we have checked the query params
+    if (options.shortUrl === '') {
+        return null;
+    }
+
+    return (
+        <>
+            <h1>Example Discussion</h1>
+            <p>
+                Set a specific discussion using the id in a query param like{' '}
+                <a href="/?id=32255">?id=32255</a>.
+            </p>
+            <App
+                baseUrl="https://discussion.theguardian.com/discussion-api"
+                pillar={options.pillar}
+                isClosedForComments={options.closedForComments}
+                shortUrl={`/p/${options.shortUrl}`}
+                additionalHeaders={{
+                    'D2-X-UID': 'testD2Header',
+                    'GU-Client': 'testClientHeader',
+                }}
+                expanded={false}
+                onPermalinkClick={() => {}}
+                apiKey="discussion-rendering"
+            />
+        </>
+    );
+};
+
+ReactDOM.render(<IndexPageWrapper />, document.getElementById('root'));

--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -83,6 +83,20 @@ export const getDiscussion = (
         },
     })
         .then(resp => resp.json())
+        .then(json => {
+            if (
+                json.errorCode === 'DISCUSSION_ONLY_AVAILABLE_IN_LINEAR_FORMAT'
+            ) {
+                // We need force a refetch with unthreaded set, as we don't know
+                // that this discussion is only available in linear format until
+                // we get the response to tell us
+                return getDiscussion(shortUrl, {
+                    ...opts,
+                    ...{ threads: 'unthreaded' },
+                });
+            }
+            return json;
+        })
         .catch(error => console.error(`Error fetching ${url}`, error));
 };
 

--- a/src/lib/mockFetchCalls.js
+++ b/src/lib/mockFetchCalls.js
@@ -6,6 +6,7 @@ import { topPicks } from '../fixtures/topPicks';
 import { noTopPicks } from '../fixtures/noTopPicks';
 import { discussionWithNoComments } from '../fixtures/discussionWithNoComments';
 import { discussionWithTwoComments } from '../fixtures/discussionWithTwoComments';
+import { legacyDiscussionWithoutThreading } from '../fixtures/legacyDiscussionWithoutThreading';
 
 export const mockedMessageID = '123456';
 
@@ -70,6 +71,19 @@ export const mockFetchCalls = () => {
             },
         )
         .get(/.*\/discussion\/p\/39f5a\/topcomments.*/, {
+            status: 200,
+            body: noTopPicks,
+        })
+
+        // Get discussion 32255
+        .get(
+            /.*\/discussion.theguardian.com\/discussion-api\/discussion\/p\/32255\?.*/,
+            {
+                status: 200,
+                body: legacyDiscussionWithoutThreading,
+            },
+        )
+        .get(/.*\/discussion\/p\/32255\/topcomments.*/, {
             status: 200,
             body: noTopPicks,
         })

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -127,6 +127,7 @@ export interface UserProfile {
 
 export interface DiscussionResponse {
     status: string;
+    errorCode?: string;
     page: number;
     pages: number;
     pageSize: number;


### PR DESCRIPTION
## What does this change?

- Adds state to the test server to allow easy setting of discussion and pillars (gives the option of cypress testing)
- Fixes legacy discussions that return an error when requesting with anything but `unthreaded`

![2020-07-24 15 32 08](https://user-images.githubusercontent.com/638051/88402939-b8257200-cdc3-11ea-8e1e-b3974bca73fb.gif)

## Bug

## Link to supporting Trello card

https://trello.com/c/peBSRvJO/1924-older-articles-dont-load-discussion
