### PR TITLE
Disable focus manager on click in storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,4 @@
-import React from "react"
-import { addDecorator } from "@storybook/react"
-import { useEffect } from "@storybook/addons"
+import React, { useEffect } from "react"
 import { FocusStyleManager } from "@guardian/src-foundations/utils"
 import MockDate from 'mockdate';
 import { mockFetchCalls } from '../src/lib/mockFetchCalls';
@@ -78,4 +76,4 @@ const FocusManagerDecorator = storyFn => {
 	return <div>{storyFn()}</div>
 }
 
-addDecorator(FocusManagerDecorator)
+export const decorators = [FocusManagerDecorator];

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,7 @@
+import React from "react"
+import { addDecorator } from "@storybook/react"
+import { useEffect } from "@storybook/addons"
+import { FocusStyleManager } from "@guardian/src-foundations/utils"
 import MockDate from 'mockdate';
 import { mockFetchCalls } from '../src/lib/mockFetchCalls';
 
@@ -65,3 +69,13 @@ export const parameters = {
   },
   actions: { argTypesRegex: "^on[A-Z].*" },
 }
+
+const FocusManagerDecorator = storyFn => {
+	useEffect(() => {
+		FocusStyleManager.onlyShowFocusOnTabs()
+	})
+
+	return <div>{storyFn()}</div>
+}
+
+addDecorator(FocusManagerDecorator)


### PR DESCRIPTION
## What does this change?

Disables Source's [Focus Manager](https://theguardian.design/2a1e5182b/p/6691bb-accessibility/t/32e9fb) unless a tab keypress is detected.

## Why?

By default, Source components have a blue focus "halo" which is visible on keyboard focus, and also on click interaction. It is undesirable to show this halo on click. The Focus Manager must be disabled manually.

**Before**

![2021-01-07 21 56 46](https://user-images.githubusercontent.com/5931528/103950743-57051700-5135-11eb-98ac-79609ce9d9d2.gif)

**After**

![2021-01-07 22 02 43](https://user-images.githubusercontent.com/5931528/103950759-5c626180-5135-11eb-8ca8-6e3126b1b94b.gif)


## Link to supporting Trello card
