### PR TITLE
Remove deprecated IDAPI user model fields

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -81,7 +81,6 @@ type UserNameUser = {
 	};
 	statusFields: {
 		userEmailValidated: boolean;
-		allowThirdPartyProfiling: boolean;
 	};
 	privateFields: {
 		brazeUuid: string;


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
- Remove deprecated IDAPI user model fields - these fields are now represented by items in the consents array on the user model.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Avoid confusion of unused deprecated fields.
