### PR TITLE
Fix bug with long usernames

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,12 @@ const footerStyles = css`
 	justify-content: flex-end;
 `;
 
+const commentColumnWrapperStyles = css`
+	display: flex;
+	flex-direction: column;
+	max-width: 100%;
+`;
+
 const commentContainerStyles = css`
 	display: flex;
 	flex-direction: column;
@@ -460,7 +466,7 @@ export const App = ({
 	}
 
 	return (
-		<Column>
+		<div className={commentColumnWrapperStyles}>
 			<div data-component="discussion">
 				{user && !isClosedForComments && (
 					<CommentForm
@@ -553,6 +559,6 @@ export const App = ({
 					/>
 				)}
 			</div>
-		</Column>
+		</div>
 	);
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,6 @@ import { CommentForm } from './components/CommentForm/CommentForm';
 import { Filters } from './components/Filters/Filters';
 import { Pagination } from './components/Pagination/Pagination';
 import { LoadingComments } from './components/LoadingComments/LoadingComments';
-import { Column } from './components/Column/Column';
 import { PillarButton } from './components/PillarButton/PillarButton';
 
 type Props = {
@@ -466,36 +465,75 @@ export const App = ({
 	}
 
 	return (
-		<div className={commentColumnWrapperStyles}>
-			<div data-component="discussion">
-				{user && !isClosedForComments && (
-					<CommentForm
-						pillar={pillar}
-						shortUrl={shortUrl}
-						onAddComment={onAddComment}
-						user={user}
-						onComment={onComment}
-						onReply={onReply}
-						onPreview={onPreview}
-					/>
-				)}
-				{!!picks.length && (
-					<TopPicks
-						pillar={pillar}
-						comments={picks}
-						isSignedIn={!!user}
-						onPermalinkClick={onPermalinkClick}
-						onRecommend={onRecommend}
-					/>
-				)}
-				<Filters
+		<div data-component="discussion" className={commentColumnWrapperStyles}>
+			{user && !isClosedForComments && (
+				<CommentForm
 					pillar={pillar}
-					filters={filters}
-					onFilterChange={onFilterChange}
-					totalPages={totalPages}
-					commentCount={commentCount}
+					shortUrl={shortUrl}
+					onAddComment={onAddComment}
+					user={user}
+					onComment={onComment}
+					onReply={onReply}
+					onPreview={onPreview}
 				/>
-				{showPagination && (
+			)}
+			{!!picks.length && (
+				<TopPicks
+					pillar={pillar}
+					comments={picks}
+					isSignedIn={!!user}
+					onPermalinkClick={onPermalinkClick}
+					onRecommend={onRecommend}
+				/>
+			)}
+			<Filters
+				pillar={pillar}
+				filters={filters}
+				onFilterChange={onFilterChange}
+				totalPages={totalPages}
+				commentCount={commentCount}
+			/>
+			{showPagination && (
+				<Pagination
+					totalPages={totalPages}
+					currentPage={page}
+					setCurrentPage={(newPage: number) => {
+						onPageChange(newPage);
+					}}
+					commentCount={commentCount}
+					filters={filters}
+				/>
+			)}
+			{loading ? (
+				<LoadingComments />
+			) : !comments.length ? (
+				<NoComments />
+			) : (
+				<ul className={commentContainerStyles}>
+					{comments.map((comment) => (
+						<li key={comment.id}>
+							<CommentContainer
+								comment={comment}
+								pillar={pillar}
+								isClosedForComments={isClosedForComments}
+								shortUrl={shortUrl}
+								user={user}
+								threads={filters.threads}
+								commentBeingRepliedTo={commentBeingRepliedTo}
+								setCommentBeingRepliedTo={setCommentBeingRepliedTo}
+								commentToScrollTo={commentToScrollTo}
+								mutes={mutes}
+								toggleMuteStatus={toggleMuteStatus}
+								onPermalinkClick={onPermalinkClick}
+								onRecommend={onRecommend}
+								onReply={onReply}
+							/>
+						</li>
+					))}
+				</ul>
+			)}
+			{showPagination && (
+				<footer className={footerStyles}>
 					<Pagination
 						totalPages={totalPages}
 						currentPage={page}
@@ -505,60 +543,19 @@ export const App = ({
 						commentCount={commentCount}
 						filters={filters}
 					/>
-				)}
-				{loading ? (
-					<LoadingComments />
-				) : !comments.length ? (
-					<NoComments />
-				) : (
-					<ul className={commentContainerStyles}>
-						{comments.map((comment) => (
-							<li key={comment.id}>
-								<CommentContainer
-									comment={comment}
-									pillar={pillar}
-									isClosedForComments={isClosedForComments}
-									shortUrl={shortUrl}
-									user={user}
-									threads={filters.threads}
-									commentBeingRepliedTo={commentBeingRepliedTo}
-									setCommentBeingRepliedTo={setCommentBeingRepliedTo}
-									commentToScrollTo={commentToScrollTo}
-									mutes={mutes}
-									toggleMuteStatus={toggleMuteStatus}
-									onPermalinkClick={onPermalinkClick}
-									onRecommend={onRecommend}
-									onReply={onReply}
-								/>
-							</li>
-						))}
-					</ul>
-				)}
-				{showPagination && (
-					<footer className={footerStyles}>
-						<Pagination
-							totalPages={totalPages}
-							currentPage={page}
-							setCurrentPage={(newPage: number) => {
-								onPageChange(newPage);
-							}}
-							commentCount={commentCount}
-							filters={filters}
-						/>
-					</footer>
-				)}
-				{user && !isClosedForComments && (
-					<CommentForm
-						pillar={pillar}
-						shortUrl={shortUrl}
-						onAddComment={onAddComment}
-						user={user}
-						onComment={onComment}
-						onReply={onReply}
-						onPreview={onPreview}
-					/>
-				)}
-			</div>
+				</footer>
+			)}
+			{user && !isClosedForComments && (
+				<CommentForm
+					pillar={pillar}
+					shortUrl={shortUrl}
+					onAddComment={onAddComment}
+					user={user}
+					onComment={onComment}
+					onReply={onReply}
+					onPreview={onPreview}
+				/>
+			)}
 		</div>
 	);
 };

--- a/src/components/CommentContainer/CommentContainer.stories.tsx
+++ b/src/components/CommentContainer/CommentContainer.stories.tsx
@@ -74,6 +74,42 @@ const threadComment: CommentType = {
 	},
 };
 
+const threadCommentWithLongUsernames: CommentType = {
+	id: 25488498,
+	body: "<p>It's still there FrankDeFord - and thanks, I will pass that on</p>",
+	date: '26 July 2013 4:35pm',
+	isoDateTime: '2013-07-26T15:13:20Z',
+	status: 'visible',
+	webUrl: 'https://discussion.theguardian.com/comment-permalink/25488498',
+	apiUrl: 'https://discussion.guardianapis.com/discussion-api/comment/25488498',
+	numRecommends: 0,
+	isHighlighted: false,
+	responseTo: {
+		displayName: 'FrankDeFord',
+		commentApiUrl:
+			'https://discussion.guardianapis.com/discussion-api/comment/25487686',
+		isoDateTime: '2013-07-26T15:13:20Z',
+		date: '26 July 2013 4:13pm',
+		commentId: '25487686',
+		commentWebUrl:
+			'https://discussion.theguardian.com/comment-permalink/25487686',
+	},
+	userProfile: {
+		userId: '3150446',
+		displayName: 'ThisIsAVeryLongUserNameTooLongInFact',
+		webUrl: 'https://profile.theguardian.com/user/id/3150446',
+		apiUrl:
+			'https://discussion.guardianapis.com/discussion-api/profile/3150446',
+		avatar: 'https://avatar.guim.co.uk/user/3150446',
+		secureAvatarUrl: 'https://avatar.guim.co.uk/user/3150446',
+		badge: [
+			{
+				name: 'Staff',
+			},
+		],
+	},
+};
+
 const commentDataWithLongThread: CommentType = {
 	id: 25487686,
 	body:
@@ -134,6 +170,13 @@ const commentDataThreadedWithLongThread: CommentType = {
 	},
 };
 
+const commentDataThreadedWithLongUserNames: CommentType = {
+	...commentData,
+	...{
+		responses: [threadCommentWithLongUsernames],
+	},
+};
+
 export const defaultStory = () => (
 	<CommentContainer
 		comment={commentData}
@@ -181,3 +224,19 @@ export const threadedCommentWithShowMore = () => (
 	/>
 );
 threadedCommentWithShowMore.story = { name: 'threaded with show more button' };
+
+export const threadedCommentWithLongUsernames = () => (
+	<CommentContainer
+		comment={commentDataThreadedWithLongUserNames}
+		pillar={Pillar.Lifestyle}
+		isClosedForComments={false}
+		shortUrl="randomShortURL"
+		user={aUser}
+		threads="collapsed"
+		setCommentBeingRepliedTo={(comment) => {}}
+		mutes={[]}
+		toggleMuteStatus={() => {}}
+		onPermalinkClick={() => {}}
+	/>
+);
+threadedComment.story = { name: 'threaded' };

--- a/src/components/CommentContainer/CommentContainer.stories.tsx
+++ b/src/components/CommentContainer/CommentContainer.stories.tsx
@@ -239,4 +239,28 @@ export const threadedCommentWithLongUsernames = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
-threadedComment.story = { name: 'threaded' };
+threadedCommentWithLongUsernames.story = {
+	name: 'threaded with long usernames',
+};
+
+export const threadedCommentWithLongUsernamesMobile = () => (
+	<CommentContainer
+		comment={commentDataThreadedWithLongUserNames}
+		pillar={Pillar.Lifestyle}
+		isClosedForComments={false}
+		shortUrl="randomShortURL"
+		user={aUser}
+		threads="collapsed"
+		setCommentBeingRepliedTo={(comment) => {}}
+		mutes={[]}
+		toggleMuteStatus={() => {}}
+		onPermalinkClick={() => {}}
+	/>
+);
+threadedCommentWithLongUsernamesMobile.story = {
+	name: 'threaded with long usernames on mobile display',
+	parameters: {
+		viewport: { defaultViewport: 'mobileMedium' },
+		chromatic: { viewports: [375] },
+	},
+};


### PR DESCRIPTION
## What does this change?
Long usernames were causing the width to stretch in mobile view on DCR due to the width not being set on a container. This moves from using a `Column` for comments, to a div with the same flex styling but with a `max-width` of `100%`.

I've also added a story to explicitly check for threaded replies with long usernames, though in this case that wasn't causing an issue as it was a combination of factors that only occurred when implementing in DCR.

Also requires https://github.com/guardian/dotcom-rendering/pull/2342 to be merged.

## Why?
Poor UX when expanding comments. Long usernames caused horizontal scroll on mobile views.

## Link to supporting Trello card
https://trello.com/c/3MZnq43Z/2281-comments-not-properly-fitting-on-the-screen-on-iphones