### PR TITLE
Add config-name to Release Drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,5 +12,7 @@ jobs:
         steps:
             # Drafts your next Release notes as Pull Requests are merged into "master"
             - uses: release-drafter/release-drafter@v5
+            with:
+                config-name: "./github/release_drafter.yml"
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this change?

Adds `config-name: "./github/release_drafter.yml"` to the release drafter, so it should work.
