### PR TITLE
Ensure that long usernames don't push out replies

### DIFF
--- a/src/components/Comment/Comment.stories.tsx
+++ b/src/components/Comment/Comment.stories.tsx
@@ -67,6 +67,34 @@ const replyCommentData: CommentType = {
     },
 };
 
+const longReplyCommentData: CommentType = {
+    ...commentData,
+    responseTo: {
+        displayName: 'ArtVandelayWithAVeryLongUserName',
+        commentApiUrl: '',
+        isoDateTime: '',
+        date: '',
+        commentId: '123456',
+        commentWebUrl: '',
+    },
+};
+
+const longBothReplyCommentData: CommentType = {
+    ...commentData,
+    userProfile: {
+        ...commentData.userProfile,
+        displayName: 'AVeryLongUserNameForThisUserToo',
+    },
+    responseTo: {
+        displayName: 'ArtVandelayWithAVeryLongUserName',
+        commentApiUrl: '',
+        isoDateTime: '',
+        date: '',
+        commentId: '123456',
+        commentWebUrl: '',
+    },
+};
+
 const staffUser: UserProfile = {
     userId: 'abc123',
     displayName: 'Jane Smith',
@@ -156,6 +184,46 @@ export const MobileReply = () => (
 );
 MobileReply.story = {
     name: 'A reply on mobile view',
+    parameters: {
+        viewport: { defaultViewport: 'mobileMedium' },
+        chromatic: { viewports: [375] },
+    },
+};
+
+export const LongMobileReply = () => (
+    <Comment
+        comment={longReplyCommentData}
+        pillar={'culture'}
+        setCommentBeingRepliedTo={() => {}}
+        isReply={true}
+        isClosedForComments={false}
+        isMuted={false}
+        toggleMuteStatus={() => {}}
+        onPermalinkClick={() => {}}
+    />
+);
+LongMobileReply.story = {
+    name: 'A long username reply on mobile view',
+    parameters: {
+        viewport: { defaultViewport: 'mobileMedium' },
+        chromatic: { viewports: [375] },
+    },
+};
+
+export const LongBothMobileReply = () => (
+    <Comment
+        comment={longBothReplyCommentData}
+        pillar={'culture'}
+        setCommentBeingRepliedTo={() => {}}
+        isReply={true}
+        isClosedForComments={false}
+        isMuted={false}
+        toggleMuteStatus={() => {}}
+        onPermalinkClick={() => {}}
+    />
+);
+LongBothMobileReply.story = {
+    name: 'Both long usernames replying on mobile view',
     parameters: {
         viewport: { defaultViewport: 'mobileMedium' },
         chromatic: { viewports: [375] },

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -233,7 +233,7 @@ const cssReplyToWrapper = css`
 // - Both labels should truncate with ellipsis if they fill their space
 // Test page: https://codepen.io/gtrufitt/pen/LYGKQyY
 
-const cssReplyDisplayName = css`
+const cssReplyAlphaDisplayName = css`
     ${until.mobileLandscape} {
         ${cssTextOverflowElip}
         width: 100%;
@@ -241,7 +241,7 @@ const cssReplyDisplayName = css`
     }
 `;
 
-const cssReplyToDisplayName = css`
+const cssReplyBetaDisplayName = css`
     ${until.mobileLandscape} {
         ${cssTextOverflowElip}
         min-width: 40%;
@@ -398,7 +398,7 @@ export const Comment = ({
                                             className={cx(
                                                 colourStyles(pillar),
                                                 boldFont,
-                                                cssReplyDisplayName,
+                                                cssReplyAlphaDisplayName,
                                             )}
                                         >
                                             <Link
@@ -420,7 +420,7 @@ export const Comment = ({
                                                     colourStyles(pillar),
                                                     regularFont,
                                                     svgOverrides,
-                                                    cssReplyToDisplayName,
+                                                    cssReplyBetaDisplayName,
                                                 )}
                                             >
                                                 <Link

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -173,6 +173,7 @@ const svgOverrides = css`
 
 const commentDetails = css`
     flex-grow: 1;
+    width: 100%;
 `;
 
 const headerStyles = css`
@@ -209,6 +210,43 @@ const hideAboveMobileLandscape = css`
 const negativeMargin = css`
     margin-top: 0px;
     margin-bottom: -6px;
+`;
+
+const cssTextOverflowElip = css`
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+`;
+
+const cssReplyToWrapper = css`
+    ${until.mobileLandscape} {
+        padding-right: 10px;
+        width: calc(100% - 35px);
+        box-sizing: border-box;
+    }
+`;
+
+// In order to show as much of the usernames as possible without fixed widths:
+// - First label should shrink to contents but be no bigger than 60%
+// - Second label should never force first label less than its contents if less than 60%
+// - Second label should fill remaining space after above
+// - Both labels should truncate with ellipsis if they fill their space
+// Test page: https://codepen.io/gtrufitt/pen/LYGKQyY
+
+const cssReplyDisplayName = css`
+    ${until.mobileLandscape} {
+        ${cssTextOverflowElip}
+        width: 100%;
+        max-width: fit-content;
+    }
+`;
+
+const cssReplyToDisplayName = css`
+    ${until.mobileLandscape} {
+        ${cssTextOverflowElip}
+        min-width: 40%;
+        flex-grow: 1;
+    }
 `;
 
 const Space = ({ amount }: { amount: 1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24 }) => (
@@ -291,34 +329,76 @@ export const Comment = ({
 
                 <div className={commentDetails}>
                     <header className={headerStyles}>
-                        <Column>
-                            <div
-                                className={cx(
-                                    comment.responseTo &&
-                                        hideBelowMobileLandscape,
-                                    hideAboveMobileLandscape,
-                                )}
-                            >
-                                <Row>
-                                    <div
-                                        className={css`
-                                            margin-right: ${space[2]}px;
-                                        `}
-                                    >
-                                        <Avatar
-                                            imageUrl={
-                                                comment.userProfile.avatar
-                                            }
-                                            displayName={''}
-                                            size="small"
-                                        />
-                                    </div>
-                                    <Column>
+                        <div className={cssReplyToWrapper}>
+                            <Column>
+                                <div
+                                    className={cx(
+                                        comment.responseTo &&
+                                            hideBelowMobileLandscape,
+                                        hideAboveMobileLandscape,
+                                    )}
+                                >
+                                    <Row>
+                                        <div
+                                            className={css`
+                                                margin-right: ${space[2]}px;
+                                            `}
+                                        >
+                                            <Avatar
+                                                imageUrl={
+                                                    comment.userProfile.avatar
+                                                }
+                                                displayName={''}
+                                                size="small"
+                                            />
+                                        </div>
+                                        <Column>
+                                            <div
+                                                className={cx(
+                                                    colourStyles(pillar),
+                                                    boldFont,
+                                                    negativeMargin,
+                                                )}
+                                            >
+                                                <Link
+                                                    href={
+                                                        comment.userProfile
+                                                            .webUrl
+                                                    }
+                                                    subdued={true}
+                                                    rel="nofollow"
+                                                >
+                                                    {
+                                                        comment.userProfile
+                                                            .displayName
+                                                    }
+                                                </Link>
+                                            </div>
+                                            <Timestamp
+                                                isoDateTime={
+                                                    comment.isoDateTime
+                                                }
+                                                webUrl={comment.webUrl}
+                                                commentId={comment.id}
+                                                onPermalinkClick={
+                                                    onPermalinkClick
+                                                }
+                                            />
+                                        </Column>
+                                    </Row>
+                                </div>
+                                <div
+                                    className={cx(
+                                        !comment.responseTo &&
+                                            hideBelowMobileLandscape,
+                                    )}
+                                >
+                                    <Row>
                                         <div
                                             className={cx(
                                                 colourStyles(pillar),
                                                 boldFont,
-                                                negativeMargin,
+                                                cssReplyDisplayName,
                                             )}
                                         >
                                             <Link
@@ -334,90 +414,69 @@ export const Comment = ({
                                                 }
                                             </Link>
                                         </div>
-                                        <Timestamp
-                                            isoDateTime={comment.isoDateTime}
-                                            webUrl={comment.webUrl}
-                                            commentId={comment.id}
-                                            onPermalinkClick={onPermalinkClick}
-                                        />
-                                    </Column>
-                                </Row>
-                            </div>
-                            <div
-                                className={cx(
-                                    !comment.responseTo &&
-                                        hideBelowMobileLandscape,
-                                )}
-                            >
-                                <Row>
-                                    <div
-                                        className={cx(
-                                            colourStyles(pillar),
-                                            boldFont,
+                                        {comment.responseTo ? (
+                                            <div
+                                                className={cx(
+                                                    colourStyles(pillar),
+                                                    regularFont,
+                                                    svgOverrides,
+                                                    cssReplyToDisplayName,
+                                                )}
+                                            >
+                                                <Link
+                                                    href={`#comment-${comment.responseTo.commentId}`}
+                                                    subdued={true}
+                                                    icon={<SvgIndent />}
+                                                    iconSide="left"
+                                                    rel="nofollow"
+                                                >
+                                                    {
+                                                        comment.responseTo
+                                                            .displayName
+                                                    }
+                                                </Link>
+                                            </div>
+                                        ) : (
+                                            <></>
                                         )}
-                                    >
-                                        <Link
-                                            href={comment.userProfile.webUrl}
-                                            subdued={true}
-                                            rel="nofollow"
-                                        >
-                                            {comment.userProfile.displayName}
-                                        </Link>
-                                    </div>
-                                    {comment.responseTo ? (
                                         <div
                                             className={cx(
-                                                colourStyles(pillar),
-                                                regularFont,
-                                                svgOverrides,
+                                                timestampWrapperStyles,
+                                                comment.responseTo &&
+                                                    hideBelowMobileLandscape,
                                             )}
                                         >
-                                            <Link
-                                                href={`#comment-${comment.responseTo.commentId}`}
-                                                subdued={true}
-                                                icon={<SvgIndent />}
-                                                iconSide="left"
-                                                rel="nofollow"
-                                            >
-                                                {comment.responseTo.displayName}
-                                            </Link>
+                                            <Timestamp
+                                                isoDateTime={
+                                                    comment.isoDateTime
+                                                }
+                                                webUrl={comment.webUrl}
+                                                commentId={comment.id}
+                                                onPermalinkClick={
+                                                    onPermalinkClick
+                                                }
+                                            />
                                         </div>
-                                    ) : (
-                                        <></>
-                                    )}
-                                    <div
-                                        className={cx(
-                                            timestampWrapperStyles,
-                                            comment.responseTo &&
-                                                hideBelowMobileLandscape,
+                                    </Row>
+                                    <Row>
+                                        {showStaffbadge ? (
+                                            <div className={iconWrapper}>
+                                                <GuardianStaff />
+                                            </div>
+                                        ) : (
+                                            <></>
                                         )}
-                                    >
-                                        <Timestamp
-                                            isoDateTime={comment.isoDateTime}
-                                            webUrl={comment.webUrl}
-                                            commentId={comment.id}
-                                            onPermalinkClick={onPermalinkClick}
-                                        />
-                                    </div>
-                                </Row>
-                                <Row>
-                                    {showStaffbadge ? (
-                                        <div className={iconWrapper}>
-                                            <GuardianStaff />
-                                        </div>
-                                    ) : (
-                                        <></>
-                                    )}
-                                    {showPickBadge ? (
-                                        <div className={iconWrapper}>
-                                            <GuardianPick />
-                                        </div>
-                                    ) : (
-                                        <></>
-                                    )}
-                                </Row>
-                            </div>
-                        </Column>
+                                        {showPickBadge ? (
+                                            <div className={iconWrapper}>
+                                                <GuardianPick />
+                                            </div>
+                                        ) : (
+                                            <></>
+                                        )}
+                                    </Row>
+                                </div>
+                            </Column>
+                        </div>
                         {comment.status !== 'blocked' && (
                             <RecommendationCount
                                 commentId={comment.id}

--- a/src/components/Timestamp/Timestamp.tsx
+++ b/src/components/Timestamp/Timestamp.tsx
@@ -26,6 +26,7 @@ const timeStyles = css`
     ${textSans.xsmall({ fontWeight: 'light' })}
     min-width: 0.75rem;
     margin-right: 0.3125rem;
+    white-space: nowrap;
 `;
 
 export const Timestamp = ({

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,6 +38,7 @@ const IndexPageWrapper = () => {
                 </a>
                 .
             </p>
+            <style>{`body { padding: 0 10px;}`}</style>
             <App
                 baseUrl="https://discussion.theguardian.com/discussion-api"
                 pillar={options.pillar}


### PR DESCRIPTION
## What does this change?

Usernames will be truncated if they are too long and don't have enough space, instead of before where they pushed the comments container too wide.

They truncate in the most space effective way possible, always showing as much of each username as is practical.

### Before
![image](https://user-images.githubusercontent.com/638051/89030814-22d92f00-d329-11ea-921d-718f1e6ef497.png)


### After
![Screen Shot 2020-07-31 at 11 35 38](https://user-images.githubusercontent.com/638051/89030822-279de300-d329-11ea-9378-b82c86d86bc3.png)
![Screen Shot 2020-07-31 at 11 35 30](https://user-images.githubusercontent.com/638051/89030823-28367980-d329-11ea-83b7-58bfb5d373e1.png)
![Screen Shot 2020-07-31 at 11 34 46](https://user-images.githubusercontent.com/638051/89030824-28cf1000-d329-11ea-876c-6b4cc3049312.png)

