### PR TITLE
set authentication event parameters on signin link

### DIFF
--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -19,6 +19,7 @@ import { ButtonLink } from '../ButtonLink/ButtonLink';
 
 import { Pillar, CommentType, UserProfile } from '../../types';
 import { pickComment, unPickComment } from '../../lib/api';
+import { createAuthenticationEventParams } from "../../lib/identity-component-event";
 
 type Props = {
     user?: UserProfile;
@@ -535,7 +536,7 @@ export const Comment = ({
                                                         )}
                                                     >
                                                         <Link
-                                                            href={`https://profile.theguardian.com/signin?returnUrl=${comment.webUrl}`}
+                                                            href={`https://profile.theguardian.com/signin?returnUrl=${comment.webUrl}&${createAuthenticationEventParams('signin_to_reply_comment')}`}
                                                             subdued={true}
                                                             icon={<SvgIndent />}
                                                             iconSide="left"

--- a/src/lib/identity-component-event.test.ts
+++ b/src/lib/identity-component-event.test.ts
@@ -1,0 +1,7 @@
+import { createAuthenticationEventParams } from "./identity-component-event";
+
+describe('createAuthenticationEventParams', () => {
+    it('creates authentication event params given a component Id', () => {
+        expect(createAuthenticationEventParams('signin_to_reply_comment')).toBe('componentEventParams=componentType%3Didentityauthentication%26componentId%3Dsignin_to_reply_comment')
+    });
+});

--- a/src/lib/identity-component-event.ts
+++ b/src/lib/identity-component-event.ts
@@ -1,0 +1,7 @@
+
+export type AuthenticationComponentId = 'signin_to_reply_comment'
+
+export const createAuthenticationEventParams = (componentId: AuthenticationComponentId) => {
+    const params = `componentType=identityauthentication&componentId=${componentId}`;
+    return `componentEventParams=${encodeURIComponent(params)}`;
+};


### PR DESCRIPTION
## What does this change?

Pass component event parameters for all signin referrers. These parameters get propagated from /signin to IDAPI which sends the component events on behalf of the user. IDAPI sends the component event to Ophan using the /signin page view ID and the new SC_GU_U cookie. This means the /signin pageview entry has session information associated and the component ID used for signing in.

## Why?

This will allow data analysts to track how many users are using different sign in mechanisms to authenticate using the Guardian website.

## Link to supporting Trello card

https://trello.com/c/37cmz78X/2206-improve-and-create-additional-ophan-events-sent-from-identity-pages-and-identity-api