### PR TITLE
Comments loading...

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -55,7 +55,7 @@ describe('App', () => {
 		expect(screen.queryByText('View more comments')).toBeInTheDocument();
 		fireEvent.click(screen.getByText('View more comments'));
 		expect(screen.queryByText('View more comments')).not.toBeInTheDocument();
-		expect(screen.getByText('Display threads')).toBeInTheDocument();
+		expect(screen.getByText('Loading...')).toBeInTheDocument();
 	});
 
 	it('should not render the comment form if user is logged out', async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -463,6 +463,7 @@ export const App = ({
 							icon={<SvgPlus />}
 							iconSide="left"
 							linkName="more-comments"
+							size="small"
 						>
 							{rendering ? 'Loading...' : 'View more comments'}
 						</PillarButton>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -223,6 +223,7 @@ export const App = ({
     onComment,
     onReply,
     onPreview
+    onPreview,
 }: Props) => {
     const [filters, setFilters] = useState<FilterOptions>(
         initialiseFilters({
@@ -233,6 +234,7 @@ export const App = ({
         }),
     );
     const [isExpanded, setIsExpanded] = useState<boolean>(expanded);
+    const [rendering, setRendering] = useState<boolean>(false);
     const [loading, setLoading] = useState<boolean>(true);
     const [totalPages, setTotalPages] = useState<number>(0);
     const [page, setPage] = useState<number>(initialPage || 1);
@@ -330,8 +332,17 @@ export const App = ({
     };
 
     const expandView = () => {
-        setIsExpanded(true);
+        setRendering(true);
         onHeightChange();
+        // We use setTimeout here to push the isExpanded state change to the end of the
+        // stack. This has the effect of allowing the page to render with the new `rendering`
+        // state so that the button text updates. Only after that render is complete do we
+        // set isExpanded and display the remaining comments.
+        // Note. While its technically true that this slows down new comments appearing, the
+        // difference is negligable and worth it for the improved reader experience
+        setTimeout(() => {
+            setIsExpanded(true);
+        });
     };
 
     const toggleMuteStatus = (userId: string) => {
@@ -460,7 +471,7 @@ export const App = ({
                             iconSide="left"
                             linkName="more-comments"
                         >
-                            View more comments
+                            {rendering ? 'Loading...' : 'View more comments'}
                         </PillarButton>
                     </div>
                 )}

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -25,7 +25,7 @@ export const Default = () => {
 };
 Default.story = { name: 'default' };
 
-export const NoPages = () => {
+export const TwoPages = () => {
 	const [page, setCurrentPage] = useState(1);
 	return (
 		<Pagination
@@ -37,7 +37,7 @@ export const NoPages = () => {
 		/>
 	);
 };
-NoPages.story = { name: 'with two pages' };
+TwoPages.story = { name: 'with two pages' };
 
 export const ThreePages = () => {
 	const [page, setCurrentPage] = useState(1);


### PR DESCRIPTION
## What?
Shows a loading message after the `View more comments` button is pressed

### Before
![show more without loading](https://user-images.githubusercontent.com/1336821/103543029-bfce6400-4e95-11eb-8833-295999fa1a81.gif)

### After
![show more with loading](https://user-images.githubusercontent.com/1336821/103543039-c3fa8180-4e95-11eb-89e9-996b2d5b63ac.gif)



## Why?
Because rendering large discussions can take a while and this message lets the reader know that we received their request and something is happening