### PR TITLE
Typescript v4.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "@guardian/src-text-input": "^2.4.0",
     "emotion": "^10.0.27",
     "react": "^16.13.1",
-    "react-dom": "^16.12.0"
+    "react-dom": "^16.12.0",
+    "typescript": "^4.1.3"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",
@@ -82,7 +83,7 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-visualizer": "^4.0.4",
     "storybook-chromatic": "^4.0.2",
-    "typescript": "^3.7.5"
+    "typescript": "^4.1.3"
   },
   "scripts": {
     "start": "react-app-rewired start",

--- a/src/components/Row/Row.tsx
+++ b/src/components/Row/Row.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 
-type Props = { children: JSX.Element | JSX.Element[] };
+type Props = { children: React.ReactNode };
 
 export const Row = ({ children }: Props) => (
 	<div

--- a/yarn.lock
+++ b/yarn.lock
@@ -17134,10 +17134,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.5:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 uglify-js@3.4.x:
   version "3.4.10"


### PR DESCRIPTION
## What does this change?
Upgrades and sets typescript version to 4.1.3 and adds this as a peer dependency

## Why?
Because we want to make sure everyone using this lib is on the same version