### PR TITLE
App callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guardian/discussion-rendering",
     "description": "This codebase started as a hack day project by @gtrufitt and @nicl. The purpose is parity of the existing discussion application on Frontend using the discussion API (search for Private Repo).",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "author": "",
     "homepage": "https://github.com/guardian/discussion-rendering#readme",
     "license": "Apache",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ type Props = {
     onRecommend?: (commentId: number) => Promise<Boolean>;
     onComment?: (shortUrl: string, body: string) => Promise<CommentResponse>;
     onReply?: (shortUrl: string, body: string, parentCommentId: number) => Promise<CommentResponse>;
+    onPreview?: (body: string) => Promise<string>;
 };
 
 const footerStyles = css`
@@ -220,7 +221,8 @@ export const App = ({
     onHeightChange = () => {},
     onRecommend,
     onComment,
-    onReply
+    onReply,
+    onPreview
 }: Props) => {
     const [filters, setFilters] = useState<FilterOptions>(
         initialiseFilters({
@@ -376,6 +378,7 @@ export const App = ({
                         user={user}
                         onComment={onComment}
                         onReply={onReply}
+                        onPreview={onPreview}
                     />
                 )}
                 {picks && picks.length ? (
@@ -476,6 +479,7 @@ export const App = ({
                         user={user}
                         onComment={onComment}
                         onReply={onReply}
+                        onPreview={onPreview}
                     />
                 )}
                 {!!picks.length && (
@@ -558,6 +562,7 @@ export const App = ({
                         user={user}
                         onComment={onComment}
                         onReply={onReply}
+                        onPreview={onPreview}
                     />
                 )}
             </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import {
     PageSizeType,
     OrderByType,
     Pillar,
+    CommentResponse,
 } from './types';
 import { getDiscussion, getPicks, initialiseApi } from './lib/api';
 import { CommentContainer } from './components/CommentContainer/CommentContainer';
@@ -41,6 +42,7 @@ type Props = {
     apiKey: string;
     onHeightChange?: () => void;
     onRecommend?: (commentId: number) => Promise<Boolean>;
+    onComment?: (shortUrl: string, body: string) => Promise<CommentResponse>;
 };
 
 const footerStyles = css`
