### PR TITLE
Dynamic pagination text

### DIFF
--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -136,3 +136,45 @@ export const LotsOfPages = () => {
     );
 };
 LotsOfPages.story = { name: 'with many pages' };
+
+export const WhenExpanded = () => {
+    const [page, setCurrentPage] = useState(1);
+    return (
+        <Pagination
+            totalPages={4}
+            currentPage={page}
+            setCurrentPage={setCurrentPage}
+            filters={{ ...DEFAULT_FILTERS, threads: 'expanded' }}
+            commentCount={100}
+        />
+    );
+};
+WhenExpanded.story = { name: 'when expanded' };
+
+export const WhenCollapsed = () => {
+    const [page, setCurrentPage] = useState(1);
+    return (
+        <Pagination
+            totalPages={4}
+            currentPage={page}
+            setCurrentPage={setCurrentPage}
+            filters={{ ...DEFAULT_FILTERS, threads: 'collapsed' }}
+            commentCount={100}
+        />
+    );
+};
+WhenCollapsed.story = { name: 'when collapsed' };
+
+export const WhenUnthreaded = () => {
+    const [page, setCurrentPage] = useState(1);
+    return (
+        <Pagination
+            totalPages={4}
+            currentPage={page}
+            setCurrentPage={setCurrentPage}
+            filters={{ ...DEFAULT_FILTERS, threads: 'unthreaded' }}
+            commentCount={100}
+        />
+    );
+};
+WhenUnthreaded.story = { name: 'when unthreaded' };

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -304,7 +304,11 @@ export const Pagination = ({
             </div>
             {commentCount && (
                 <div className={paginationText}>
-                    {`Displaying comments ${startIndex} to ${endIndex} of ${commentCount}`}
+                    {`Displaying ${
+                        filters.threads === 'unthreaded'
+                            ? 'comments'
+                            : 'threads'
+                    } ${startIndex} to ${endIndex} of ${commentCount}`}
                 </div>
             )}
         </div>


### PR DESCRIPTION
## What does this change?
Updates Pagination to change the text it uses based on the reader's filter preferences.

Say 'Displaying threads' when we're counting by threads and say 'Displaying comments' when we're counting by comments

## Why?
It's actually really confusing if we always show the text 'Displaying comments 1 to 203' because actually we're not always doing that. If the reader's filter prefs for threading are set to something other than `unthreaded` then it means we 'count' things based on threads, not the number of actual comments.

This means the total count will change. A discussion with 2 comments that both have 10 replies will have a total of 22 comments but only 2 'threads'. 

![Screenshot 2020-12-21 at 13 05 55](https://user-images.githubusercontent.com/1336821/102780151-5d517000-438d-11eb-8b57-c3239c223cd5.jpg)
