### PR TITLE
Migrate to @emotion/core

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -5,13 +5,23 @@ module.exports = {
   ],
   webpackFinal: async config => {
       config.module.rules.push({
-          test: /\.(ts|tsx)$/,
-          use: [
-              {
-                  loader: require.resolve('ts-loader'),
-              },
-          ],
-      });
+        test: /\.(ts|tsx)$/,
+        loader: require.resolve('babel-loader'),
+        options: {
+            presets: [
+                '@babel/preset-typescript',
+                '@emotion/babel-preset-css-prop',
+                [
+                    '@babel/preset-env',
+                    {
+                        targets: {
+                            esmodules: true,
+                        },
+                    },
+                ],
+            ],
+        },
+    });
 
       return config;
   },

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -25,7 +25,7 @@ const guardianViewports = {
   phablet: {
       name: 'phablet',
       styles: {
-          width: '660px',
+          width: '660px', 
           height: '800px',
       },
   },

--- a/babel.config.js
+++ b/babel.config.js
@@ -15,4 +15,9 @@ module.exports = {
         "@babel/preset-react",
         '@emotion/babel-preset-css-prop'
     ],
+    env: {
+        test: {	
+            plugins: ['@babel/plugin-transform-runtime'],	
+        },	
+    },
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,12 +2,7 @@ module.exports = {
     plugins: [
         'const-enum',
         '@babel/transform-typescript',
-        [
-            'babel-plugin-emotion',
-            {
-                'cssPropOptimization': true
-            }
-        ]
+        'babel-plugin-emotion',
     ],
     presets: [
         '@babel/preset-env',

--- a/babel.config.js
+++ b/babel.config.js
@@ -16,8 +16,8 @@ module.exports = {
         '@emotion/babel-preset-css-prop'
     ],
     env: {
-        test: {	
-            plugins: ['@babel/plugin-transform-runtime'],	
-        },	
+        test: {
+            plugins: ['@babel/plugin-transform-runtime'],
+        },
     },
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,14 +1,18 @@
 module.exports = {
-    plugins: ["const-enum", "@babel/transform-typescript"],
+    plugins: [
+        "const-enum",
+        "@babel/transform-typescript",
+        [
+            "babel-plugin-emotion",
+            {
+                "cssPropOptimization": true
+            }
+        ]
+    ],
     presets: [
         '@babel/preset-env',
         '@babel/preset-typescript',
-        '@babel/preset-react',
-        '@emotion/babel-preset-css-prop',
+        "@babel/preset-react",
+        '@emotion/babel-preset-css-prop'
     ],
-    env: {
-        test: {
-            plugins: ['@babel/plugin-transform-runtime'],
-        },
-    },
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,18 +1,18 @@
 module.exports = {
     plugins: [
-        "const-enum",
-        "@babel/transform-typescript",
+        'const-enum',
+        '@babel/transform-typescript',
         [
-            "babel-plugin-emotion",
+            'babel-plugin-emotion',
             {
-                "cssPropOptimization": true
+                'cssPropOptimization': true
             }
         ]
     ],
     presets: [
         '@babel/preset-env',
         '@babel/preset-typescript',
-        "@babel/preset-react",
+        '@babel/preset-react',
         '@emotion/babel-preset-css-prop'
     ],
     env: {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "timeago.js": "^4.0.2"
   },
   "peerDependencies": {
-    "@emotion/core": "^10.0.28",
+    "@emotion/core": "10.0.35",
     "@guardian/src-button": "2.7.1",
     "@guardian/src-foundations": "2.7.1",
     "@guardian/src-icons": "2.7.1",
@@ -46,7 +46,9 @@
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.12.7",
-    "@emotion/babel-preset-css-prop": "^10.0.14",
+    "@emotion/babel-preset-css-prop": "10.0.23",
+    "@emotion/core": "10.0.35",
+    "@emotion/eslint-plugin": "^11.0.0",
     "@guardian/prettier": "^0.4.2",
     "@guardian/src-button": "2.7.1",
     "@guardian/src-foundations": "2.7.1",
@@ -108,9 +110,13 @@
   "eslintConfig": {
     "extends": "react-app",
     "plugins": [
+      "@emotion",
       "react-hooks"
     ],
     "rules": {
+      "@emotion/no-vanilla": "error",
+      "@emotion/import-from-emotion": "error",
+      "@emotion/styled-import": "error",
       "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": "warn"
     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@guardian/src-link": "2.7.1",
     "@guardian/src-text-input": "2.7.1",
     "@guardian/types": "^3.0.0",
-    "emotion": "^10.0.27",
     "react": "^16.13.1",
     "react-dom": "^16.12.0",
     "typescript": "^4.1.3"
@@ -69,7 +68,6 @@
     "@types/react-dom": "^16.9.5",
     "babel-loader": "^8.2.2",
     "babel-plugin-const-enum": "^1.0.1",
-    "emotion": "^10.0.27",
     "eslint-plugin-react-hooks": "^4.0.4",
     "fetch-mock": "^9.3.1",
     "husky": "^4.2.3",

--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+/** @jsxRuntime classic */
+/** @jsx jsx */
 import { App } from './App';
-import { css } from '@emotion/core';
+import { css, jsx } from '@emotion/core';
 
 import { Pillar } from '@guardian/types';
 

--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { App } from './App';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 import { Pillar } from '@guardian/types';
 
@@ -25,7 +25,7 @@ const aUser: UserProfile = {
 
 export const LoggedOutHiddenPicks = () => (
 	<div
-		className={css`
+		css={css`
 			width: 100%;
 			max-width: 620px;
 		`}
@@ -51,7 +51,7 @@ LoggedOutHiddenPicks.story = {
 
 export const InitialPage = () => (
 	<div
-		className={css`
+		css={css`
 			width: 100%;
 			max-width: 620px;
 		`}
@@ -76,7 +76,7 @@ InitialPage.story = { name: 'with initial page set to 3' };
 
 export const Overrides = () => (
 	<div
-		className={css`
+		css={css`
 			width: 100%;
 			max-width: 620px;
 		`}
@@ -103,7 +103,7 @@ Overrides.story = { name: 'with page size overridden to 50' };
 
 export const LoggedInHiddenNoPicks = () => (
 	<div
-		className={css`
+		css={css`
 			width: 100%;
 			max-width: 620px;
 		`}
@@ -130,7 +130,7 @@ LoggedInHiddenNoPicks.story = {
 
 export const LoggedOutHiddenNoPicks = () => (
 	<div
-		className={css`
+		css={css`
 			width: 100%;
 			max-width: 620px;
 		`}
@@ -156,7 +156,7 @@ LoggedOutHiddenNoPicks.story = {
 
 export const Closed = () => (
 	<div
-		className={css`
+		css={css`
 			width: 100%;
 			max-width: 620px;
 		`}
@@ -181,7 +181,7 @@ Closed.story = { name: 'Logged in but closed for comments' };
 
 export const NoComments = () => (
 	<div
-		className={css`
+		css={css`
 			width: 100%;
 			max-width: 620px;
 		`}
@@ -207,7 +207,7 @@ NoComments.story = {
 
 export const LegacyDiscussion = () => (
 	<div
-		className={css`
+		css={css`
 			width: 100%;
 			max-width: 620px;
 		`}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
 import React, { useState, useEffect } from 'react';
-import { css } from 'emotion';
+import { css, jsx } from '@emotion/core';
 
 import { neutral } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
@@ -83,7 +85,7 @@ const DEFAULT_FILTERS: FilterOptions = {
 
 const NoComments = () => (
 	<div
-		className={css`
+		css={css`
 			color: ${neutral[46]};
 			${textSans.small()}
 			padding-top: ${space[5]}px;
@@ -373,7 +375,7 @@ export const App = ({
 
 	if (!isExpanded) {
 		return (
-			<div className={commentContainerStyles} data-component="discussion">
+			<div css={commentContainerStyles} data-component="discussion">
 				{user && !isClosedForComments && (
 					<CommentForm
 						pillar={pillar}
@@ -386,7 +388,7 @@ export const App = ({
 					/>
 				)}
 				{picks && picks.length ? (
-					<div className={picksWrapper}>
+					<div css={picksWrapper}>
 						{!!picks.length && (
 							<TopPicks
 								pillar={pillar}
@@ -398,7 +400,7 @@ export const App = ({
 						)}
 					</div>
 				) : (
-					<>
+					<React.Fragment>
 						<Filters
 							pillar={pillar}
 							filters={filters}
@@ -422,7 +424,7 @@ export const App = ({
 						) : !comments.length ? (
 							<NoComments />
 						) : (
-							<ul className={commentContainerStyles}>
+							<ul css={commentContainerStyles}>
 								{comments.slice(0, 2).map((comment) => (
 									<li key={comment.id}>
 										<CommentContainer
@@ -443,11 +445,11 @@ export const App = ({
 								))}
 							</ul>
 						)}
-					</>
+					</React.Fragment>
 				)}
 				{commentCount > 2 && (
 					<div
-						className={css`
+						css={css`
 							width: 250px;
 						`}
 					>
@@ -468,7 +470,7 @@ export const App = ({
 	}
 
 	return (
-		<div data-component="discussion" className={commentColumnWrapperStyles}>
+		<div data-component="discussion" css={commentColumnWrapperStyles}>
 			{user && !isClosedForComments && (
 				<CommentForm
 					pillar={pillar}
@@ -512,7 +514,7 @@ export const App = ({
 			) : !comments.length ? (
 				<NoComments />
 			) : (
-				<ul className={commentContainerStyles}>
+				<ul css={commentContainerStyles}>
 					{comments.map((comment) => (
 						<li key={comment.id}>
 							<CommentContainer
@@ -536,7 +538,7 @@ export const App = ({
 				</ul>
 			)}
 			{showPagination && (
-				<footer className={footerStyles}>
+				<footer css={footerStyles}>
 					<Pagination
 						totalPages={totalPages}
 						currentPage={page}

--- a/src/components/AbuseReportForm/AbuseReportForm.stories.tsx
+++ b/src/components/AbuseReportForm/AbuseReportForm.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 import { Pillar } from '@guardian/types';
 
@@ -16,7 +16,7 @@ const wrapperStyles = css`
 `;
 
 export const Dialog = () => (
-	<div className={wrapperStyles}>
+	<div css={wrapperStyles}>
 		<AbuseReportForm
 			toggleSetShowForm={() => {}}
 			pillar={Pillar.Sport}

--- a/src/components/AbuseReportForm/AbuseReportForm.tsx
+++ b/src/components/AbuseReportForm/AbuseReportForm.tsx
@@ -1,5 +1,7 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { css, cx } from 'emotion';
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { useState, useEffect, useRef } from 'react';
+import { css, jsx } from '@emotion/core';
 
 import { palette } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
@@ -167,9 +169,9 @@ export const AbuseReportForm: React.FC<{
 	const labelStylesClass = labelStyles(pillar);
 	return (
 		<div aria-modal="true" ref={modalRef}>
-			<form className={formWrapper} onSubmit={onSubmit}>
-				<div className={inputWrapper}>
-					<label className={labelStylesClass} htmlFor="category">
+			<form css={formWrapper} onSubmit={onSubmit}>
+				<div css={inputWrapper}>
+					<label css={labelStylesClass} htmlFor="category">
 						Category
 					</label>
 					<select
@@ -197,12 +199,12 @@ export const AbuseReportForm: React.FC<{
 						<option value="9">Other</option>
 					</select>
 					{errors.categoryId && (
-						<span className={errorMessageStyles}>{errors.categoryId}</span>
+						<span css={errorMessageStyles}>{errors.categoryId}</span>
 					)}
 				</div>
 
-				<div className={inputWrapper}>
-					<label className={labelStylesClass} htmlFor="reason">
+				<div css={inputWrapper}>
+					<label css={labelStylesClass} htmlFor="reason">
 						Reason (optional)
 					</label>
 					<textarea
@@ -217,12 +219,12 @@ export const AbuseReportForm: React.FC<{
 						value={formVariables.reason}
 					></textarea>
 					{errors.reason && (
-						<span className={errorMessageStyles}>{errors.reason}</span>
+						<span css={errorMessageStyles}>{errors.reason}</span>
 					)}
 				</div>
 
-				<div className={inputWrapper}>
-					<label className={labelStylesClass} htmlFor="email">
+				<div css={inputWrapper}>
+					<label css={labelStylesClass} htmlFor="email">
 						Email (optional)
 					</label>
 					<input
@@ -237,9 +239,7 @@ export const AbuseReportForm: React.FC<{
 						}
 						value={formVariables.email}
 					></input>
-					{errors.email && (
-						<span className={errorMessageStyles}>{errors.email}</span>
-					)}
+					{errors.email && <span css={errorMessageStyles}>{errors.email}</span>}
 				</div>
 
 				<div>
@@ -249,12 +249,12 @@ export const AbuseReportForm: React.FC<{
 
 					{errors.response && (
 						<span
-							className={cx(
+							css={[
 								errorMessageStyles,
 								css`
 									margin-left: 1em;
 								`,
-							)}
+							]}
 						>
 							{errors.response}
 						</span>
@@ -262,7 +262,7 @@ export const AbuseReportForm: React.FC<{
 
 					{successMessage && (
 						<span
-							className={css`
+							css={css`
 								color: green;
 								margin-left: 1em;
 							`}
@@ -272,7 +272,7 @@ export const AbuseReportForm: React.FC<{
 					)}
 				</div>
 				<div
-					className={css`
+					css={css`
 						position: absolute;
 						right: ${space[3]}px;
 						top: ${space[3]}px;

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -5,7 +5,7 @@ export default { component: Avatar, title: 'Avatar' };
 
 export const Sizes = () => {
 	return (
-		<>
+		<React.Fragment>
 			<Avatar
 				imageUrl="https://avatar.guim.co.uk/no-user-image.gif"
 				size="small"
@@ -21,16 +21,16 @@ export const Sizes = () => {
 				size="large"
 				displayName=""
 			/>
-		</>
+		</React.Fragment>
 	);
 };
 Sizes.story = { name: 'different sizes' };
 
 export const NoImage = () => {
 	return (
-		<>
+		<React.Fragment>
 			<Avatar size="medium" displayName="" />
-		</>
+		</React.Fragment>
 	);
 };
 NoImage.story = { name: 'with no image url given' };

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 type Props = {
 	imageUrl?: string;
@@ -20,17 +20,11 @@ export const Avatar = ({
 }: Props) => {
 	switch (size) {
 		case 'small':
-			return (
-				<img src={imageUrl} alt={displayName} className={imageStyles(36)} />
-			);
+			return <img src={imageUrl} alt={displayName} css={imageStyles(36)} />;
 		case 'large':
-			return (
-				<img src={imageUrl} alt={displayName} className={imageStyles(60)} />
-			);
+			return <img src={imageUrl} alt={displayName} css={imageStyles(60)} />;
 		case 'medium':
 		default:
-			return (
-				<img src={imageUrl} alt={displayName} className={imageStyles(48)} />
-			);
+			return <img src={imageUrl} alt={displayName} css={imageStyles(48)} />;
 	}
 };

--- a/src/components/Badges/Badges.tsx
+++ b/src/components/Badges/Badges.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { css, cx } from 'emotion';
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
 
 import { space, neutral, brand } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
@@ -35,12 +36,12 @@ const guardianPickLabel = css`
 `;
 
 export const GuardianStaff = () => (
-	<div className={staffBadge}>
+	<div css={staffBadge}>
 		<svg
 			width="36"
 			height="36"
 			viewBox="0 0 36 36"
-			className={cx(iconStyles, staffIcon)}
+			css={[iconStyles, staffIcon]}
 		>
 			<path d="M18 0a18 18 0 1 0 0 36 18 18 0 0 0 0-36"></path>
 			<path
@@ -48,19 +49,19 @@ export const GuardianStaff = () => (
 				d="M21.2 4.4c2.3.4 5.3 2 6.3 3.1v5.2H27L21.2 5v-.6zm-2.2.4c-4 0-6.3 5.6-6.3 13.2 0 7.7 2.2 13.3 6.3 13.3v.6c-6 .4-14.4-4.2-14-13.8A13.3 13.3 0 0 1 19 4v.7zm10.4 14.4l-1.9.9v8.6c-1 1-3.8 2.6-6.3 3.1V19.9l-2.2-.7v-.6h10.4v.6z"
 			></path>
 		</svg>
-		<p className={cx(labelText, staffLabel)}>Staff</p>
+		<p css={[labelText, staffLabel]}>Staff</p>
 	</div>
 );
 
 export const GuardianPick = () => (
-	<div className={staffBadge}>
-		<svg width="36" height="36" viewBox="0 0 36 36" className={iconStyles}>
+	<div css={staffBadge}>
+		<svg width="36" height="36" viewBox="0 0 36 36" css={iconStyles}>
 			<path d="M18 0a18 18 0 1 0 0 36 18 18 0 0 0 0-36"></path>
 			<path
 				fill={neutral[100]}
 				d="M21.2 4.4c2.3.4 5.3 2 6.3 3.1v5.2H27L21.2 5v-.6zm-2.2.4c-4 0-6.3 5.6-6.3 13.2 0 7.7 2.2 13.3 6.3 13.3v.6c-6 .4-14.4-4.2-14-13.8A13.3 13.3 0 0 1 19 4v.7zm10.4 14.4l-1.9.9v8.6c-1 1-3.8 2.6-6.3 3.1V19.9l-2.2-.7v-.6h10.4v.6z"
 			></path>
 		</svg>
-		<p className={cx(labelText, guardianPickLabel)}>Guardian Pick</p>
+		<p css={[labelText, guardianPickLabel]}>Guardian Pick</p>
 	</div>
 );

--- a/src/components/ButtonLink/ButtonLink.stories.tsx
+++ b/src/components/ButtonLink/ButtonLink.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 import { space } from '@guardian/src-foundations';
 import { SvgCheckmark } from '@guardian/src-icons';
@@ -12,7 +12,7 @@ import { ButtonLink } from './ButtonLink';
 
 const Space = ({ amount }: { amount: 1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24 }) => (
 	<div
-		className={css`
+		css={css`
 			width: ${space[amount]}px;
 		`}
 	/>
@@ -104,7 +104,7 @@ Grey.story = { name: 'a button with no pillar' };
 
 export const Background = () => (
 	<div
-		className={css`
+		css={css`
 			background-color: lightgrey;
 			padding: 20px;
 		`}

--- a/src/components/ButtonLink/ButtonLink.tsx
+++ b/src/components/ButtonLink/ButtonLink.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { css, cx } from 'emotion';
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
 
 import { palette, neutral } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
@@ -52,7 +53,7 @@ export const ButtonLink = ({
 	children,
 	linkName,
 }: Props) => (
-	<div className={cx(buttonOverrides(size, pillar))}>
+	<div css={[buttonOverrides(size, pillar)]}>
 		<Button
 			priority="subdued"
 			size={size}

--- a/src/components/Column/Column.tsx
+++ b/src/components/Column/Column.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 type Props = { children: JSX.Element | JSX.Element[] };
 
 export const Column = ({ children }: Props) => (
 	<div
-		className={css`
+		css={css`
 			display: flex;
 			flex-direction: column;
 		`}

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -1,5 +1,7 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
 import React, { useState } from 'react';
-import { css, cx } from 'emotion';
+import { css, jsx } from '@emotion/core';
 
 import { space, palette, remSpace } from '@guardian/src-foundations';
 import { from, until } from '@guardian/src-foundations/mq';
@@ -249,7 +251,7 @@ const cssReplyBetaDisplayName = css`
 
 const Space = ({ amount }: { amount: 1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24 }) => (
 	<div
-		className={css`
+		css={css`
 			width: ${space[amount]}px;
 		`}
 	/>
@@ -303,10 +305,10 @@ export const Comment = ({
 	const showPickBadge = comment.status !== 'blocked' && isHighlighted;
 
 	return (
-		<>
+		<React.Fragment>
 			{error && (
 				<span
-					className={css`
+					css={css`
 						color: red;
 					`}
 				>
@@ -316,9 +318,9 @@ export const Comment = ({
 			<div
 				id={`comment-${comment.id}`}
 				data-testid={comment.id}
-				className={cx(commentWrapper, wasScrolledTo && selectedStyles)}
+				css={[commentWrapper, wasScrolledTo && selectedStyles]}
 			>
-				<div className={cx(avatarMargin)}>
+				<div css={avatarMargin}>
 					<Avatar
 						imageUrl={comment.userProfile.avatar}
 						displayName={comment.userProfile.displayName}
@@ -326,19 +328,19 @@ export const Comment = ({
 					/>
 				</div>
 
-				<div className={commentDetails}>
-					<header className={headerStyles}>
-						<div className={cssReplyToWrapper}>
+				<div css={commentDetails}>
+					<header css={headerStyles}>
+						<div css={cssReplyToWrapper}>
 							<Column>
 								<div
-									className={cx(
+									css={[
 										comment.responseTo && hideBelowMobileLandscape,
 										hideAboveMobileLandscape,
-									)}
+									]}
 								>
 									<Row>
 										<div
-											className={css`
+											css={css`
 												margin-right: ${space[2]}px;
 											`}
 										>
@@ -350,11 +352,7 @@ export const Comment = ({
 										</div>
 										<Column>
 											<div
-												className={cx(
-													colourStyles(pillar),
-													boldFont,
-													negativeMargin,
-												)}
+												css={[colourStyles(pillar), boldFont, negativeMargin]}
 											>
 												<Link
 													href={comment.userProfile.webUrl}
@@ -373,18 +371,14 @@ export const Comment = ({
 										</Column>
 									</Row>
 								</div>
-								<div
-									className={cx(
-										!comment.responseTo && hideBelowMobileLandscape,
-									)}
-								>
+								<div css={[!comment.responseTo && hideBelowMobileLandscape]}>
 									<Row>
 										<div
-											className={cx(
+											css={[
 												colourStyles(pillar),
 												boldFont,
 												cssReplyAlphaDisplayName,
-											)}
+											]}
 										>
 											<Link
 												href={comment.userProfile.webUrl}
@@ -396,12 +390,12 @@ export const Comment = ({
 										</div>
 										{comment.responseTo ? (
 											<div
-												className={cx(
+												css={[
 													colourStyles(pillar),
 													regularFont,
 													svgReplyArrow,
 													cssReplyBetaDisplayName,
-												)}
+												]}
 											>
 												<Link
 													href={`#comment-${comment.responseTo.commentId}`}
@@ -414,13 +408,13 @@ export const Comment = ({
 												</Link>
 											</div>
 										) : (
-											<></>
+											<React.Fragment></React.Fragment>
 										)}
 										<div
-											className={cx(
+											css={[
 												timestampWrapperStyles,
 												comment.responseTo && hideBelowMobileLandscape,
-											)}
+											]}
 										>
 											<Timestamp
 												isoDateTime={comment.isoDateTime}
@@ -432,18 +426,18 @@ export const Comment = ({
 									</Row>
 									<Row>
 										{showStaffbadge ? (
-											<div className={iconWrapper}>
+											<div css={iconWrapper}>
 												<GuardianStaff />
 											</div>
 										) : (
-											<></>
+											<React.Fragment></React.Fragment>
 										)}
 										{showPickBadge ? (
-											<div className={iconWrapper}>
+											<div css={iconWrapper}>
 												<GuardianPick />
 											</div>
 										) : (
-											<></>
+											<React.Fragment></React.Fragment>
 										)}
 									</Row>
 								</div>
@@ -464,34 +458,36 @@ export const Comment = ({
 					</header>
 
 					<div
-						className={cx(
+						css={[
 							comment.responseTo && hideBelowMobileLandscape,
 							hideAboveMobileLandscape,
-						)}
+						]}
 					>
 						<Row>
 							{showStaffbadge ? (
-								<div className={iconWrapper}>
+								<div css={iconWrapper}>
 									<GuardianStaff />
 								</div>
 							) : (
-								<></>
+								<React.Fragment></React.Fragment>
 							)}
 							{showPickBadge ? (
-								<div className={iconWrapper}>
+								<div css={iconWrapper}>
 									<GuardianPick />
 								</div>
 							) : (
-								<></>
+								<React.Fragment></React.Fragment>
 							)}
 						</Row>
 					</div>
 
 					{/* MUTED */}
 					{isMuted && (
-						<p className={blockedCommentStyles}>
+						<p css={blockedCommentStyles}>
 							<Row>
-								<>All posts from this user have been muted on this device.</>
+								<React.Fragment>
+									All posts from this user have been muted on this device.
+								</React.Fragment>
 								<Space amount={1} />
 								<ButtonLink
 									onClick={() => toggleMuteStatus(comment.userProfile.userId)}
@@ -507,28 +503,28 @@ export const Comment = ({
 					{/* BLOCKED */}
 					{!isMuted && comment.status === 'blocked' && (
 						<p
-							className={cx(blockedCommentStyles, commentLinkStyling)}
+							css={[blockedCommentStyles, commentLinkStyling]}
 							dangerouslySetInnerHTML={{ __html: comment.body }}
 						/>
 					)}
 
 					{/* NORMAL */}
 					{!isMuted && comment.status !== 'blocked' && (
-						<>
+						<React.Fragment>
 							<div
-								className={cx(commentCss, commentLinkStyling)}
+								css={[commentCss, commentLinkStyling]}
 								dangerouslySetInnerHTML={{
 									__html: comment.body,
 								}}
 							/>
-							<div className={spaceBetween}>
+							<div css={spaceBetween}>
 								<Row>
 									{/* When commenting is closed, no reply link shows at all */}
 									{!isClosedForComments && (
-										<>
+										<React.Fragment>
 											{/* If user is not logged in we link to the login page */}
 											{user ? (
-												<div className={svgReplyArrow}>
+												<div css={svgReplyArrow}>
 													<ButtonLink
 														pillar={pillar}
 														onClick={() => setCommentBeingRepliedTo(comment)}
@@ -540,12 +536,7 @@ export const Comment = ({
 													</ButtonLink>
 												</div>
 											) : (
-												<div
-													className={cx(
-														svgReplyArrow,
-														commentControlsLink(pillar),
-													)}
-												>
+												<div css={[svgReplyArrow, commentControlsLink(pillar)]}>
 													<Link
 														href={`https://profile.theguardian.com/signin?returnUrl=${
 															comment.webUrl
@@ -563,7 +554,7 @@ export const Comment = ({
 												</div>
 											)}
 											<Space amount={4} />
-										</>
+										</React.Fragment>
 									)}
 									<Space amount={4} />
 									{/* Only staff can pick, and they cannot pick thier own comment */}
@@ -594,7 +585,7 @@ export const Comment = ({
 											Mute
 										</ButtonLink>
 									) : (
-										<></>
+										<React.Fragment></React.Fragment>
 									)}
 									<Space amount={4} />
 									<ButtonLink
@@ -606,7 +597,7 @@ export const Comment = ({
 									</ButtonLink>
 									{showAbuseReportForm && (
 										<div
-											className={css`
+											css={css`
 												position: relative;
 											`}
 										>
@@ -619,10 +610,10 @@ export const Comment = ({
 									)}
 								</Row>
 							</div>
-						</>
+						</React.Fragment>
 					)}
 				</div>
 			</div>
-		</>
+		</React.Fragment>
 	);
 };

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -1,5 +1,7 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
 import React, { useState, useEffect } from 'react';
-import { css, cx } from 'emotion';
+import { css, jsx } from '@emotion/core';
 
 import { space, neutral, border } from '@guardian/src-foundations';
 import { SvgPlus } from '@guardian/src-icons';
@@ -69,7 +71,7 @@ const removeMargin = css`
 	margin: 0px;
 `;
 
-export const avatar = (avatarSize: number): string => css`
+export const avatar = (avatarSize: number) => css`
 	border-radius: ${avatarSize + 10}px;
 	width: ${avatarSize}px;
 	height: ${avatarSize}px;
@@ -126,7 +128,7 @@ export const CommentContainer = ({
 	};
 
 	return (
-		<div className={cx(commentToScrollTo === comment.id && selectedStyles)}>
+		<div css={[commentToScrollTo === comment.id && selectedStyles]}>
 			<Comment
 				comment={comment}
 				pillar={pillar}
@@ -140,10 +142,10 @@ export const CommentContainer = ({
 				onRecommend={onRecommend}
 			/>
 
-			<>
+			<React.Fragment>
 				{showResponses && responses && (
-					<div className={nestingStyles}>
-						<ul className={cx(commentContainerStyles, removeMargin)}>
+					<div css={nestingStyles}>
+						<ul css={[commentContainerStyles, removeMargin]}>
 							{responses.map((responseComment) => (
 								<li key={responseComment.id}>
 									<Comment
@@ -166,13 +168,13 @@ export const CommentContainer = ({
 							comment.metaData.responseCount &&
 							comment.metaData.responseCount > 3 && (
 								<div
-									className={cx(
+									css={[
 										topBorder,
 										css`
 											padding-top: ${space[3]}px;
 											padding-bottom: ${space[3]}px;
 										`,
-									)}
+									]}
 								>
 									<PillarButton
 										priority="secondary"
@@ -198,7 +200,7 @@ export const CommentContainer = ({
 					user && (
 						<div
 							id={`comment-reply-form-${commentBeingRepliedTo.id}`}
-							className={nestingStyles}
+							css={nestingStyles}
 						>
 							<CommentReplyPreview
 								pillar={pillar}
@@ -219,7 +221,7 @@ export const CommentContainer = ({
 							/>
 						</div>
 					)}
-			</>
+			</React.Fragment>
 		</div>
 	);
 };

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -1,5 +1,7 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
 import React, { useState, useRef, useEffect } from 'react';
-import { css, cx } from 'emotion';
+import { css, jsx } from '@emotion/core';
 
 import { palette, space } from '@guardian/src-foundations';
 import { neutral, text } from '@guardian/src-foundations/palette';
@@ -147,7 +149,7 @@ const bottomContainer = css`
 
 const Space = ({ amount }: { amount: 1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24 }) => (
 	<div
-		className={css`
+		css={css`
 			width: ${space[amount]}px;
 		`}
 	/>
@@ -368,36 +370,36 @@ export const CommentForm = ({
 	}
 
 	return (
-		<>
+		<React.Fragment>
 			<form
-				className={formWrapper}
+				css={formWrapper}
 				onSubmit={(e) => {
 					e.preventDefault();
 					submitForm();
 				}}
 			>
 				{error && (
-					<div className={msgContainerStyles}>
+					<div css={msgContainerStyles}>
 						<p
-							className={cx(errorTextStyles, linkStyles)}
+							css={[errorTextStyles, linkStyles]}
 							dangerouslySetInnerHTML={{ __html: error }}
 						/>
 					</div>
 				)}
 				{info && (
-					<div className={msgContainerStyles}>
-						<p className={cx(infoTextStyles, linkStyles)}>{info}</p>
+					<div css={msgContainerStyles}>
+						<p css={[infoTextStyles, linkStyles]}>{info}</p>
 					</div>
 				)}
 				{isActive && (
-					<div className={wrapperHeaderTextStyles}>
-						<p className={cx(headerTextStyles, linkStyles)}>
+					<div css={wrapperHeaderTextStyles}>
+						<p css={[headerTextStyles, linkStyles]}>
 							Please keep comments respectful and abide by the{' '}
 							<a href="/community-standards">community guidelines</a>.
 						</p>
 
 						{user.privateFields && user.privateFields.isPremoderated && (
-							<p className={cx(errorTextStyles, linkStyles)}>
+							<p css={[errorTextStyles, linkStyles]}>
 								Your comments are currently being pre-moderated (
 								<a href="/community-faqs#311" target="_blank" rel="nofollow">
 									why?
@@ -412,11 +414,11 @@ export const CommentForm = ({
 					placeholder={
 						commentBeingRepliedTo || !isActive ? 'Join the discussion' : ''
 					}
-					className={cx(
+					css={[
 						commentTextArea,
 						commentBeingRepliedTo && isActive && greyPlaceholder,
 						!commentBeingRepliedTo && !isActive && blackPlaceholder,
-					)}
+					]}
 					ref={textAreaRef}
 					style={{ height: isActive ? '132px' : '50px' }}
 					onChange={(e) => {
@@ -425,9 +427,9 @@ export const CommentForm = ({
 					value={body}
 					onFocus={() => setIsActive(true)}
 				/>
-				<div className={bottomContainer}>
+				<div css={bottomContainer}>
 					<Row>
-						<>
+						<React.Fragment>
 							<PillarButton
 								pillar={pillar}
 								type="submit"
@@ -437,7 +439,7 @@ export const CommentForm = ({
 								Post your comment
 							</PillarButton>
 							{(isActive || body) && (
-								<>
+								<React.Fragment>
 									<Space amount={3} />
 									<PillarButton
 										pillar={pillar}
@@ -459,9 +461,9 @@ export const CommentForm = ({
 									>
 										Cancel
 									</PillarButton>
-								</>
+								</React.Fragment>
 							)}
-						</>
+						</React.Fragment>
 					</Row>
 					{isActive && (
 						<Row>
@@ -470,7 +472,7 @@ export const CommentForm = ({
 									e.preventDefault();
 									transformText(boldString);
 								}}
-								className={commentAddOns}
+								css={commentAddOns}
 								data-link-name="formatting-controls-bold"
 							>
 								B
@@ -480,7 +482,7 @@ export const CommentForm = ({
 									e.preventDefault();
 									transformText(italicsString);
 								}}
-								className={commentAddOns}
+								css={commentAddOns}
 								data-link-name="formatting-controls-italic"
 							>
 								i
@@ -490,7 +492,7 @@ export const CommentForm = ({
 									e.preventDefault();
 									transformText(strikethroughString);
 								}}
-								className={commentAddOns}
+								css={commentAddOns}
 								data-link-name="formatting-controls-strikethrough"
 							>
 								{`S̶`}
@@ -500,17 +502,17 @@ export const CommentForm = ({
 									e.preventDefault();
 									transformText(codeString);
 								}}
-								className={commentAddOns}
+								css={commentAddOns}
 								data-link-name="formatting-controls-code"
 							>
-								{`<>`}
+								{`<React.Fragment>`}
 							</button>
 							<button
 								onClick={(e) => {
 									e.preventDefault();
 									transformText(quoteString);
 								}}
-								className={commentAddOns}
+								css={commentAddOns}
 								data-link-name="formatting-controls-quote"
 							>
 								"
@@ -520,7 +522,7 @@ export const CommentForm = ({
 									e.preventDefault();
 									transformLink();
 								}}
-								className={commentAddOns}
+								css={commentAddOns}
 								data-link-name="formatting-controls-link"
 							>
 								Link
@@ -531,6 +533,6 @@ export const CommentForm = ({
 			</form>
 
 			{showPreview && <Preview previewHtml={previewBody} />}
-		</>
+		</React.Fragment>
 	);
 };

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -505,7 +505,7 @@ export const CommentForm = ({
 								css={commentAddOns}
 								data-link-name="formatting-controls-code"
 							>
-								{`<React.Fragment>`}
+								{`<>`}
 							</button>
 							<button
 								onClick={(e) => {

--- a/src/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
@@ -4,7 +4,7 @@ import { Pillar } from '@guardian/types';
 
 import { CommentReplyPreview, Preview } from './CommentReplyPreview';
 import { CommentType } from '../../types';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 export default { title: 'CommentReplyPreview' };
 
@@ -63,7 +63,7 @@ export const Default = () => (
 Default.story = { name: 'default' };
 
 export const SingleLinePreview = () => (
-	<div className={padding}>
+	<div css={padding}>
 		<Preview
 			commentBeingRepliedTo={{
 				...commentBeingRepliedTo,
@@ -77,7 +77,7 @@ export const SingleLinePreview = () => (
 SingleLinePreview.story = { name: 'Single line' };
 
 export const SingleBlockPreview = () => (
-	<div className={padding}>
+	<div css={padding}>
 		<Preview
 			commentBeingRepliedTo={{
 				...commentBeingRepliedTo,
@@ -91,7 +91,7 @@ export const SingleBlockPreview = () => (
 SingleBlockPreview.story = { name: 'Single Block' };
 
 export const MultiBlockPreview = () => (
-	<div className={padding}>
+	<div css={padding}>
 		<Preview
 			commentBeingRepliedTo={{
 				...commentBeingRepliedTo,

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 import { textSans } from '@guardian/src-foundations/typography';
 import { neutral, space, text } from '@guardian/src-foundations';
@@ -18,7 +18,7 @@ type Props = {
 
 const Space = ({ amount }: { amount: 1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24 }) => (
 	<div
-		className={css`
+		css={css`
 			width: ${space[amount]}px;
 		`}
 	/>
@@ -85,13 +85,13 @@ export const CommentReplyPreview = ({
 		false,
 	);
 	return (
-		<>
+		<React.Fragment>
 			<Row>
-				<div className={indentStyles}>
+				<div css={indentStyles}>
 					<SvgIndent />
 				</div>
 				<Space amount={1} />
-				<div className={smallFontStyles}>
+				<div css={smallFontStyles}>
 					{commentBeingRepliedTo.userProfile.displayName}
 				</div>
 				<Space amount={3} />
@@ -112,7 +112,7 @@ export const CommentReplyPreview = ({
 					displayReplyComment={displayReplyComment}
 				/>
 			)}
-		</>
+		</React.Fragment>
 	);
 };
 
@@ -126,13 +126,13 @@ export const Preview = ({
 	displayReplyComment: boolean;
 }) => {
 	return (
-		<div className={previewStyle}>
-			<p className={replyPreviewHeaderStyle}>
+		<div css={previewStyle}>
+			<p css={replyPreviewHeaderStyle}>
 				{commentBeingRepliedTo.userProfile.displayName} @{' '}
 				{commentBeingRepliedTo.date} said:
 			</p>
 			<div
-				className={commentStyles}
+				css={commentStyles}
 				dangerouslySetInnerHTML={{
 					__html: commentBeingRepliedTo.body || '',
 				}}
@@ -142,7 +142,7 @@ export const Preview = ({
 				onClick={() => setDisplayReplyComment(!displayReplyComment)}
 				linkName="hide-comment"
 			>
-				<span className={blueLink}>Hide Comment</span>
+				<span css={blueLink}>Hide Comment</span>
 			</ButtonLink>
 		</div>
 	);

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 import { Pillar } from '@guardian/types';
 
@@ -8,7 +8,7 @@ import { Dropdown } from './Dropdown';
 
 const Container = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
 	<div
-		className={css`
+		css={css`
 			padding: 10px;
 		`}
 	>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,5 +1,7 @@
-import React, { useState, useEffect } from 'react';
-import { css, cx } from 'emotion';
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { useState, useEffect } from 'react';
+import { css, jsx } from '@emotion/core';
 
 import FocusLock from 'react-focus-lock';
 
@@ -195,12 +197,12 @@ export const Dropdown = ({ id, label, options, pillar, onSelect }: Props) => {
 	const activeLink = options.find((option) => option.isActive);
 
 	return (
-		<div className={containerStyles}>
-			<div className={labelStyles}>
+		<div css={containerStyles}>
+			<div css={labelStyles}>
 				{label}
 				<button
 					onClick={() => setIsExpanded(!isExpanded)}
-					className={cx(buttonStyles, isExpanded && expandedStyles)}
+					css={[buttonStyles, isExpanded && expandedStyles]}
 					aria-controls={dropdownID}
 					aria-expanded={isExpanded ? 'true' : 'false'}
 				>
@@ -208,16 +210,16 @@ export const Dropdown = ({ id, label, options, pillar, onSelect }: Props) => {
 				</button>
 			</div>
 			<FocusLock>
-				<ul id={dropdownID} className={cx(ulStyles, isExpanded && ulExpanded)}>
+				<ul id={dropdownID} css={[ulStyles, isExpanded && ulExpanded]}>
 					{options.map((option, index) => (
 						<li key={option.title}>
 							<button
 								onClick={() => onSelect(option.value)}
-								className={cx(
+								css={[
 									linkStyles(!!option.disabled),
 									option.isActive && activeStyles(pillar),
 									index === 0 && firstStyles,
-								)}
+								]}
 								disabled={option.isActive || option.disabled}
 							>
 								{option.title}

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 import { space } from '@guardian/src-foundations';
 import { border } from '@guardian/src-foundations/palette';
@@ -58,8 +58,8 @@ export const Filters = ({
 	totalPages,
 	commentCount,
 }: Props) => (
-	<div id="comment-filters" className={filterBar}>
-		<div className={filterPadding}>
+	<div id="comment-filters" css={filterBar}>
+		<div css={filterPadding}>
 			<Dropdown
 				id="order-by-dropdown"
 				label="Sort by"
@@ -89,8 +89,8 @@ export const Filters = ({
 				}
 			/>
 		</div>
-		<div className={dividerStyles} />
-		<div className={filterPadding}>
+		<div css={dividerStyles} />
+		<div css={filterPadding}>
 			<Dropdown
 				id="page-size-dropdown"
 				label="Per page"
@@ -123,8 +123,8 @@ export const Filters = ({
 				}
 			/>
 		</div>
-		<div className={dividerStyles} />
-		<div className={filterPadding}>
+		<div css={dividerStyles} />
+		<div css={filterPadding}>
 			<Dropdown
 				id="threads-dropdown"
 				label="Display threads"

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -1,5 +1,8 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
 import React, { useState, useEffect } from 'react';
-import { css, cx } from 'emotion';
+import { css, jsx } from '@emotion/core';
+
 import { textSans, headline } from '@guardian/src-foundations/typography';
 import { space, neutral } from '@guardian/src-foundations';
 import { TextInput } from '@guardian/src-text-input';
@@ -41,7 +44,7 @@ const Text = ({
 	children,
 }: {
 	children: string | JSX.Element | JSX.Element[];
-}) => <p className={textStyling}>{children}</p>;
+}) => <p css={textStyling}>{children}</p>;
 
 export const FirstCommentWelcome = ({
 	body,
@@ -69,7 +72,7 @@ export const FirstCommentWelcome = ({
 
 	return (
 		<div
-			className={css`
+			css={css`
 				padding: ${space[2]}px;
 			`}
 		>
@@ -80,7 +83,7 @@ export const FirstCommentWelcome = ({
 				}}
 			>
 				<h3
-					className={css`
+					css={css`
 						${headline.xxsmall({ fontWeight: 'bold' })};
 					`}
 				>
@@ -106,7 +109,7 @@ export const FirstCommentWelcome = ({
 					error={error}
 				/>
 				<Text>
-					<>
+					<React.Fragment>
 						Please keep your posts respectful and abide by the{' '}
 						<Link
 							href="/community-standards"
@@ -114,18 +117,18 @@ export const FirstCommentWelcome = ({
 							subdued={true}
 							rel="nofollow"
 						>
-							<span className={textStyling}>community guidelines</span>
+							<span css={textStyling}>community guidelines</span>
 						</Link>
 						{` -`} and if you spot a comment you think doesn’t adhere to the
 						guidelines, please use the ‘Report’ link next to it to let us know.
-					</>
+					</React.Fragment>
 				</Text>
 				<Text>
 					Please preview your comment below and click ‘post’ when you’re happy
 					with it.
 				</Text>
 				<div
-					className={cx(previewStyle, textStyling)}
+					css={[previewStyle, textStyling]}
 					dangerouslySetInnerHTML={{ __html: previewBody || '' }}
 				/>
 				<Row>
@@ -138,7 +141,7 @@ export const FirstCommentWelcome = ({
 						Post your comment
 					</PillarButton>
 					<div
-						className={css`
+						css={css`
 							width: ${space[3]}px;
 						`}
 					></div>

--- a/src/components/LoadingComments/LoadingComments.tsx
+++ b/src/components/LoadingComments/LoadingComments.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { css, keyframes } from 'emotion';
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { css, jsx, keyframes } from '@emotion/core';
 
 import { space } from '@guardian/src-foundations';
 import { neutral } from '@guardian/src-foundations/palette';
@@ -58,7 +59,7 @@ const Grey = ({
 	spaceLeft?: 1 | 2 | 3 | 4 | 5 | 6 | 9;
 }) => (
 	<div
-		className={css`
+		css={css`
 			height: ${height}px;
 			width: ${width ? `${width}px` : '100%'};
 			margin-bottom: ${spaceBelow && space[spaceBelow]}px;
@@ -71,8 +72,8 @@ const Grey = ({
 );
 
 export const LoadingComments = () => (
-	<div className={containerStyles} data-testid="loading-comments">
-		<div className={avatarStyles(48)} />
+	<div css={containerStyles} data-testid="loading-comments">
+		<div css={avatarStyles(48)} />
 		<Column>
 			<Row>
 				<Grey height={20} width={140} spaceBelow={9} />

--- a/src/components/LoadingPicks/LoadingPicks.tsx
+++ b/src/components/LoadingPicks/LoadingPicks.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { css, keyframes } from 'emotion';
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { css, jsx, keyframes } from '@emotion/core';
 
 import { space } from '@guardian/src-foundations';
 import { neutral } from '@guardian/src-foundations/palette';
@@ -70,7 +71,7 @@ const FullWidthColumn = ({
 	children: JSX.Element | JSX.Element[];
 }) => (
 	<div
-		className={css`
+		css={css`
 			display: flex;
 			flex-direction: column;
 			width: 100%;
@@ -92,7 +93,7 @@ const Grey = ({
 	spaceLeft?: 1 | 2 | 3 | 4 | 5 | 6 | 9;
 }) => (
 	<div
-		className={css`
+		css={css`
 			height: ${height}px;
 			width: ${width ? `${width}px` : '100%'};
 			margin-bottom: ${spaceBelow && space[spaceBelow]}px;
@@ -105,11 +106,11 @@ const Grey = ({
 );
 
 export const LoadingPicks = () => (
-	<div className={containerStyles}>
+	<div css={containerStyles}>
 		<FullWidthColumn>
-			<div className={pickBoxStyles} />
+			<div css={pickBoxStyles} />
 			<Row>
-				<div className={avatarStyles(48)} />
+				<div css={avatarStyles(48)} />
 				<FullWidthColumn>
 					<Grey height={20} width={90} spaceBelow={1} />
 					<Grey height={15} width={50} spaceBelow={9} />

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { css, cx } from 'emotion';
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
 
 import { textSans } from '@guardian/src-foundations/typography';
 import { neutral, border, space } from '@guardian/src-foundations';
@@ -131,7 +132,7 @@ const Forward = ({
 	currentPage: number;
 	setCurrentPage: Function;
 }) => (
-	<div className={cx(chevronButtonStyles({ isSelected: false }), shiftRight)}>
+	<div css={[chevronButtonStyles({ isSelected: false }), shiftRight]}>
 		<Button
 			onClick={() => setCurrentPage(currentPage + 1)}
 			aria-label="Previous discussion page"
@@ -154,7 +155,7 @@ const Back = ({
 	const newPage = Math.max(0, currentPage - 1);
 
 	return (
-		<div className={chevronButtonStyles({ isSelected: false })}>
+		<div css={chevronButtonStyles({ isSelected: false })}>
 			<Button
 				onClick={() => setCurrentPage(newPage)}
 				aria-label="Previous discussion page"
@@ -179,7 +180,7 @@ const PageButton = ({
 }) => (
 	<button
 		key={currentPage}
-		className={pageButtonStyles(isSelected)}
+		css={pageButtonStyles(isSelected)}
 		onClick={() => setCurrentPage(currentPage)}
 		data-link-name={`Pagination view page ${currentPage}`}
 	>
@@ -250,8 +251,8 @@ export const Pagination = ({
 	if (endIndex > commentCount) endIndex = commentCount; // If there are less total comments than allowed on the page, endIndex is total comment count
 
 	return (
-		<div className={wrapperStyles}>
-			<div className={paginationButtons}>
+		<div css={wrapperStyles}>
+			<div css={paginationButtons}>
 				{showBackButton && (
 					<Back currentPage={currentPage} setCurrentPage={setCurrentPage} />
 				)}
@@ -260,7 +261,7 @@ export const Pagination = ({
 					setCurrentPage={setCurrentPage}
 					isSelected={currentPage === 1}
 				/>
-				{showFirstElipsis && <div className={elipsisStyles}>&hellip;</div>}
+				{showFirstElipsis && <div css={elipsisStyles}>&hellip;</div>}
 				<PageButton
 					currentPage={secondPage}
 					setCurrentPage={setCurrentPage}
@@ -280,7 +281,7 @@ export const Pagination = ({
 						isSelected={currentPage === forthPage}
 					/>
 				)}
-				{showSecondElipsis && <div className={elipsisStyles}>&hellip;</div>}
+				{showSecondElipsis && <div css={elipsisStyles}>&hellip;</div>}
 				{showLastPage && (
 					<PageButton
 						currentPage={lastPage}
@@ -293,7 +294,7 @@ export const Pagination = ({
 				)}
 			</div>
 			{commentCount && (
-				<div className={paginationText}>
+				<div css={paginationText}>
 					{`Displaying ${
 						filters.threads === 'unthreaded' ? 'comments' : 'threads'
 					} ${startIndex} to ${endIndex} of ${commentCount}`}

--- a/src/components/PillarButton/PillarButton.stories.tsx
+++ b/src/components/PillarButton/PillarButton.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 import { space } from '@guardian/src-foundations';
 import { SvgCheckmark } from '@guardian/src-icons';
@@ -11,7 +11,7 @@ import { PillarButton } from './PillarButton';
 
 const Space = ({ amount }: { amount: 1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24 }) => (
 	<div
-		className={css`
+		css={css`
 			width: ${space[amount]}px;
 		`}
 	/>

--- a/src/components/PillarButton/PillarButton.tsx
+++ b/src/components/PillarButton/PillarButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 import { palette, neutral } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
@@ -94,7 +94,7 @@ export const PillarButton = ({
 	linkName,
 	size = 'default',
 }: Props) => (
-	<div className={buttonOverrides(pillar, priority)}>
+	<div css={buttonOverrides(pillar, priority)}>
 		<Button
 			priority={priority}
 			size={size}

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 import { space, neutral } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
@@ -52,11 +52,11 @@ const spout = css`
 `;
 
 export const Preview = ({ previewHtml }: Props) => (
-	<>
-		<div className={spout} />
+	<React.Fragment>
+		<div css={spout} />
 		<p
-			className={previewStyle}
+			css={previewStyle}
 			dangerouslySetInnerHTML={{ __html: previewHtml || '' }}
 		/>
-	</>
+	</React.Fragment>
 );

--- a/src/components/RecommendationCount/RecommendationCount.tsx
+++ b/src/components/RecommendationCount/RecommendationCount.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 import { textSans } from '@guardian/src-foundations/typography';
 import { neutral } from '@guardian/src-foundations/palette';
@@ -72,14 +72,14 @@ export const RecommendationCount = ({
 
 	return (
 		<Row>
-			<div className={countStyles}>{count}</div>
+			<div css={countStyles}>{count}</div>
 			<button
-				className={buttonStyles(recommended, isSignedIn)}
+				css={buttonStyles(recommended, isSignedIn)}
 				onClick={() => tryToRecommend()}
 				disabled={recommended || !isSignedIn || userMadeComment}
 				data-link-name="Recommend comment"
 			>
-				<div className={arrowStyles(recommended)}>
+				<div css={arrowStyles(recommended)}>
 					<SvgArrowUpStraight />
 				</div>
 			</button>

--- a/src/components/Row/Row.tsx
+++ b/src/components/Row/Row.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 type Props = { children: React.ReactNode };
 
 export const Row = ({ children }: Props) => (
 	<div
-		className={css`
+		css={css`
 			display: flex;
 			flex-direction: row;
 		`}

--- a/src/components/Timestamp/Timestamp.tsx
+++ b/src/components/Timestamp/Timestamp.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 import { textSans } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';
@@ -44,7 +44,7 @@ export const Timestamp = ({
 	return (
 		<a
 			href={webUrl}
-			className={linkStyles}
+			css={linkStyles}
 			data-link-name="jump-to-comment-timestamp"
 			onClick={(e) => {
 				onPermalinkClick(commentId);
@@ -52,7 +52,7 @@ export const Timestamp = ({
 			}}
 			rel="nofollow"
 		>
-			<time dateTime={isoDateTime.toString()} className={timeStyles}>
+			<time dateTime={isoDateTime.toString()} css={timeStyles}>
 				{timeAgo}
 			</time>
 		</a>

--- a/src/components/TopPick/TopPick.stories.tsx
+++ b/src/components/TopPick/TopPick.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css } from '@emotion/core';
 
 import { Pillar } from '@guardian/types';
 
@@ -52,7 +52,7 @@ const commentWithShortBody: CommentType = {
 
 export const LongPick = () => (
 	<div
-		className={css`
+		css={css`
 			width: 100%;
 			max-width: 300px;
 		`}
@@ -70,7 +70,7 @@ LongPick.story = { name: 'Long' };
 
 export const ShortPick = () => (
 	<div
-		className={css`
+		css={css`
 			width: 100%;
 			max-width: 300px;
 		`}

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -1,5 +1,7 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
 import React from 'react';
-import { css, cx } from 'emotion';
+import { css, jsx } from '@emotion/core';
 
 import { from } from '@guardian/src-foundations/mq';
 import { space, neutral, palette } from '@guardian/src-foundations';
@@ -104,7 +106,7 @@ const PickBubble = ({
 	children: JSX.Element | JSX.Element[];
 }) => (
 	<div
-		className={css`
+		css={css`
 			display: flex;
 			flex-direction: column;
 			justify-content: space-between;
@@ -148,7 +150,7 @@ const Bottom = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
 
 const PickMeta = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
 	<div
-		className={css`
+		css={css`
 			display: flex;
 			justify-content: space-between;
 			padding-top: ${space[1]}px;
@@ -172,19 +174,19 @@ export const TopPick = ({
 	onPermalinkClick,
 	onRecommend,
 }: Props) => (
-	<div className={pickStyles}>
+	<div css={pickStyles}>
 		<PickBubble>
 			<Top>
-				<h3 className={titleStyles}>Guardian Pick</h3>
+				<h3 css={titleStyles}>Guardian Pick</h3>
 				<p
-					className={cx(wrapStyles, inCommentLinkStyling)}
+					css={[wrapStyles, inCommentLinkStyling]}
 					dangerouslySetInnerHTML={{
 						__html: truncateText(comment.body, 450),
 					}}
 				></p>
 			</Top>
 			<Bottom>
-				<div className={smallFontSize}>
+				<div css={smallFontSize}>
 					<Link
 						priority="primary"
 						subdued={true}
@@ -202,7 +204,7 @@ export const TopPick = ({
 		</PickBubble>
 		<PickMeta>
 			<Row>
-				<div className={avatarMargin}>
+				<div css={avatarMargin}>
 					<Avatar
 						imageUrl={comment.userProfile.avatar}
 						displayName={''}
@@ -210,10 +212,10 @@ export const TopPick = ({
 					/>
 				</div>
 				<Column>
-					<span className={userNameStyles(pillar)}>
+					<span css={userNameStyles(pillar)}>
 						<a
 							href={comment.userProfile.webUrl}
-							className={cx(linkStyles, inheritColour)}
+							css={[linkStyles, inheritColour]}
 							rel="nofollow"
 						>
 							{comment.userProfile.displayName}
@@ -229,7 +231,7 @@ export const TopPick = ({
 						.length ? (
 						<GuardianStaff />
 					) : (
-						<></>
+						<React.Fragment></React.Fragment>
 					)}
 				</Column>
 			</Row>

--- a/src/components/TopPicks/TopPicks.tsx
+++ b/src/components/TopPicks/TopPicks.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { css, cx } from 'emotion';
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
 
 import { until, from } from '@guardian/src-foundations/mq';
 import { Theme } from '@guardian/types';
@@ -65,9 +66,9 @@ export const TopPicks = ({
 			: rightColComments.push(comment),
 	);
 	return (
-		<div className={picksWrapper}>
-			<div className={twoColCommentsStyles}>
-				<div className={cx(columWrapperStyles, paddingRight)}>
+		<div css={picksWrapper}>
+			<div css={twoColCommentsStyles}>
+				<div css={[columWrapperStyles, paddingRight]}>
 					{leftColComments.map((comment) => (
 						<TopPick
 							key={comment.id}
@@ -82,7 +83,7 @@ export const TopPicks = ({
 						/>
 					))}
 				</div>
-				<div className={cx(columWrapperStyles, paddingLeft)}>
+				<div css={[columWrapperStyles, paddingLeft]}>
 					{rightColComments.map((comment) => (
 						<TopPick
 							key={comment.id}
@@ -98,7 +99,7 @@ export const TopPicks = ({
 					))}
 				</div>
 			</div>
-			<div className={oneColCommentsStyles}>
+			<div css={oneColCommentsStyles}>
 				{comments.map((comment) => (
 					<TopPick
 						key={comment.id}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,8 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
 import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
+import { jsx } from '@emotion/core';
 
 import { pillarToEnum } from './lib/pillarToEnum';
 import { CAPIPillar } from './types';
@@ -30,7 +33,7 @@ const IndexPageWrapper = () => {
 	}
 
 	return (
-		<>
+		<React.Fragment>
 			<h1>Example Discussion</h1>
 			<p>
 				Set a specific discussion using the id in a query param like{' '}
@@ -53,7 +56,7 @@ const IndexPageWrapper = () => {
 				onPermalinkClick={() => {}}
 				apiKey="discussion-rendering"
 			/>
-		</>
+		</React.Fragment>
 	);
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6846,16 +6846,6 @@ create-ecdh@^4.0.0:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
 
-create-emotion@^10.0.27:
-  version "10.0.27"
-  resolved "https://registry.yarnpkg.com/create-emotion/-/create-emotion-10.0.27.tgz#cb4fa2db750f6ca6f9a001a33fbf1f6c46789503"
-  integrity sha512-fIK73w82HPPn/RsAij7+Zt8eCE8SptcJ3WoRMfxMtjteYxud8GDTKKld7MYwAX2TVhrw29uR1N/bVGxeStHILg==
-  dependencies:
-    "@emotion/cache" "^10.0.27"
-    "@emotion/serialize" "^0.11.15"
-    "@emotion/sheet" "0.9.4"
-    "@emotion/utils" "0.11.3"
-
 create-hash@^1.1.0, create-hash@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
@@ -7850,14 +7840,6 @@ emotion-theming@^10.0.19:
     "@babel/runtime" "^7.5.5"
     "@emotion/weak-memoize" "0.2.5"
     hoist-non-react-statics "^3.3.0"
-
-emotion@^10.0.27:
-  version "10.0.27"
-  resolved "https://registry.yarnpkg.com/emotion/-/emotion-10.0.27.tgz#f9ca5df98630980a23c819a56262560562e5d75e"
-  integrity sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==
-  dependencies:
-    babel-plugin-emotion "^10.0.27"
-    create-emotion "^10.0.27"
 
 encodeurl@~1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2179,22 +2179,22 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@emotion/babel-plugin-jsx-pragmatic@^0.1.5":
+"@emotion/babel-plugin-jsx-pragmatic@^0.1.4":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin-jsx-pragmatic/-/babel-plugin-jsx-pragmatic-0.1.5.tgz#27debfe9c27c4d83574d509787ae553bf8a34d7e"
   integrity sha512-y+3AJ0SItMDaAgGPVkQBC/S/BaqaPACkQ6MyCI2CUlrjTxKttTVfD3TMtcs7vLEcLxqzZ1xiG0vzwCXjhopawQ==
   dependencies:
     "@babel/plugin-syntax-jsx" "^7.2.0"
 
-"@emotion/babel-preset-css-prop@^10.0.14":
-  version "10.0.27"
-  resolved "https://registry.yarnpkg.com/@emotion/babel-preset-css-prop/-/babel-preset-css-prop-10.0.27.tgz#58868d9a6afee0eeaeb0fa9dc5ccb1b12d4f786b"
-  integrity sha512-rducrjTpLGDholp0l2l4pXqpzAqYYGMg/x4IteO0db2smf6zegn6RRZdDnbaoMSs63tfPWgo2WukT1/F1gX/AA==
+"@emotion/babel-preset-css-prop@10.0.23":
+  version "10.0.23"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-preset-css-prop/-/babel-preset-css-prop-10.0.23.tgz#7c21a36c97c3ce9e96f5896b56f68b9bbac800bd"
+  integrity sha512-XG1s1SQF8twf/ufh+j3EdVjQW7SjcAPOdPZDxEsVVahoR1mF2/nWl4adc5ROppSr/P84QJEdquA6lmyZWcnaBQ==
   dependencies:
     "@babel/plugin-transform-react-jsx" "^7.3.0"
     "@babel/runtime" "^7.5.5"
-    "@emotion/babel-plugin-jsx-pragmatic" "^0.1.5"
-    babel-plugin-emotion "^10.0.27"
+    "@emotion/babel-plugin-jsx-pragmatic" "^0.1.4"
+    babel-plugin-emotion "^10.0.23"
 
 "@emotion/cache@^10.0.27":
   version "10.0.27"
@@ -2205,6 +2205,18 @@
     "@emotion/stylis" "0.8.5"
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
+
+"@emotion/core@10.0.35":
+  version "10.0.35"
+  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.35.tgz#513fcf2e22cd4dfe9d3894ed138c9d7a859af9b3"
+  integrity sha512-sH++vJCdk025fBlRZSAhkRlSUoqSqgCzYf5fMOmqqi3bM6how+sQpg3hkgJonj8GxXM4WbD7dRO+4tegDB9fUw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/cache" "^10.0.27"
+    "@emotion/css" "^10.0.27"
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/sheet" "0.9.4"
+    "@emotion/utils" "0.11.3"
 
 "@emotion/core@^10.1.1":
   version "10.1.1"
@@ -2226,6 +2238,11 @@
     "@emotion/serialize" "^0.11.15"
     "@emotion/utils" "0.11.3"
     babel-plugin-emotion "^10.0.27"
+
+"@emotion/eslint-plugin@^11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/eslint-plugin/-/eslint-plugin-11.0.0.tgz#7666b750df62dc33a93bb1e09086f1caaecadc6f"
+  integrity sha512-V5w/LgV61xta+U6LKht3WQqfjTLueU2mh1aRTcK5OfkRhZ4OZFE0Inq/oVwLCq5g3Hzoaq27PRm+Tk9W18QScw==
 
 "@emotion/hash@0.7.4":
   version "0.7.4"
@@ -5207,7 +5224,7 @@ babel-plugin-dynamic-import-node@^2.3.3:
   dependencies:
     object.assign "^4.1.0"
 
-babel-plugin-emotion@^10.0.20, babel-plugin-emotion@^10.0.33:
+babel-plugin-emotion@^10.0.20, babel-plugin-emotion@^10.0.23, babel-plugin-emotion@^10.0.33:
   version "10.0.33"
   resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz#ce1155dcd1783bbb9286051efee53f4e2be63e03"
   integrity sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==
@@ -15631,9 +15648,9 @@ react-docgen@^5.0.0:
     strip-indent "^3.0.0"
 
 react-dom@^16.12.0:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
-  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
+  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
## What does this change?
Update the use of `@emotion/core` to be more in line with how you write emotion 10.

## Why?
We have been using Emotion 10 but we write emotion code as if we are using Emotion 9 (this was allowed to help make the transition simple). But now as we are aiming to go to Emotion 11, we should first migrate to using Emotion 10 syntax.

## JSX?
Emotion uses `jsx` exposed from `@emotion/core` (in Emotion 10), rather than React, as a way of converting `css` props on components to `classNames`. In order to get this working you need to add a babel preset `@emotion/babel-preset-css-prop` and make sure that react files start with `/** @jsx jsx */` (a way to indicate to babel that you want to use JSX rather than React.

## Fragments?
Babel does not understand `<></>`, therefore we use React to explicitly define `React.Fragment`

## JSX Runtime?
We can only support JSX runtime classic untile we migrate to Emotion 11, so each file needs to have the pragma:`/** @jsxRuntime classic */` at the top
