### PR TITLE
Update React v17

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -5,13 +5,30 @@ module.exports = {
   ],
   webpackFinal: async config => {
       config.module.rules.push({
-          test: /\.(ts|tsx)$/,
-          use: [
-              {
-                  loader: require.resolve('ts-loader'),
-              },
-          ],
-      });
+        test: /\.(ts|tsx)$/,
+        loader: require.resolve('babel-loader'),
+        options: {
+            presets: [
+                '@babel/preset-typescript',
+                [
+                    '@babel/preset-env',
+                    {
+                        targets: {
+                            esmodules: true,
+                        },
+                    },
+                ],
+                [
+                  '@babel/preset-react',
+                  {
+                      'runtime': 'automatic',
+                      'importSource': '@emotion/core'
+                  }
+                ],
+                '@emotion/babel-preset-css-prop',
+            ],
+        },
+    });
 
       return config;
   },

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -10,14 +10,7 @@ module.exports = {
         options: {
             presets: [
                 '@babel/preset-typescript',
-                [
-                    '@babel/preset-env',
-                    {
-                        targets: {
-                            esmodules: true,
-                        },
-                    },
-                ],
+                '@babel/preset-env',
                 [
                   '@babel/preset-react',
                   {
@@ -25,7 +18,6 @@ module.exports = {
                       'importSource': '@emotion/core'
                   }
                 ],
-                '@emotion/babel-preset-css-prop',
             ],
         },
     });

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react"
+import { useEffect } from "react"
 import { FocusStyleManager } from "@guardian/src-foundations/utils"
 import MockDate from 'mockdate';
 import { mockFetchCalls } from '../src/lib/mockFetchCalls';

--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,6 @@ module.exports = {
                 'importSource': '@emotion/core'
             }
         ],
-        '@emotion/babel-preset-css-prop',
     ],
     env: {
         test: {

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    plugins: ['const-enum', '@babel/transform-typescript', 'babel-plugin-emotion'],
+    plugins: ['const-enum', '@babel/transform-typescript'],
     presets: [
         '@babel/preset-env',
         '@babel/preset-typescript',
@@ -13,7 +13,7 @@ module.exports = {
     ],
     env: {
         test: {
-            plugins: ['@babel/plugin-transform-runtime', 'babel-plugin-emotion'],
+            plugins: ['@babel/plugin-transform-runtime'],
         },
     },
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,14 +1,20 @@
 module.exports = {
-    plugins: ["const-enum", "@babel/transform-typescript"],
+    plugins: ['const-enum', '@babel/transform-typescript', 'babel-plugin-emotion'],
     presets: [
         '@babel/preset-env',
         '@babel/preset-typescript',
-        '@babel/preset-react',
+        [
+            '@babel/preset-react',
+            {
+                'runtime': 'automatic',
+                'importSource': '@emotion/core'
+            }
+        ],
         '@emotion/babel-preset-css-prop',
     ],
     env: {
         test: {
-            plugins: ['@babel/plugin-transform-runtime'],
+            plugins: ['@babel/plugin-transform-runtime', 'babel-plugin-emotion'],
         },
     },
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "timeago.js": "^4.0.2"
   },
   "peerDependencies": {
-    "@emotion/core": "^10.0.28",
+    "@emotion/core": "10.0.35",
     "@guardian/src-button": "2.7.1",
     "@guardian/src-foundations": "2.7.1",
     "@guardian/src-icons": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -44,9 +44,11 @@
     "@babel/core": "^7.12.10",
     "@babel/plugin-transform-runtime": "^7.9.0",
     "@babel/preset-env": "^7.5.5",
-    "@babel/preset-react": "^7.0.0",
+    "@babel/preset-react": "^7.12.10",
     "@babel/preset-typescript": "^7.12.7",
+    "@emotion/babel-plugin": "^11.1.2",
     "@emotion/babel-preset-css-prop": "^10.0.14",
+    "@emotion/core": "10.0.35",
     "@guardian/prettier": "^0.4.2",
     "@guardian/src-button": "2.7.1",
     "@guardian/src-foundations": "2.7.1",
@@ -63,8 +65,8 @@
     "@testing-library/user-event": "^12.6.2",
     "@types/jest": "^26.0.0",
     "@types/node": "^14.10.2",
-    "@types/react": "^16.9.34",
-    "@types/react-dom": "^16.9.5",
+    "@types/react": "^17.0.0",
+    "@types/react-dom": "^17.0.0",
     "babel-loader": "^8.2.2",
     "babel-plugin-const-enum": "^1.0.1",
     "emotion": "^10.0.27",
@@ -76,8 +78,8 @@
     "np": "^7.2.0",
     "prettier": "^2.2.1",
     "pretty-quick": "^2.0.1",
-    "react": "^16.13.1",
-    "react-dom": "^16.12.0",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
     "react-scripts": "3.3.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
@@ -112,7 +114,9 @@
     ],
     "rules": {
       "react-hooks/rules-of-hooks": "error",
-      "react-hooks/exhaustive-deps": "warn"
+      "react-hooks/exhaustive-deps": "warn",
+      "react/jsx-uses-react": "off",
+      "react/react-in-jsx-scope": "off"
     },
     "ignorePatterns": [
       "build"
@@ -152,7 +156,8 @@
     "globals": {
       "ts-jest": {
         "diagnostics": false,
-        "tsConfigFile": "tsconfig.json"
+        "tsConfigFile": "tsconfig.json",
+        "babelConfig": true
       }
     },
     "testMatch": [

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-react": "^7.12.10",
     "@babel/preset-typescript": "^7.12.7",
-    "@emotion/babel-plugin": "^11.1.2",
     "@emotion/core": "10.0.35",
     "@guardian/prettier": "^0.4.2",
     "@guardian/src-button": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@babel/preset-react": "^7.12.10",
     "@babel/preset-typescript": "^7.12.7",
     "@emotion/babel-plugin": "^11.1.2",
-    "@emotion/babel-preset-css-prop": "^10.0.14",
     "@emotion/core": "10.0.35",
     "@guardian/prettier": "^0.4.2",
     "@guardian/src-button": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "build/**/*"
   ],
   "dependencies": {
-    "babel-plugin-emotion": "^10.0.33",
     "customize-cra": "^1.0.0",
     "react-app-rewired": "^2.1.6",
     "react-focus-lock": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,8 @@
     "@guardian/src-link": "2.7.1",
     "@guardian/src-text-input": "2.7.1",
     "@guardian/types": "^3.0.0",
-    "emotion": "^10.0.27",
-    "react": "^16.13.1",
-    "react-dom": "^16.12.0",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
     "typescript": "^4.1.3"
   },
   "devDependencies": {

--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { App } from './App';
 import { css } from 'emotion';
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import {
 	render,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { css } from 'emotion';
 
 import { neutral } from '@guardian/src-foundations/palette';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { css } from 'emotion';
 
 import { neutral } from '@guardian/src-foundations/palette';
@@ -398,7 +398,7 @@ export const App = ({
 						)}
 					</div>
 				) : (
-					<React.Fragment>
+					<>
 						<Filters
 							pillar={pillar}
 							filters={filters}
@@ -443,7 +443,7 @@ export const App = ({
 								))}
 							</ul>
 						)}
-					</React.Fragment>
+					</>
 				)}
 				{commentCount > 2 && (
 					<div

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { css } from 'emotion';
 
 import { neutral } from '@guardian/src-foundations/palette';
@@ -398,7 +398,7 @@ export const App = ({
 						)}
 					</div>
 				) : (
-					<>
+					<React.Fragment>
 						<Filters
 							pillar={pillar}
 							filters={filters}
@@ -443,7 +443,7 @@ export const App = ({
 								))}
 							</ul>
 						)}
