### PR TITLE
Update settings to add titlebar colour and fix extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,7 @@
         "esbenp.prettier-vscode",
         "wix.vscode-import-cost",
         "orta.vscode-jest",
-        "shinnn.stylelint",
+        "stylelint.vscode-stylelint",
         "editorconfig.editorconfig",
         "dbaeumer.vscode-eslint",
         "stkb.rewrap",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,9 @@
   "eslint.enable": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
-  }
+  },
+  "workbench.colorCustomizations": {
+        "titleBar.activeBackground": "#DC267F",
+        "titleBar.activeForeground": "#000000"
+    }
 }


### PR DESCRIPTION
## What does this change?
Changes title bar colour to aid in between project distinctions. colour palette taken from https://davidmathlogic.com/colorblind/#%23648FFF-%23785EF0-%23DC267F-%23FE6100-%23FFB000
![image](https://user-images.githubusercontent.com/9122944/106138631-4825e900-6164-11eb-8d8e-e8e84aec87b9.png)

## Why?
Because I get confused easily

## Link to supporting Trello card
