### PR TITLE
Fix svg button issues

### DIFF
--- a/src/components/AbuseReportForm/AbuseReportForm.tsx
+++ b/src/components/AbuseReportForm/AbuseReportForm.tsx
@@ -304,7 +304,7 @@ export const AbuseReportForm: React.FC<{
                         data-link-name="cancel-report-abuse"
                         hideLabel={true}
                     >
-                        {}
+                        close report abuse modal
                     </Button>
                 </div>
             </form>

--- a/src/components/CommentContainer/CommentContainer.stories.tsx
+++ b/src/components/CommentContainer/CommentContainer.stories.tsx
@@ -75,6 +75,38 @@ const threadComment: CommentType = {
     },
 };
 
+const commentDataWithLongThread: CommentType = {
+    id: 25487686,
+    body:
+        "<p>Beau Jos pizza in Idaho Springs is a great place for mountain pizza pies. Order one with extra thick crust and drizzle it with honey. Y'all can try the Challenge if you fancy, and sketch on your napkins so your art can join their walls. This was 15 years ago, but I hope it's still there! As for music, anything from Boulder's own Big Head Todd &amp; the Monsters - 'Broken Hearted Savior' is a good start, with 'Bittersweet' a good road track. I'm jealous!!!</p>",
+    date: '26 July 2013 4:13pm',
+    isoDateTime: '2013-07-26T15:13:20Z',
+    status: 'visible',
+    webUrl: 'https://discussion.theguardian.com/comment-permalink/25487686',
+    apiUrl:
+        'https://discussion.guardianapis.com/discussion-api/comment/25487686',
+    numRecommends: 0,
+    isHighlighted: false,
+    userProfile: {
+        userId: '2762428',
+        displayName: 'FrankDeFord',
+        webUrl: 'https://profile.theguardian.com/user/id/2762428',
+        apiUrl:
+            'https://discussion.guardianapis.com/discussion-api/profile/2762428',
+        avatar: 'https://avatar.guim.co.uk/user/2762428',
+        secureAvatarUrl: 'https://avatar.guim.co.uk/user/2762428',
+        badge: [],
+    },
+    responses: [],
+    metaData: {
+        commentCount: 6,
+        staffCommenterCount: 1,
+        editorsPickCount: 0,
+        blockedCount: 0,
+        responseCount: 5,
+    },
+};
+
 const aUser = {
     userId: 'abc123',
     displayName: 'Jane Smith',
@@ -92,6 +124,13 @@ const aUser = {
 
 const commentDataThreaded: CommentType = {
     ...commentData,
+    ...{
+        responses: [threadComment],
+    },
+};
+
+const commentDataThreadedWithLongThread: CommentType = {
+    ...commentDataWithLongThread,
     ...{
         responses: [threadComment],
     },
@@ -128,3 +167,19 @@ export const threadedComment = () => (
     />
 );
 threadedComment.story = { name: 'threaded' };
+
+export const threadedCommentWithShowMore = () => (
+    <CommentContainer
+        comment={commentDataThreadedWithLongThread}
+        pillar={'lifestyle'}
+        isClosedForComments={false}
+        shortUrl="randomShortURL"
+        user={aUser}
+        threads="collapsed"
+        setCommentBeingRepliedTo={comment => {}}
+        mutes={[]}
+        toggleMuteStatus={() => {}}
+        onPermalinkClick={() => {}}
+    />
+);
+threadedCommentWithShowMore.story = { name: 'threaded with show more button' };

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -48,6 +48,8 @@ const buttonStyles = (pillar: Pillar) => css`
     border: 1px solid ${neutral[86]};
     svg {
         fill: ${neutral[60]};
+        width: 15px;
+        height: 15px;
     }
 
     :hover {

--- a/src/components/RecommendationCount/RecommendationCount.tsx
+++ b/src/components/RecommendationCount/RecommendationCount.tsx
@@ -35,8 +35,9 @@ const buttonStyles = (recommended: boolean, isSignedIn: boolean) => css`
 `;
 
 const arrowStyles = (recommended: Boolean) => css`
-    margin-left: -4px;
-    margin-bottom: -2px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     svg {
         fill: ${recommended ? neutral[100] : neutral[46]};
         height: 15px;


### PR DESCRIPTION
## What does this change?

Fixes `show more comments` svg button (not displaying on chrome and taking up too big on firfore)

Also fixes alignment issues of the upvote svg by using flexbox rather than margin guessing

Also adds a story to display `show more replies` to catch issue in visual regression

## Before
![Screenshot 2020-10-28 at 14 50 43](https://user-images.githubusercontent.com/8831403/97452771-fdaa8b80-192c-11eb-854b-0e0b468ee2af.png)

## After
![Screenshot 2020-10-28 at 14 50 06](https://user-images.githubusercontent.com/8831403/97452783-013e1280-192d-11eb-86b6-c52c49951dc1.png)

## Why?
SVGs looked broken on Chrome and Firefox

## Link to supporting Trello card
https://trello.com/c/qvm4skV0/2120-discussion-render-svg-issues