@@ -215,7 +217,8 @@ export const App = ({
     onPermalinkClick,
     apiKey,
     onHeightChange = () => {},
-    onRecommend
+    onRecommend,
+    onComment
 }: Props) => {
     const [filters, setFilters] = useState<FilterOptions>(
         initialiseFilters({
@@ -369,6 +372,7 @@ export const App = ({
                         shortUrl={shortUrl}
                         onAddComment={onAddComment}
                         user={user}
+                        onComment={onComment}
                     />
                 )}
                 {picks && picks.length ? (
@@ -467,6 +471,7 @@ export const App = ({
                         shortUrl={shortUrl}
                         onAddComment={onAddComment}
                         user={user}
+                        onComment={onComment}
                     />
                 )}
                 {!!picks.length && (
@@ -546,6 +551,7 @@ export const App = ({
                         shortUrl={shortUrl}
                         onAddComment={onAddComment}
                         user={user}
+                        onComment={onComment}
                     />
                 )}
             </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -215,6 +215,7 @@ export const App = ({
     onPermalinkClick,
     apiKey,
     onHeightChange = () => {},
+    onRecommend
 }: Props) => {
     const [filters, setFilters] = useState<FilterOptions>(
         initialiseFilters({
@@ -378,6 +379,7 @@ export const App = ({
                                 comments={picks.slice(0, 2)}
                                 isSignedIn={!!user}
                                 onPermalinkClick={onPermalinkClick}
+                                onRecommend={onRecommend}
                             />
                         )}
                     </div>
@@ -427,6 +429,7 @@ export const App = ({
                                             mutes={mutes}
                                             toggleMuteStatus={toggleMuteStatus}
                                             onPermalinkClick={onPermalinkClick}
+                                            onRecommend={onRecommend}
                                         />
                                     </li>
                                 ))}
@@ -472,6 +475,7 @@ export const App = ({
                         comments={picks}
                         isSignedIn={!!user}
                         onPermalinkClick={onPermalinkClick}
+                        onRecommend={onRecommend}
                     />
                 )}
                 <Filters
@@ -517,6 +521,7 @@ export const App = ({
                                     mutes={mutes}
                                     toggleMuteStatus={toggleMuteStatus}
                                     onPermalinkClick={onPermalinkClick}
+                                    onRecommend={onRecommend}
                                 />
                             </li>
                         ))}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ type Props = {
     onHeightChange?: () => void;
     onRecommend?: (commentId: number) => Promise<Boolean>;
     onComment?: (shortUrl: string, body: string) => Promise<CommentResponse>;
+    onReply?: (shortUrl: string, body: string, parentCommentId: number) => Promise<CommentResponse>;
 };
 
 const footerStyles = css`
@@ -218,7 +219,8 @@ export const App = ({
     apiKey,
     onHeightChange = () => {},
     onRecommend,
-    onComment
+    onComment,
+    onReply
 }: Props) => {
     const [filters, setFilters] = useState<FilterOptions>(
         initialiseFilters({
@@ -373,6 +375,7 @@ export const App = ({
                         onAddComment={onAddComment}
                         user={user}
                         onComment={onComment}
+                        onReply={onReply}
                     />
                 )}
                 {picks && picks.length ? (
@@ -472,6 +475,7 @@ export const App = ({
                         onAddComment={onAddComment}
                         user={user}
                         onComment={onComment}
+                        onReply={onReply}
                     />
                 )}
                 {!!picks.length && (
@@ -527,6 +531,7 @@ export const App = ({
                                     toggleMuteStatus={toggleMuteStatus}
                                     onPermalinkClick={onPermalinkClick}
                                     onRecommend={onRecommend}
+                                    onReply={onReply}
                                 />
                             </li>
                         ))}
@@ -552,6 +557,7 @@ export const App = ({
                         onAddComment={onAddComment}
                         user={user}
                         onComment={onComment}
+                        onReply={onReply}
                     />
                 )}
             </div>

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -32,6 +32,7 @@ type Props = {
     isMuted: boolean;
     toggleMuteStatus: (userId: string) => void;
     onPermalinkClick: (commentId: number) => void;
+    onRecommend?: (commentId: number) => Promise<Boolean>;
 };
 
 const shiftLeft = css`
@@ -272,6 +273,7 @@ export const Comment = ({
     isMuted,
     toggleMuteStatus,
     onPermalinkClick,
+    onRecommend
 }: Props) => {
     const [isHighlighted, setIsHighlighted] = useState<boolean>(
         comment.isHighlighted,
@@ -487,6 +489,7 @@ export const Comment = ({
                                 initialCount={comment.numRecommends}
                                 alreadyRecommended={false}
                                 isSignedIn={!!user}
+                                onRecommend={onRecommend}
                                 userMadeComment={
                                     !!user &&
                                     user.userId === comment.userProfile.userId

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -25,6 +25,7 @@ type Props = {
     mutes: string[];
     toggleMuteStatus: (userId: string) => void;
     onPermalinkClick: (commentId: number) => void;
+    onRecommend?: (commentId: number) => Promise<Boolean>;
 };
 
 const nestingStyles = css`
@@ -98,6 +99,7 @@ export const CommentContainer = ({
     mutes,
     toggleMuteStatus,
     onPermalinkClick,
+    onRecommend
 }: Props) => {
     // Filter logic
     const [expanded, setExpanded] = useState<boolean>(threads === 'expanded');
@@ -142,6 +144,7 @@ export const CommentContainer = ({
                 isMuted={mutes.includes(comment.userProfile.userId)}
                 toggleMuteStatus={toggleMuteStatus}
                 onPermalinkClick={onPermalinkClick}
+                onRecommend={onRecommend}
             />
 
             <>

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -28,6 +28,7 @@ type Props = {
     onRecommend?: (commentId: number) => Promise<Boolean>;
     onComment?: (shortUrl: string, body: string) => Promise<CommentResponse>;
     onReply?: (shortUrl: string, body: string, parentCommentId: number) => Promise<CommentResponse>;
+    onPreview?: (body: string) => Promise<string>;
 };
 
 const nestingStyles = css`
@@ -103,7 +104,8 @@ export const CommentContainer = ({
     onPermalinkClick,
     onRecommend,
     onComment,
-    onReply
+    onReply,
+    onPreview
 }: Props) => {
     // Filter logic
     const [expanded, setExpanded] = useState<boolean>(threads === 'expanded');
@@ -237,6 +239,7 @@ export const CommentContainer = ({
                                 commentBeingRepliedTo={commentBeingRepliedTo}
                                 onComment={onComment}
                                 onReply={onReply}
+                                onPreview={onPreview}
                             />
                         </div>
                     )}

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -4,7 +4,7 @@ import { css, cx } from 'emotion';
 import { space, neutral, palette, border } from '@guardian/src-foundations';
 import { SvgPlus } from '@guardian/src-icons';
 
-import { Pillar, CommentType, UserProfile, ThreadsType } from '../../types';
+import { Pillar, CommentType, UserProfile, ThreadsType, CommentResponse } from '../../types';
 import { CommentForm } from '../CommentForm/CommentForm';
 import { Comment } from '../Comment/Comment';
 import { Row } from '../Row/Row';
@@ -26,6 +26,7 @@ type Props = {
     toggleMuteStatus: (userId: string) => void;
     onPermalinkClick: (commentId: number) => void;
     onRecommend?: (commentId: number) => Promise<Boolean>;
+    onComment?: (shortUrl: string, body: string) => Promise<CommentResponse>;
 };
 
 const nestingStyles = css`
@@ -99,7 +100,8 @@ export const CommentContainer = ({
     mutes,
     toggleMuteStatus,
     onPermalinkClick,
-    onRecommend
+    onRecommend,
+    onComment
 }: Props) => {
     // Filter logic
     const [expanded, setExpanded] = useState<boolean>(threads === 'expanded');
@@ -231,6 +233,7 @@ export const CommentContainer = ({
                                     setCommentBeingRepliedTo
                                 }
                                 commentBeingRepliedTo={commentBeingRepliedTo}
+                                onComment={onComment}
                             />
                         </div>
                     )}

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -27,6 +27,7 @@ type Props = {
     onPermalinkClick: (commentId: number) => void;
     onRecommend?: (commentId: number) => Promise<Boolean>;
     onComment?: (shortUrl: string, body: string) => Promise<CommentResponse>;
+    onReply?: (shortUrl: string, body: string, parentCommentId: number) => Promise<CommentResponse>;
 };
 
 const nestingStyles = css`
@@ -101,7 +102,8 @@ export const CommentContainer = ({
     toggleMuteStatus,
     onPermalinkClick,
     onRecommend,
-    onComment
+    onComment,
+    onReply
 }: Props) => {
     // Filter logic
     const [expanded, setExpanded] = useState<boolean>(threads === 'expanded');
@@ -234,6 +236,7 @@ export const CommentContainer = ({
                                 }
                                 commentBeingRepliedTo={commentBeingRepliedTo}
                                 onComment={onComment}
+                                onReply={onReply}
                             />
                         </div>
                     )}

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -6,7 +6,7 @@ import { neutral, text } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 
 import { simulateNewComment } from '../../lib/simulateNewComment';
-import { comment, reply, preview, addUserName } from '../../lib/api';
+import { comment as defaultComment, reply, preview, addUserName } from '../../lib/api';
 import { CommentResponse, UserProfile, CommentType, Pillar } from '../../types';
 
 import { FirstCommentWelcome } from '../FirstCommentWelcome/FirstCommentWelcome';
@@ -21,6 +21,7 @@ type Props = {
     onAddComment: (response: CommentType) => void;
     setCommentBeingRepliedTo?: () => void;
     commentBeingRepliedTo?: CommentType;
+    onComment?: (shortUrl: string, body: string) => Promise<CommentResponse>;
 };
 
 const boldString = (text: string) => `<b>${text}</b>`;
@@ -146,6 +147,7 @@ export const CommentForm = ({
     user,
     setCommentBeingRepliedTo,
     commentBeingRepliedTo,
+    onComment
 }: Props) => {
     const [isActive, setIsActive] = useState<boolean>(
         commentBeingRepliedTo ? true : false,
@@ -238,6 +240,7 @@ export const CommentForm = ({
         setInfo('');
 
         if (body) {
+            const comment = onComment ?? defaultComment;
             const response: CommentResponse = commentBeingRepliedTo
                 ? await reply(shortUrl, body, commentBeingRepliedTo.id)
                 : await comment(shortUrl, body);

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -6,7 +6,7 @@ import { neutral, text } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 
 import { simulateNewComment } from '../../lib/simulateNewComment';
-import { comment as defaultComment, reply, preview, addUserName } from '../../lib/api';
+import { comment as defaultComment, reply as defaultReply, preview, addUserName } from '../../lib/api';
 import { CommentResponse, UserProfile, CommentType, Pillar } from '../../types';
 
 import { FirstCommentWelcome } from '../FirstCommentWelcome/FirstCommentWelcome';
@@ -22,6 +22,7 @@ type Props = {
     setCommentBeingRepliedTo?: () => void;
     commentBeingRepliedTo?: CommentType;
     onComment?: (shortUrl: string, body: string) => Promise<CommentResponse>;
+    onReply?: (shortUrl: string, body: string, parentCommentId: number) => Promise<CommentResponse>;
 };
 
 const boldString = (text: string) => `<b>${text}</b>`;
@@ -147,7 +148,8 @@ export const CommentForm = ({
     user,
     setCommentBeingRepliedTo,
     commentBeingRepliedTo,
-    onComment
+    onComment,
+    onReply
 }: Props) => {
     const [isActive, setIsActive] = useState<boolean>(
         commentBeingRepliedTo ? true : false,
@@ -241,6 +243,7 @@ export const CommentForm = ({
 
         if (body) {
             const comment = onComment ?? defaultComment;
+            const reply = onReply ?? defaultReply;
             const response: CommentResponse = commentBeingRepliedTo
                 ? await reply(shortUrl, body, commentBeingRepliedTo.id)
                 : await comment(shortUrl, body);

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -6,7 +6,7 @@ import { neutral, text } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 
 import { simulateNewComment } from '../../lib/simulateNewComment';
-import { comment as defaultComment, reply as defaultReply, preview, addUserName } from '../../lib/api';
+import { comment as defaultComment, reply as defaultReply, preview as defaultPreview, addUserName } from '../../lib/api';
 import { CommentResponse, UserProfile, CommentType, Pillar } from '../../types';
 
 import { FirstCommentWelcome } from '../FirstCommentWelcome/FirstCommentWelcome';
@@ -23,6 +23,7 @@ type Props = {
     commentBeingRepliedTo?: CommentType;
     onComment?: (shortUrl: string, body: string) => Promise<CommentResponse>;
     onReply?: (shortUrl: string, body: string, parentCommentId: number) => Promise<CommentResponse>;
+    onPreview?: (body: string) => Promise<string>;
 };
 
 const boldString = (text: string) => `<b>${text}</b>`;
@@ -149,7 +150,8 @@ export const CommentForm = ({
     setCommentBeingRepliedTo,
     commentBeingRepliedTo,
     onComment,
-    onReply
+    onReply,
+    onPreview
 }: Props) => {
     const [isActive, setIsActive] = useState<boolean>(
         commentBeingRepliedTo ? true : false,
@@ -218,6 +220,7 @@ export const CommentForm = ({
         if (!body) return;
 
         try {
+            const preview = onPreview ?? defaultPreview;
             const response = await preview(body);
             setPreviewBody(response);
             setShowPreview(true);
@@ -356,6 +359,7 @@ export const CommentForm = ({
                 error={error}
                 submitForm={submitUserName}
                 cancelSubmit={() => setUserNameMissing(false)}
+                onPreview={onPreview}
             />
         );
     }

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -7,7 +7,7 @@ import { Link } from '@guardian/src-link';
 import { Row } from '../Row/Row';
 import { PillarButton } from '../PillarButton/PillarButton';
 
-import { preview } from '../../lib/api';
+import { preview as defaultPreview } from '../../lib/api';
 
 import { Pillar } from '../../types';
 
@@ -17,6 +17,7 @@ type Props = {
     error?: string;
     submitForm: (userName: string) => void;
     cancelSubmit: () => void;
+    onPreview?: (body: string) => Promise<string>;
 };
 
 const previewStyle = css`
@@ -48,6 +49,7 @@ export const FirstCommentWelcome = ({
     error = '',
     submitForm,
     cancelSubmit,
+    onPreview
 }: Props) => {
     const [previewBody, setPreviewBody] = useState<string>('');
     const [userName, setUserName] = useState<string>('');
@@ -55,6 +57,7 @@ export const FirstCommentWelcome = ({
     useEffect(() => {
         const fetchShowPreview = async () => {
             try {
+                const preview = onPreview ?? defaultPreview;
                 const response = await preview(body);
                 setPreviewBody(response);
             } catch (e) {

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -49,7 +49,7 @@ export const FirstCommentWelcome = ({
     error = '',
     submitForm,
     cancelSubmit,
-    onPreview
+    onPreview,
 }: Props) => {
     const [previewBody, setPreviewBody] = useState<string>('');
     const [userName, setUserName] = useState<string>('');
@@ -65,7 +65,7 @@ export const FirstCommentWelcome = ({
             }
         };
         fetchShowPreview();
-    }, [body]);
+    }, [body, onPreview]);
 
     return (
         <div

--- a/src/components/RecommendationCount/RecommendationCount.tsx
+++ b/src/components/RecommendationCount/RecommendationCount.tsx
@@ -7,7 +7,7 @@ import { brand } from '@guardian/src-foundations';
 import { SvgArrowUpStraight } from '@guardian/src-icons';
 import { Row } from '../Row/Row';
 
-import { recommend } from '../../lib/api';
+import { recommend as recommendDefault } from '../../lib/api';
 
 type Props = {
     commentId: number;
@@ -50,7 +50,7 @@ export const RecommendationCount = ({
     alreadyRecommended,
     isSignedIn,
     userMadeComment,
-    onRecommend = recommend,
+    onRecommend,
 }: Props) => {
     const [count, setCount] = useState(initialCount);
     const [recommended, setRecommended] = useState(alreadyRecommended);
@@ -59,9 +59,9 @@ export const RecommendationCount = ({
         const newCount = count + 1;
         setCount(newCount);
         setRecommended(true);
+        const recommend = onRecommend ?? recommendDefault;
 
-        //makeApi call
-        onRecommend(commentId).then(accepted => {
+        recommend(commentId).then(accepted => {
             if (!accepted) {
                 setCount(newCount - 1);
                 setRecommended(alreadyRecommended);

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -21,6 +21,7 @@ type Props = {
     isSignedIn: boolean;
     userMadeComment: boolean;
     onPermalinkClick: (commentId: number) => void;
+    onRecommend?: (commentId: number) => Promise<Boolean>;
 };
 
 const pickStyles = css`
@@ -166,6 +167,7 @@ export const TopPick = ({
     isSignedIn,
     userMadeComment,
     onPermalinkClick,
+    onRecommend
 }: Props) => (
     <div className={pickStyles}>
         <PickBubble>
@@ -235,6 +237,7 @@ export const TopPick = ({
                 alreadyRecommended={false}
                 isSignedIn={isSignedIn}
                 userMadeComment={userMadeComment}
+                onRecommend={onRecommend}
             />
         </PickMeta>
     </div>

--- a/src/components/TopPicks/TopPicks.tsx
+++ b/src/components/TopPicks/TopPicks.tsx
@@ -12,6 +12,7 @@ type Props = {
     comments: CommentType[];
     isSignedIn: boolean;
     onPermalinkClick: (commentId: number) => void;
+    onRecommend?: (commentId: number) => Promise<Boolean>;
 };
 
 const columWrapperStyles = css`
@@ -53,6 +54,7 @@ export const TopPicks = ({
     comments,
     isSignedIn,
     onPermalinkClick,
+    onRecommend
 }: Props) => {
     const leftColComments: CommentType[] = [];
     const rightColComments: CommentType[] = [];
@@ -76,6 +78,7 @@ export const TopPicks = ({
                                 user.userId === comment.userProfile.userId
                             }
                             onPermalinkClick={onPermalinkClick}
+                            onRecommend={onRecommend}
                         />
                     ))}
                 </div>
@@ -91,6 +94,7 @@ export const TopPicks = ({
                                 user.userId === comment.userProfile.userId
                             }
                             onPermalinkClick={onPermalinkClick}
+                            onRecommend={onRecommend}
                         />
                     ))}
                 </div>
@@ -106,6 +110,7 @@ export const TopPicks = ({
                             !!user && user.userId === comment.userProfile.userId
                         }
                         onPermalinkClick={onPermalinkClick}
+                        onRecommend={onRecommend}
                     />
                 ))}
             </div>


### PR DESCRIPTION
## What does this change?
Adds callbacks for:

- [X] recommend
- [x] comment
- [x] reply
- [x] preview

This lets the apps perform these actions with authentication in the native layers.
All are optional and should fallback to the default callbacks, which are the current actions used.

## Why?
discussion authentication on apps uses an identity token (http header) rather than cookies used on the website. We would like to continue using this on apps, so would require callbacks in discussion-rendering to hook in to.