-					</>
+					</React.Fragment>
 				)}
 				{commentCount > 2 && (
 					<div

--- a/src/components/AbuseReportForm/AbuseReportForm.stories.tsx
+++ b/src/components/AbuseReportForm/AbuseReportForm.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from 'emotion';
 
 import { Pillar } from '@guardian/types';

--- a/src/components/AbuseReportForm/AbuseReportForm.test.tsx
+++ b/src/components/AbuseReportForm/AbuseReportForm.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 
 import {

--- a/src/components/AbuseReportForm/AbuseReportForm.tsx
+++ b/src/components/AbuseReportForm/AbuseReportForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { css, cx } from 'emotion';
 
 import { palette } from '@guardian/src-foundations';

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -1,12 +1,10 @@
-import React from 'react';
-
 import { Avatar } from './Avatar';
 
 export default { component: Avatar, title: 'Avatar' };
 
 export const Sizes = () => {
 	return (
-		<React.Fragment>
+		<>
 			<Avatar
 				imageUrl="https://avatar.guim.co.uk/no-user-image.gif"
 				size="small"
@@ -22,16 +20,16 @@ export const Sizes = () => {
 				size="large"
 				displayName=""
 			/>
-		</React.Fragment>
+		</>
 	);
 };
 Sizes.story = { name: 'different sizes' };
 
 export const NoImage = () => {
 	return (
-		<React.Fragment>
+		<>
 			<Avatar size="medium" displayName="" />
-		</React.Fragment>
+		</>
 	);
 };
 NoImage.story = { name: 'with no image url given' };

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Avatar } from './Avatar';
 
 export default { component: Avatar, title: 'Avatar' };

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -1,10 +1,12 @@
+import React from 'react';
+
 import { Avatar } from './Avatar';
 
 export default { component: Avatar, title: 'Avatar' };
 
 export const Sizes = () => {
 	return (
-		<>
+		<React.Fragment>
 			<Avatar
 				imageUrl="https://avatar.guim.co.uk/no-user-image.gif"
 				size="small"
@@ -20,16 +22,16 @@ export const Sizes = () => {
 				size="large"
 				displayName=""
 			/>
-		</>
+		</React.Fragment>
 	);
 };
 Sizes.story = { name: 'different sizes' };
 
 export const NoImage = () => {
 	return (
-		<>
+		<React.Fragment>
 			<Avatar size="medium" displayName="" />
-		</>
+		</React.Fragment>
 	);
 };
 NoImage.story = { name: 'with no image url given' };

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from 'emotion';
 
 type Props = {

--- a/src/components/Badges/Badges.tsx
+++ b/src/components/Badges/Badges.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css, cx } from 'emotion';
 
 import { space, neutral, brand } from '@guardian/src-foundations';

--- a/src/components/ButtonLink/ButtonLink.stories.tsx
+++ b/src/components/ButtonLink/ButtonLink.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from 'emotion';
 
 import { space } from '@guardian/src-foundations';

--- a/src/components/ButtonLink/ButtonLink.tsx
+++ b/src/components/ButtonLink/ButtonLink.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css, cx } from 'emotion';
 
 import { palette, neutral } from '@guardian/src-foundations';

--- a/src/components/Column/Column.tsx
+++ b/src/components/Column/Column.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from 'emotion';
 
 type Props = { children: JSX.Element | JSX.Element[] };

--- a/src/components/Comment/Comment.stories.tsx
+++ b/src/components/Comment/Comment.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Pillar } from '@guardian/types';
 
 import { Comment } from './Comment';

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { css, cx } from 'emotion';
 
 import { space, palette, remSpace } from '@guardian/src-foundations';
@@ -303,7 +303,7 @@ export const Comment = ({
 	const showPickBadge = comment.status !== 'blocked' && isHighlighted;
 
 	return (
-		<>
+		<React.Fragment>
 			{error && (
 				<span
 					className={css`
@@ -414,7 +414,7 @@ export const Comment = ({
 												</Link>
 											</div>
 										) : (
-											<></>
+											<React.Fragment></React.Fragment>
 										)}
 										<div
 											className={cx(
@@ -436,14 +436,14 @@ export const Comment = ({
 												<GuardianStaff />
 											</div>
 										) : (
-											<></>
+											<React.Fragment></React.Fragment>
 										)}
 										{showPickBadge ? (
 											<div className={iconWrapper}>
 												<GuardianPick />
 											</div>
 										) : (
-											<></>
+											<React.Fragment></React.Fragment>
 										)}
 									</Row>
 								</div>
@@ -475,14 +475,14 @@ export const Comment = ({
 									<GuardianStaff />
 								</div>
 							) : (
-								<></>
+								<React.Fragment></React.Fragment>
 							)}
 							{showPickBadge ? (
 								<div className={iconWrapper}>
 									<GuardianPick />
 								</div>
 							) : (
-								<></>
+								<React.Fragment></React.Fragment>
 							)}
 						</Row>
 					</div>
@@ -491,7 +491,9 @@ export const Comment = ({
 					{isMuted && (
 						<p className={blockedCommentStyles}>
 							<Row>
-								<>All posts from this user have been muted on this device.</>
+								<React.Fragment>
+									All posts from this user have been muted on this device.
+								</React.Fragment>
 								<Space amount={1} />
 								<ButtonLink
 									onClick={() => toggleMuteStatus(comment.userProfile.userId)}
@@ -514,7 +516,7 @@ export const Comment = ({
 
 					{/* NORMAL */}
 					{!isMuted && comment.status !== 'blocked' && (
-						<>
+						<React.Fragment>
 							<div
 								className={cx(commentCss, commentLinkStyling)}
 								dangerouslySetInnerHTML={{
@@ -525,7 +527,7 @@ export const Comment = ({
 								<Row>
 									{/* When commenting is closed, no reply link shows at all */}
 									{!isClosedForComments && (
-										<>
+										<React.Fragment>
 											{/* If user is not logged in we link to the login page */}
 											{user ? (
 												<div className={svgReplyArrow}>
@@ -563,7 +565,7 @@ export const Comment = ({
 												</div>
 											)}
 											<Space amount={4} />
-										</>
+										</React.Fragment>
 									)}
 									<Space amount={4} />
 									{/* Only staff can pick, and they cannot pick thier own comment */}
@@ -594,7 +596,7 @@ export const Comment = ({
 											Mute
 										</ButtonLink>
 									) : (
-										<></>
+										<React.Fragment></React.Fragment>
 									)}
 									<Space amount={4} />
 									<ButtonLink
@@ -619,10 +621,10 @@ export const Comment = ({
 									)}
 								</Row>
 							</div>
-						</>
+						</React.Fragment>
 					)}
 				</div>
 			</div>
-		</>
+		</React.Fragment>
 	);
 };

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { css, cx } from 'emotion';
 
 import { space, palette, remSpace } from '@guardian/src-foundations';
@@ -303,7 +303,7 @@ export const Comment = ({
 	const showPickBadge = comment.status !== 'blocked' && isHighlighted;
 
 	return (
-		<React.Fragment>
+		<>
 			{error && (
 				<span
 					className={css`
@@ -414,7 +414,7 @@ export const Comment = ({
 												</Link>
 											</div>
 										) : (
-											<React.Fragment></React.Fragment>
+											<></>
 										)}
 										<div
 											className={cx(
@@ -436,14 +436,14 @@ export const Comment = ({
 												<GuardianStaff />
 											</div>
 										) : (
-											<React.Fragment></React.Fragment>
+											<></>
 										)}
 										{showPickBadge ? (
 											<div className={iconWrapper}>
 												<GuardianPick />
 											</div>
 										) : (
-											<React.Fragment></React.Fragment>
+											<></>
 										)}
 									</Row>
 								</div>
@@ -475,14 +475,14 @@ export const Comment = ({
 									<GuardianStaff />
 								</div>
 							) : (
-								<React.Fragment></React.Fragment>
+								<></>
 							)}
 							{showPickBadge ? (
 								<div className={iconWrapper}>
 									<GuardianPick />
 								</div>
 							) : (
-								<React.Fragment></React.Fragment>
+								<></>
 							)}
 						</Row>
 					</div>
@@ -491,9 +491,7 @@ export const Comment = ({
 					{isMuted && (
 						<p className={blockedCommentStyles}>
 							<Row>
-								<React.Fragment>
-									All posts from this user have been muted on this device.
-								</React.Fragment>
+								<>All posts from this user have been muted on this device.</>
 								<Space amount={1} />
 								<ButtonLink
 									onClick={() => toggleMuteStatus(comment.userProfile.userId)}
@@ -516,7 +514,7 @@ export const Comment = ({
 
 					{/* NORMAL */}
 					{!isMuted && comment.status !== 'blocked' && (
-						<React.Fragment>
+						<>
 							<div
 								className={cx(commentCss, commentLinkStyling)}
 								dangerouslySetInnerHTML={{
@@ -527,7 +525,7 @@ export const Comment = ({
 								<Row>
 									{/* When commenting is closed, no reply link shows at all */}
 									{!isClosedForComments && (
-										<React.Fragment>
+										<>
 											{/* If user is not logged in we link to the login page */}
 											{user ? (
 												<div className={svgReplyArrow}>
@@ -565,7 +563,7 @@ export const Comment = ({
 												</div>
 											)}
 											<Space amount={4} />
-										</React.Fragment>
+										</>
 									)}
 									<Space amount={4} />
 									{/* Only staff can pick, and they cannot pick thier own comment */}
@@ -596,7 +594,7 @@ export const Comment = ({
 											Mute
 										</ButtonLink>
 									) : (
-										<React.Fragment></React.Fragment>
+										<></>
 									)}
 									<Space amount={4} />
 									<ButtonLink
@@ -621,10 +619,10 @@ export const Comment = ({
 									)}
 								</Row>
 							</div>
-						</React.Fragment>
+						</>
 					)}
 				</div>
 			</div>
-		</React.Fragment>
+		</>
 	);
 };

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { css, cx } from 'emotion';
 
 import { space, palette, remSpace } from '@guardian/src-foundations';

--- a/src/components/CommentContainer/CommentContainer.stories.tsx
+++ b/src/components/CommentContainer/CommentContainer.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Pillar } from '@guardian/types';
 
 import { CommentContainer } from './CommentContainer';

--- a/src/components/CommentContainer/CommentContainer.test.tsx
+++ b/src/components/CommentContainer/CommentContainer.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import {
 	render,

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { css, cx } from 'emotion';
 
 import { space, neutral, border } from '@guardian/src-foundations';
@@ -140,7 +140,7 @@ export const CommentContainer = ({
 				onRecommend={onRecommend}
 			/>
 
-			<>
+			<React.Fragment>
 				{showResponses && responses && (
 					<div className={nestingStyles}>
 						<ul className={cx(commentContainerStyles, removeMargin)}>
@@ -219,7 +219,7 @@ export const CommentContainer = ({
 							/>
 						</div>
 					)}
-			</>
+			</React.Fragment>
 		</div>
 	);
 };

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { css, cx } from 'emotion';
 
 import { space, neutral, border } from '@guardian/src-foundations';

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { css, cx } from 'emotion';
 
 import { space, neutral, border } from '@guardian/src-foundations';
@@ -140,7 +140,7 @@ export const CommentContainer = ({
 				onRecommend={onRecommend}
 			/>
 
-			<React.Fragment>
+			<>
 				{showResponses && responses && (
 					<div className={nestingStyles}>
 						<ul className={cx(commentContainerStyles, removeMargin)}>
@@ -219,7 +219,7 @@ export const CommentContainer = ({
 							/>
 						</div>
 					)}
-			</React.Fragment>
+			</>
 		</div>
 	);
 };

--- a/src/components/CommentForm/CommentForm.stories.tsx
+++ b/src/components/CommentForm/CommentForm.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Pillar } from '@guardian/types';
 
 import { CommentType } from '../../types';

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { css, cx } from 'emotion';
 
 import { palette, space } from '@guardian/src-foundations';
@@ -368,7 +368,7 @@ export const CommentForm = ({
 	}
 
 	return (
-		<>
+		<React.Fragment>
 			<form
 				className={formWrapper}
 				onSubmit={(e) => {
@@ -427,7 +427,7 @@ export const CommentForm = ({
 				/>
 				<div className={bottomContainer}>
 					<Row>
-						<>
+						<React.Fragment>
 							<PillarButton
 								pillar={pillar}
 								type="submit"
@@ -437,7 +437,7 @@ export const CommentForm = ({
 								Post your comment
 							</PillarButton>
 							{(isActive || body) && (
-								<>
+								<React.Fragment>
 									<Space amount={3} />
 									<PillarButton
 										pillar={pillar}
@@ -459,9 +459,9 @@ export const CommentForm = ({
 									>
 										Cancel
 									</PillarButton>
-								</>
+								</React.Fragment>
 							)}
-						</>
+						</React.Fragment>
 					</Row>
 					{isActive && (
 						<Row>
@@ -503,7 +503,7 @@ export const CommentForm = ({
 								className={commentAddOns}
 								data-link-name="formatting-controls-code"
 							>
-								{`<>`}
+								{`<React.Fragment>`}
 							</button>
 							<button
 								onClick={(e) => {
@@ -531,6 +531,6 @@ export const CommentForm = ({
 			</form>
 
 			{showPreview && <Preview previewHtml={previewBody} />}
-		</>
+		</React.Fragment>
 	);
 };

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { css, cx } from 'emotion';
 
 import { palette, space } from '@guardian/src-foundations';

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { css, cx } from 'emotion';
 
 import { palette, space } from '@guardian/src-foundations';
@@ -368,7 +368,7 @@ export const CommentForm = ({
 	}
 
 	return (
-		<React.Fragment>
+		<>
 			<form
 				className={formWrapper}
 				onSubmit={(e) => {
@@ -427,7 +427,7 @@ export const CommentForm = ({
 				/>
 				<div className={bottomContainer}>
 					<Row>
-						<React.Fragment>
+						<>
 							<PillarButton
 								pillar={pillar}
 								type="submit"
@@ -437,7 +437,7 @@ export const CommentForm = ({
 								Post your comment
 							</PillarButton>
 							{(isActive || body) && (
-								<React.Fragment>
+								<>
 									<Space amount={3} />
 									<PillarButton
 										pillar={pillar}
@@ -459,9 +459,9 @@ export const CommentForm = ({
 									>
 										Cancel
 									</PillarButton>
-								</React.Fragment>
+								</>
 							)}
-						</React.Fragment>
+						</>
 					</Row>
 					{isActive && (
 						<Row>
@@ -503,7 +503,7 @@ export const CommentForm = ({
 								className={commentAddOns}
 								data-link-name="formatting-controls-code"
 							>
-								{`<React.Fragment>`}
+								{`<>`}
 							</button>
 							<button
 								onClick={(e) => {
@@ -531,6 +531,6 @@ export const CommentForm = ({
 			</form>
 
 			{showPreview && <Preview previewHtml={previewBody} />}
-		</React.Fragment>
+		</>
 	);
 };

--- a/src/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Pillar } from '@guardian/types';
 
 import { CommentReplyPreview, Preview } from './CommentReplyPreview';

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { css } from 'emotion';
 
 import { textSans } from '@guardian/src-foundations/typography';

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { css } from 'emotion';
 
 import { textSans } from '@guardian/src-foundations/typography';
@@ -85,7 +85,7 @@ export const CommentReplyPreview = ({
 		false,
 	);
 	return (
-		<>
+		<React.Fragment>
 			<Row>
 				<div className={indentStyles}>
 					<SvgIndent />
@@ -112,7 +112,7 @@ export const CommentReplyPreview = ({
 					displayReplyComment={displayReplyComment}
 				/>
 			)}
-		</>
+		</React.Fragment>
 	);
 };
 

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { css } from 'emotion';
 
 import { textSans } from '@guardian/src-foundations/typography';
@@ -85,7 +85,7 @@ export const CommentReplyPreview = ({
 		false,
 	);
 	return (
-		<React.Fragment>
+		<>
 			<Row>
 				<div className={indentStyles}>
 					<SvgIndent />
@@ -112,7 +112,7 @@ export const CommentReplyPreview = ({
 					displayReplyComment={displayReplyComment}
 				/>
 			)}
-		</React.Fragment>
+		</>
 	);
 };
 

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { css } from 'emotion';
 
 import { Pillar } from '@guardian/types';

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 
 import { render, fireEvent, screen } from '@testing-library/react';

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { css, cx } from 'emotion';
 
 import FocusLock from 'react-focus-lock';

--- a/src/components/Filters/Filters.stories.tsx
+++ b/src/components/Filters/Filters.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Pillar } from '@guardian/types';
 

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from 'emotion';
 
 import { space } from '@guardian/src-foundations';

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.stories.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Pillar } from '@guardian/types';
 
 import { FirstCommentWelcome } from './FirstCommentWelcome';

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { css, cx } from 'emotion';
 import { textSans, headline } from '@guardian/src-foundations/typography';
 import { space, neutral } from '@guardian/src-foundations';
@@ -106,7 +106,7 @@ export const FirstCommentWelcome = ({
 					error={error}
 				/>
 				<Text>
-					<React.Fragment>
+					<>
 						Please keep your posts respectful and abide by the{' '}
 						<Link
 							href="/community-standards"
@@ -118,7 +118,7 @@ export const FirstCommentWelcome = ({
 						</Link>
 						{` -`} and if you spot a comment you think doesn’t adhere to the
 						guidelines, please use the ‘Report’ link next to it to let us know.
-					</React.Fragment>
+					</>
 				</Text>
 				<Text>
 					Please preview your comment below and click ‘post’ when you’re happy

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { css, cx } from 'emotion';
 import { textSans, headline } from '@guardian/src-foundations/typography';
 import { space, neutral } from '@guardian/src-foundations';
@@ -106,7 +106,7 @@ export const FirstCommentWelcome = ({
 					error={error}
 				/>
 				<Text>
-					<>
+					<React.Fragment>
 						Please keep your posts respectful and abide by the{' '}
 						<Link
 							href="/community-standards"
@@ -118,7 +118,7 @@ export const FirstCommentWelcome = ({
 						</Link>
 						{` -`} and if you spot a comment you think doesn’t adhere to the
 						guidelines, please use the ‘Report’ link next to it to let us know.
-					</>
+					</React.Fragment>
 				</Text>
 				<Text>
 					Please preview your comment below and click ‘post’ when you’re happy

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { css, cx } from 'emotion';
 import { textSans, headline } from '@guardian/src-foundations/typography';
 import { space, neutral } from '@guardian/src-foundations';

--- a/src/components/LoadingComments/LoadingComments.stories.tsx
+++ b/src/components/LoadingComments/LoadingComments.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { LoadingComments } from './LoadingComments';
 
 export default { component: LoadingComments, title: 'LoadingComments' };

--- a/src/components/LoadingComments/LoadingComments.tsx
+++ b/src/components/LoadingComments/LoadingComments.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css, keyframes } from 'emotion';
 
 import { space } from '@guardian/src-foundations';

--- a/src/components/LoadingPicks/LoadingPicks.stories.tsx
+++ b/src/components/LoadingPicks/LoadingPicks.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { LoadingPicks } from './LoadingPicks';
 
 export default { component: LoadingPicks, title: 'LoadingPicks' };

--- a/src/components/LoadingPicks/LoadingPicks.tsx
+++ b/src/components/LoadingPicks/LoadingPicks.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css, keyframes } from 'emotion';
 
 import { space } from '@guardian/src-foundations';

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Pagination } from './Pagination';
 
 import { FilterOptions } from '../../types';

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 
 import { FilterOptions } from '../../types';

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css, cx } from 'emotion';
 
 import { textSans } from '@guardian/src-foundations/typography';

--- a/src/components/PillarButton/PillarButton.stories.tsx
+++ b/src/components/PillarButton/PillarButton.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from 'emotion';
 
 import { space } from '@guardian/src-foundations';

--- a/src/components/PillarButton/PillarButton.tsx
+++ b/src/components/PillarButton/PillarButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from 'emotion';
 
 import { palette, neutral } from '@guardian/src-foundations';

--- a/src/components/Preview/Preview.stories.tsx
+++ b/src/components/Preview/Preview.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Preview } from './Preview';
 
 export default { component: Preview, title: 'Preview' };

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { css } from 'emotion';
 
 import { space, neutral } from '@guardian/src-foundations';
@@ -51,11 +52,11 @@ const spout = css`
 `;
 
 export const Preview = ({ previewHtml }: Props) => (
-	<>
+	<React.Fragment>
 		<div className={spout} />
 		<p
 			className={previewStyle}
 			dangerouslySetInnerHTML={{ __html: previewHtml || '' }}
 		/>
-	</>
+	</React.Fragment>
 );

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from 'emotion';
 
 import { space, neutral } from '@guardian/src-foundations';

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from 'emotion';
 
 import { space, neutral } from '@guardian/src-foundations';
@@ -52,11 +51,11 @@ const spout = css`
 `;
 
 export const Preview = ({ previewHtml }: Props) => (
-	<React.Fragment>
+	<>
 		<div className={spout} />
 		<p
 			className={previewStyle}
 			dangerouslySetInnerHTML={{ __html: previewHtml || '' }}
 		/>
-	</React.Fragment>
+	</>
 );

--- a/src/components/RecommendationCount/RecommendationCount.stories.tsx
+++ b/src/components/RecommendationCount/RecommendationCount.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { RecommendationCount } from './RecommendationCount';
 
 export default { title: 'RecommendationCount' };

--- a/src/components/RecommendationCount/RecommendationCount.tsx
+++ b/src/components/RecommendationCount/RecommendationCount.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { css } from 'emotion';
 
 import { textSans } from '@guardian/src-foundations/typography';

--- a/src/components/Row/Row.tsx
+++ b/src/components/Row/Row.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from 'emotion';
 
 type Props = { children: React.ReactNode };

--- a/src/components/Timestamp/Timestamp.stories.tsx
+++ b/src/components/Timestamp/Timestamp.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Timestamp } from './Timestamp';
 
 export default { component: Timestamp, title: 'Timestamp' };

--- a/src/components/Timestamp/Timestamp.tsx
+++ b/src/components/Timestamp/Timestamp.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { css } from 'emotion';
 
 import { textSans } from '@guardian/src-foundations/typography';

--- a/src/components/TopPick/TopPick.stories.tsx
+++ b/src/components/TopPick/TopPick.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from 'emotion';
 
 import { Pillar } from '@guardian/types';

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css, cx } from 'emotion';
 
 import { from } from '@guardian/src-foundations/mq';

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { css, cx } from 'emotion';
 
 import { from } from '@guardian/src-foundations/mq';
@@ -228,7 +229,7 @@ export const TopPick = ({
 						.length ? (
 						<GuardianStaff />
 					) : (
-						<></>
+						<React.Fragment></React.Fragment>
 					)}
 				</Column>
 			</Row>

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css, cx } from 'emotion';
 
 import { from } from '@guardian/src-foundations/mq';
@@ -229,7 +228,7 @@ export const TopPick = ({
 						.length ? (
 						<GuardianStaff />
 					) : (
-						<React.Fragment></React.Fragment>
+						<></>
 					)}
 				</Column>
 			</Row>

--- a/src/components/TopPicks/TopPicks.stories.tsx
+++ b/src/components/TopPicks/TopPicks.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Pillar } from '@guardian/types';
 
 import { CommentType } from '../../types';

--- a/src/components/TopPicks/TopPicks.tsx
+++ b/src/components/TopPicks/TopPicks.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css, cx } from 'emotion';
 
 import { until, from } from '@guardian/src-foundations/mq';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 
 import { pillarToEnum } from './lib/pillarToEnum';
@@ -30,7 +30,7 @@ const IndexPageWrapper = () => {
 	}
 
 	return (
-		<React.Fragment>
+		<>
 			<h1>Example Discussion</h1>
 			<p>
 				Set a specific discussion using the id in a query param like{' '}
@@ -53,7 +53,7 @@ const IndexPageWrapper = () => {
 				onPermalinkClick={() => {}}
 				apiKey="discussion-rendering"
 			/>
-		</React.Fragment>
+		</>
 	);
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 
 import { pillarToEnum } from './lib/pillarToEnum';
@@ -30,7 +30,7 @@ const IndexPageWrapper = () => {
 	}
 
 	return (
-		<>
+		<React.Fragment>
 			<h1>Example Discussion</h1>
 			<p>
 				Set a specific discussion using the id in a query param like{' '}
@@ -53,7 +53,7 @@ const IndexPageWrapper = () => {
 				onPermalinkClick={() => {}}
 				apiKey="discussion-rendering"
 			/>
-		</>
+		</React.Fragment>
 	);
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 
 import { pillarToEnum } from './lib/pillarToEnum';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
         "outDir": "build",
         "strict": true,
         "esModuleInterop": true,
-        "jsx": "react",
+        "jsx": "react-jsx",
         "moduleResolution": "node",
         "allowJs": true,
         "skipLibCheck": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -379,7 +379,7 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
-"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.12.5", "@babel/helper-module-imports@^7.7.0", "@babel/helper-module-imports@^7.7.4":
+"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.12.5", "@babel/helper-module-imports@^7.7.4":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz#1bfc0229f794988f76ed0a4d4e90860850b54dfb"
   integrity sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
@@ -2151,24 +2151,6 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@emotion/babel-plugin@^11.1.2":
-  version "11.1.2"
-  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.1.2.tgz#68fe1aa3130099161036858c64ee92056c6730b7"
-  integrity sha512-Nz1k7b11dWw8Nw4Z1R99A9mlB6C6rRsCtZnwNUOj4NsoZdrO2f2A/83ST7htJORD5zpOiLKY59aJN23092949w==
-  dependencies:
-    "@babel/helper-module-imports" "^7.7.0"
-    "@babel/plugin-syntax-jsx" "^7.12.1"
-    "@babel/runtime" "^7.7.2"
-    "@emotion/hash" "^0.8.0"
-    "@emotion/memoize" "^0.7.5"
-    "@emotion/serialize" "^1.0.0"
-    babel-plugin-macros "^2.6.1"
-    convert-source-map "^1.5.0"
-    escape-string-regexp "^4.0.0"
-    find-root "^1.1.0"
-    source-map "^0.5.7"
-    stylis "^4.0.3"
-
 "@emotion/cache@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.27.tgz#7895db204e2c1a991ae33d51262a3a44f6737303"
@@ -2217,7 +2199,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.4.tgz#f14932887422c9056b15a8d222a9074a7dfa2831"
   integrity sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A==
 
-"@emotion/hash@0.8.0", "@emotion/hash@^0.8.0":
+"@emotion/hash@0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
@@ -2233,11 +2215,6 @@
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
-
-"@emotion/memoize@^0.7.4", "@emotion/memoize@^0.7.5":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
-  integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
 
 "@emotion/serialize@^0.11.15":
   version "0.11.15"
@@ -2260,17 +2237,6 @@
     "@emotion/unitless" "0.7.5"
     "@emotion/utils" "0.11.3"
     csstype "^2.5.7"
-
-"@emotion/serialize@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.0.tgz#1a61f4f037cf39995c97fc80ebe99abc7b191ca9"
-  integrity sha512-zt1gm4rhdo5Sry8QpCOpopIUIKU+mUSpV9WNmFILUraatm5dttNEaYzUWWSboSMUE6PtN2j1cAsuvcugfdI3mw==
-  dependencies:
-    "@emotion/hash" "^0.8.0"
-    "@emotion/memoize" "^0.7.4"
-    "@emotion/unitless" "^0.7.5"
-    "@emotion/utils" "^1.0.0"
-    csstype "^3.0.2"
 
 "@emotion/sheet@0.9.4":
   version "0.9.4"
@@ -2300,7 +2266,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
   integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
 
-"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.5":
+"@emotion/unitless@0.7.5":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
@@ -2309,11 +2275,6 @@
   version "0.11.3"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.3.tgz#a759863867befa7e583400d322652a3f44820924"
   integrity sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==
-
-"@emotion/utils@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.0.0.tgz#abe06a83160b10570816c913990245813a2fd6af"
-  integrity sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA==
 
 "@emotion/weak-memoize@0.2.5":
   version "0.2.5"
@@ -5313,7 +5274,7 @@ babel-plugin-macros@2.7.1:
     cosmiconfig "^6.0.0"
     resolve "^1.12.0"
 
-babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.6.1, babel-plugin-macros@^2.8.0:
+babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz#0f958a7cc6556b1e65344465d99111a1e5e10138"
   integrity sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==
@@ -17653,11 +17614,6 @@ stylehacks@^4.0.0:
     browserslist "^4.0.0"
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
-
-stylis@^4.0.3:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.7.tgz#412a90c28079417f3d27c028035095e4232d2904"
-  integrity sha512-OFFeUXFgwnGOKvEXaSv0D0KQ5ADP0n6g3SVONx6I/85JzNZ3u50FRwB3lVIk1QO2HNdI75tbVzc4Z66Gdp9voA==
 
 supports-color@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1021,13 +1021,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-syntax-jsx@^7.2.0":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.8.3.tgz#521b06c83c40480f1e58b4fd33b92eceb1d6ea94"
-  integrity sha512-WxdW9xyLgBdefoo0Ynn3MRSkhe5tFVxxKNVdnZSh318WrG2e2jH+E9wd/++JsqcLJZPfz87njQJ8j2Upjm0M0A==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.8.3"
-
 "@babel/plugin-syntax-logical-assignment-operators@^7.10.4", "@babel/plugin-syntax-logical-assignment-operators@^7.8.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz#ca91ef46303530448b906652bac2e9fe9941f699"
@@ -1541,7 +1534,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-react-jsx@^7.12.1", "@babel/plugin-transform-react-jsx@^7.3.0", "@babel/plugin-transform-react-jsx@^7.7.4":
+"@babel/plugin-transform-react-jsx@^7.12.1", "@babel/plugin-transform-react-jsx@^7.7.4":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.1.tgz#c2d96c77c2b0e4362cc4e77a43ce7c2539d478cb"
   integrity sha512-RmKejwnT0T0QzQUzcbP5p1VWlpnP8QHtdhEtLG55ZDQnJNalbF3eeDyu3dnGKvGzFIQiBzFhBYTwvv435p9Xpw==
@@ -2158,13 +2151,6 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@emotion/babel-plugin-jsx-pragmatic@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin-jsx-pragmatic/-/babel-plugin-jsx-pragmatic-0.1.5.tgz#27debfe9c27c4d83574d509787ae553bf8a34d7e"
-  integrity sha512-y+3AJ0SItMDaAgGPVkQBC/S/BaqaPACkQ6MyCI2CUlrjTxKttTVfD3TMtcs7vLEcLxqzZ1xiG0vzwCXjhopawQ==
-  dependencies:
-    "@babel/plugin-syntax-jsx" "^7.2.0"
-
 "@emotion/babel-plugin@^11.1.2":
   version "11.1.2"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.1.2.tgz#68fe1aa3130099161036858c64ee92056c6730b7"
@@ -2182,16 +2168,6 @@
     find-root "^1.1.0"
     source-map "^0.5.7"
     stylis "^4.0.3"
-
-"@emotion/babel-preset-css-prop@^10.0.14":
-  version "10.0.27"
-  resolved "https://registry.yarnpkg.com/@emotion/babel-preset-css-prop/-/babel-preset-css-prop-10.0.27.tgz#58868d9a6afee0eeaeb0fa9dc5ccb1b12d4f786b"
-  integrity sha512-rducrjTpLGDholp0l2l4pXqpzAqYYGMg/x4IteO0db2smf6zegn6RRZdDnbaoMSs63tfPWgo2WukT1/F1gX/AA==
-  dependencies:
-    "@babel/plugin-transform-react-jsx" "^7.3.0"
-    "@babel/runtime" "^7.5.5"
-    "@emotion/babel-plugin-jsx-pragmatic" "^0.1.5"
-    babel-plugin-emotion "^10.0.27"
 
 "@emotion/cache@^10.0.27":
   version "10.0.27"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,14 +9,14 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.5.5":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
   integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.12.11":
+"@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
   integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
@@ -140,14 +140,7 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@babel/helper-annotate-as-pure@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz#5bf0d495a3f757ac3bda48b5bf3b3ba309c72ba3"
-  integrity sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==
-  dependencies:
-    "@babel/types" "^7.10.4"
-
-"@babel/helper-annotate-as-pure@^7.12.10":
+"@babel/helper-annotate-as-pure@^7.10.4", "@babel/helper-annotate-as-pure@^7.12.10":
   version "7.12.10"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.10.tgz#54ab9b000e60a93644ce17b3f37d313aaf1d115d"
   integrity sha512-XplmVbC1n+KY6jL8/fgLVXXUauDIB+lD5+GsQEh6F6GBF1dq1qy4DP4yXWzDKcoqXB3X58t61e85Fitoww4JVQ==
@@ -386,7 +379,7 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
-"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.12.5", "@babel/helper-module-imports@^7.7.4":
+"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.12.5", "@babel/helper-module-imports@^7.7.0", "@babel/helper-module-imports@^7.7.4":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz#1bfc0229f794988f76ed0a4d4e90860850b54dfb"
   integrity sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
@@ -549,14 +542,14 @@
   dependencies:
     "@babel/types" "^7.12.1"
 
-"@babel/helper-split-export-declaration@^7.10.4", "@babel/helper-split-export-declaration@^7.11.0":
+"@babel/helper-split-export-declaration@^7.10.4":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz#f8a491244acf6a676158ac42072911ba83ad099f"
   integrity sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==
   dependencies:
     "@babel/types" "^7.11.0"
 
-"@babel/helper-split-export-declaration@^7.12.11":
+"@babel/helper-split-export-declaration@^7.11.0", "@babel/helper-split-export-declaration@^7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz#1b4cc424458643c47d37022223da33d76ea4603a"
   integrity sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==
@@ -577,12 +570,7 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
-"@babel/helper-validator-identifier@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
-  integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
-
-"@babel/helper-validator-identifier@^7.12.11":
+"@babel/helper-validator-identifier@^7.10.4", "@babel/helper-validator-identifier@^7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
   integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
@@ -638,12 +626,12 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.11.5", "@babel/parser@^7.4.3", "@babel/parser@^7.7.4", "@babel/parser@^7.7.5":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.11.5", "@babel/parser@^7.4.3", "@babel/parser@^7.7.4", "@babel/parser@^7.7.5":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
   integrity sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
 
-"@babel/parser@^7.12.10", "@babel/parser@^7.12.11", "@babel/parser@^7.12.3", "@babel/parser@^7.12.7":
+"@babel/parser@^7.10.4", "@babel/parser@^7.12.10", "@babel/parser@^7.12.11", "@babel/parser@^7.12.3", "@babel/parser@^7.12.7":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.11.tgz#9ce3595bcd74bc5c466905e86c535b8b25011e79"
   integrity sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==
@@ -1997,7 +1985,7 @@
     "@babel/plugin-transform-react-jsx-source" "^7.12.1"
     "@babel/plugin-transform-react-pure-annotations" "^7.12.1"
 
-"@babel/preset-react@^7.12.1":
+"@babel/preset-react@^7.12.1", "@babel/preset-react@^7.12.10":
   version "7.12.10"
   resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.12.10.tgz#4fed65f296cbb0f5fb09de6be8cddc85cc909be9"
   integrity sha512-vtQNjaHRl4DUpp+t+g4wvTHsLQuye+n0H/wsXIZRn69oz/fvNC7gQ4IK73zGJBaxvHoxElDvnYCthMcT7uzFoQ==
@@ -2066,16 +2054,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.10.4", "@babel/template@^7.3.3", "@babel/template@^7.4.0", "@babel/template@^7.7.4", "@babel/template@^7.8.3":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
-  integrity sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/parser" "^7.10.4"
-    "@babel/types" "^7.10.4"
-
-"@babel/template@^7.12.7":
+"@babel/template@^7.10.4", "@babel/template@^7.12.7":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.7.tgz#c817233696018e39fbb6c491d2fb684e05ed43bc"
   integrity sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==
@@ -2083,6 +2062,15 @@
     "@babel/code-frame" "^7.10.4"
     "@babel/parser" "^7.12.7"
     "@babel/types" "^7.12.7"
+
+"@babel/template@^7.3.3", "@babel/template@^7.4.0", "@babel/template@^7.7.4", "@babel/template@^7.8.3":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
+  integrity sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/parser" "^7.10.4"
+    "@babel/types" "^7.10.4"
 
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.10.4", "@babel/traverse@^7.11.5", "@babel/traverse@^7.4.3", "@babel/traverse@^7.7.4", "@babel/traverse@^7.8.3":
   version "7.11.5"
@@ -2114,7 +2102,7 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/types@^7.0.0", "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.11.5", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.4", "@babel/types@^7.8.3":
+"@babel/types@^7.0.0", "@babel/types@^7.10.5", "@babel/types@^7.11.5", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.4", "@babel/types@^7.8.3":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.11.5.tgz#d9de577d01252d77c6800cee039ee64faf75662d"
   integrity sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==
@@ -2123,16 +2111,7 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.12.1":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.1.tgz#e109d9ab99a8de735be287ee3d6a9947a190c4ae"
-  integrity sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.10.4"
-    lodash "^4.17.19"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.12.10", "@babel/types@^7.12.11", "@babel/types@^7.12.12", "@babel/types@^7.12.5", "@babel/types@^7.12.7":
+"@babel/types@^7.10.4", "@babel/types@^7.11.0", "@babel/types@^7.12.1", "@babel/types@^7.12.10", "@babel/types@^7.12.11", "@babel/types@^7.12.12", "@babel/types@^7.12.5", "@babel/types@^7.12.7":
   version "7.12.12"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.12.tgz#4608a6ec313abbd87afa55004d373ad04a96c299"
   integrity sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==
@@ -2186,6 +2165,24 @@
   dependencies:
     "@babel/plugin-syntax-jsx" "^7.2.0"
 
+"@emotion/babel-plugin@^11.1.2":
+  version "11.1.2"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.1.2.tgz#68fe1aa3130099161036858c64ee92056c6730b7"
+  integrity sha512-Nz1k7b11dWw8Nw4Z1R99A9mlB6C6rRsCtZnwNUOj4NsoZdrO2f2A/83ST7htJORD5zpOiLKY59aJN23092949w==
+  dependencies:
+    "@babel/helper-module-imports" "^7.7.0"
+    "@babel/plugin-syntax-jsx" "^7.12.1"
+    "@babel/runtime" "^7.7.2"
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.5"
+    "@emotion/serialize" "^1.0.0"
+    babel-plugin-macros "^2.6.1"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^4.0.0"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+    stylis "^4.0.3"
+
 "@emotion/babel-preset-css-prop@^10.0.14":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/babel-preset-css-prop/-/babel-preset-css-prop-10.0.27.tgz#58868d9a6afee0eeaeb0fa9dc5ccb1b12d4f786b"
@@ -2205,6 +2202,18 @@
     "@emotion/stylis" "0.8.5"
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
+
+"@emotion/core@10.0.35":
+  version "10.0.35"
+  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.35.tgz#513fcf2e22cd4dfe9d3894ed138c9d7a859af9b3"
+  integrity sha512-sH++vJCdk025fBlRZSAhkRlSUoqSqgCzYf5fMOmqqi3bM6how+sQpg3hkgJonj8GxXM4WbD7dRO+4tegDB9fUw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/cache" "^10.0.27"
+    "@emotion/css" "^10.0.27"
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/sheet" "0.9.4"
+    "@emotion/utils" "0.11.3"
 
 "@emotion/core@^10.1.1":
   version "10.1.1"
@@ -2232,7 +2241,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.4.tgz#f14932887422c9056b15a8d222a9074a7dfa2831"
   integrity sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A==
 
-"@emotion/hash@0.8.0":
+"@emotion/hash@0.8.0", "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
@@ -2248,6 +2257,11 @@
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
+"@emotion/memoize@^0.7.4", "@emotion/memoize@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
+  integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
 
 "@emotion/serialize@^0.11.15":
   version "0.11.15"
@@ -2270,6 +2284,17 @@
     "@emotion/unitless" "0.7.5"
     "@emotion/utils" "0.11.3"
     csstype "^2.5.7"
+
+"@emotion/serialize@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.0.tgz#1a61f4f037cf39995c97fc80ebe99abc7b191ca9"
+  integrity sha512-zt1gm4rhdo5Sry8QpCOpopIUIKU+mUSpV9WNmFILUraatm5dttNEaYzUWWSboSMUE6PtN2j1cAsuvcugfdI3mw==
+  dependencies:
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/unitless" "^0.7.5"
+    "@emotion/utils" "^1.0.0"
+    csstype "^3.0.2"
 
 "@emotion/sheet@0.9.4":
   version "0.9.4"
@@ -2299,7 +2324,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
   integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
 
-"@emotion/unitless@0.7.5":
+"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.5":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
@@ -2308,6 +2333,11 @@
   version "0.11.3"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.3.tgz#a759863867befa7e583400d322652a3f44820924"
   integrity sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==
+
+"@emotion/utils@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.0.0.tgz#abe06a83160b10570816c913990245813a2fd6af"
+  integrity sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA==
 
 "@emotion/weak-memoize@0.2.5":
   version "0.2.5"
@@ -3997,10 +4027,17 @@
     "@types/react" "*"
     "@types/reactcss" "*"
 
-"@types/react-dom@*", "@types/react-dom@^16.9.5":
+"@types/react-dom@*":
   version "16.9.8"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"
   integrity sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-dom@^17.0.0":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.0.tgz#b3b691eb956c4b3401777ee67b900cb28415d95a"
+  integrity sha512-lUqY7OlkF/RbNtD5nIq7ot8NquXrdFrjSOR6+w9a9RFQevGi1oZO1dcJbXMeONAPKtZ2UrZOEJ5UOCVsxbLk/g==
   dependencies:
     "@types/react" "*"
 
@@ -4011,13 +4048,21 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.9.34":
+"@types/react@*":
   version "16.9.34"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.34.tgz#f7d5e331c468f53affed17a8a4d488cd44ea9349"
   integrity sha512-8AJlYMOfPe1KGLKyHpflCg5z46n0b5DbRfqDksxBLBTUpB75ypDBAO9eCUcjNwE6LCUslwTz00yyG/X9gaVtow==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/react@^17.0.0":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
+  integrity sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
 
 "@types/reactcss@*":
   version "1.2.3"
@@ -5292,7 +5337,7 @@ babel-plugin-macros@2.7.1:
     cosmiconfig "^6.0.0"
     resolve "^1.12.0"
 
-babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.8.0:
+babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.6.1, babel-plugin-macros@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz#0f958a7cc6556b1e65344465d99111a1e5e10138"
   integrity sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==
@@ -7175,6 +7220,11 @@ csstype@^2.2.0, csstype@^2.5.7:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.8.tgz#0fb6fc2417ffd2816a418c9336da74d7f07db431"
   integrity sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==
 
+csstype@^3.0.2:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.6.tgz#865d0b5833d7d8d40f4e5b8a6d76aea3de4725ef"
+  integrity sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw==
+
 customize-cra@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/customize-cra/-/customize-cra-1.0.0.tgz#73286563631aa08127ad4d30a2e3c89cf4e93c8d"
@@ -7251,12 +7301,19 @@ debug@^3.0.0, debug@^3.0.1, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.1, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.1.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
 
 decamelize-keys@^1.1.0:
   version "1.1.0"
@@ -9171,9 +9228,9 @@ gauge@~2.7.3:
     wide-align "^1.1.0"
 
 gensync@^1.0.0-beta.1:
-  version "1.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
-  integrity sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
+  integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
 get-caller-file@^1.0.1:
   version "1.0.3"
@@ -12062,7 +12119,7 @@ json3@^3.3.2:
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
   integrity sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
 
-json5@2.x, json5@^2.1.0, json5@^2.1.1, json5@^2.1.2:
+json5@2.x, json5@^2.1.0, json5@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
   integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
@@ -12075,6 +12132,13 @@ json5@^1.0.1:
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
+
+json5@^2.1.2:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
+  dependencies:
+    minimist "^1.2.5"
 
 jsonfile@^2.1.0:
   version "2.4.0"
@@ -12431,7 +12495,7 @@ lodash.isequal@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
-lodash.memoize@4.x, lodash.memoize@^4.1.2:
+lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
@@ -12471,7 +12535,7 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
 
-"lodash@>=3.5 <5", lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5:
+lodash@4.x, "lodash@>=3.5 <5", lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -13138,10 +13202,15 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-ms@^2.1.1:
+ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
@@ -15630,15 +15699,14 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@^16.12.0:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
-  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
+react-dom@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
+  integrity sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "^0.20.1"
 
 react-draggable@^4.0.3:
   version "4.4.3"
@@ -15837,14 +15905,13 @@ react-textarea-autosize@^8.1.1:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react@^16.13.1:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
+react@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
+  integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 reactcss@^1.2.0:
   version "1.2.3"
@@ -16653,10 +16720,10 @@ saxes@^5.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+scheduler@^0.20.1:
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.1.tgz#da0b907e24026b01181ecbc75efdc7f27b5a000c"
+  integrity sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -17611,6 +17678,11 @@ stylehacks@^4.0.0:
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
 
+stylis@^4.0.3:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.7.tgz#412a90c28079417f3d27c028035095e4232d2904"
+  integrity sha512-OFFeUXFgwnGOKvEXaSv0D0KQ5ADP0n6g3SVONx6I/85JzNZ3u50FRwB3lVIk1QO2HNdI75tbVzc4Z66Gdp9voA==
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -18083,9 +18155,9 @@ ts-essentials@^2.0.3:
   integrity sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==
 
 ts-jest@^26.4.4:
-  version "26.4.4"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.4.4.tgz#61f13fb21ab400853c532270e52cc0ed7e502c49"
-  integrity sha512-3lFWKbLxJm34QxyVNNCgXX1u4o/RV0myvA2y2Bxm46iGIjKlaY0own9gIckbjZJPn+WaJEnfPPJ20HHGpoq4yg==
+  version "26.5.0"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.0.tgz#3e3417d91bc40178a6716d7dacc5b0505835aa21"
+  integrity sha512-Ya4IQgvIFNa2Mgq52KaO8yBw2W8tWp61Ecl66VjF0f5JaV8u50nGoptHVILOPGoI7SDnShmEqnYQEmyHdQ+56g==
   dependencies:
     "@types/jest" "26.x"
     bs-logger "0.x"
@@ -18093,7 +18165,7 @@ ts-jest@^26.4.4:
     fast-json-stable-stringify "2.x"
     jest-util "^26.1.0"
     json5 "2.x"
-    lodash.memoize "4.x"
+    lodash "4.x"
     make-error "1.x"
     mkdirp "1.x"
     semver "7.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5189,7 +5189,7 @@ babel-plugin-dynamic-import-node@^2.3.3:
   dependencies:
     object.assign "^4.1.0"
 
-babel-plugin-emotion@^10.0.20, babel-plugin-emotion@^10.0.33:
+babel-plugin-emotion@^10.0.20:
   version "10.0.33"
   resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz#ce1155dcd1783bbb9286051efee53f4e2be63e03"
   integrity sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==


### PR DESCRIPTION
## What does this change?
Update to React 17 and remove `React` from import scope

## Why?
Emotion 10 uses JSX pragma, and `React` 17 favors JSX over JS. To make Emotion upgrade easier, we should first update `React`

## Changes
- Update React, react types
- Add `@emotion/core` ~(used for JSX)~
- Update `@babel/preset-react`
- ~change `<>` to `<React.Fragment>` as Emotion JSX doesnt pick up fragments: https://github.com/emotion-js/emotion/issues/1706#issuecomment-573317202~
- Remove the need for `import React` (unless `Fragment` used)

## Link to supporting Trello card
https://trello.com/c/Wlpg47zl/2410-update-to-react-17