### PR TITLE
on recommend callback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ type Props = {
     onPermalinkClick: (commentId: number) => void;
     apiKey: string;
     onHeightChange?: () => void;
+    onRecommend?: (commentId: number) => Promise<Boolean>;
 };
 
 const footerStyles = css`

--- a/src/components/RecommendationCount/RecommendationCount.tsx
+++ b/src/components/RecommendationCount/RecommendationCount.tsx
@@ -15,6 +15,7 @@ type Props = {
     alreadyRecommended: boolean;
     isSignedIn: boolean;
     userMadeComment: boolean;
+    onRecommend: (commentId: number) => Promise<Boolean>;
 };
 
 const countStyles = css`
@@ -53,6 +54,7 @@ export const RecommendationCount = ({
     alreadyRecommended,
     isSignedIn,
     userMadeComment,
+    onRecommend,
 }: Props) => {
     const [count, setCount] = useState(initialCount);
     const [recommended, setRecommended] = useState(alreadyRecommended);
@@ -63,7 +65,7 @@ export const RecommendationCount = ({
         setRecommended(true);
 
         //makeApi call
-        recommend(commentId).then(accepted => {
+        onRecommend(commentId).then(accepted => {
             if (!accepted) {
                 setCount(newCount - 1);
                 setRecommended(alreadyRecommended);
@@ -86,4 +88,8 @@ export const RecommendationCount = ({
             </button>
         </Row>
     );
+};
+
+RecommendationCount.defaultProps = {
+    onRecommend: recommend,
 };

--- a/src/components/RecommendationCount/RecommendationCount.tsx
+++ b/src/components/RecommendationCount/RecommendationCount.tsx
@@ -15,7 +15,7 @@ type Props = {
     alreadyRecommended: boolean;
     isSignedIn: boolean;
     userMadeComment: boolean;
-    onRecommend: (commentId: number) => Promise<Boolean>;
+    onRecommend?: (commentId: number) => Promise<Boolean>;
 };
 
 const countStyles = css`

--- a/src/components/RecommendationCount/RecommendationCount.tsx
+++ b/src/components/RecommendationCount/RecommendationCount.tsx
@@ -54,7 +54,7 @@ export const RecommendationCount = ({
     alreadyRecommended,
     isSignedIn,
     userMadeComment,
-    onRecommend,
+    onRecommend = recommend,
 }: Props) => {
     const [count, setCount] = useState(initialCount);
     const [recommended, setRecommended] = useState(alreadyRecommended);
@@ -88,8 +88,4 @@ export const RecommendationCount = ({
             </button>
         </Row>
     );
-};
-
-RecommendationCount.defaultProps = {
-    onRecommend: recommend,
 };

--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -208,7 +208,7 @@ export const reportAbuse = ({
     categoryId: number;
     reason?: string;
     email?: string;
-}) => {
+}): Promise<CommentResponse> => {
     const url =
         joinUrl([
             options.baseUrl,


### PR DESCRIPTION
## What does this change?
The apps don't have access to the user cookie required to validate a number of actions like posting, replying, recommending or reporting.

For these events, discussion-rendering could accept optional callbacks as props. This would allow native apps to make the requests with their identity tokens and report back the success/failure to the webview.

The Bridget communication is [promise based](https://github.com/guardian/apps-rendering/blob/c66f6db84c0af623a07d2b7a96b231f92da6c135/src/client/nativeCommunication.ts#L82) so I'm hoping they could just be passed through as props.

I've added default props to keep the current behaviour, so dotcom-rendering shouldn't need to add any changes.

This is a draft PR that can be extended if needed. 
