### PR TITLE
Determine verison of TS being used from node_modules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,8 @@
     "source.fixAll.eslint": true
   },
   "workbench.colorCustomizations": {
-        "titleBar.activeBackground": "#DC267F",
-        "titleBar.activeForeground": "#000000"
-    }
+    "titleBar.activeBackground": "#DC267F",
+    "titleBar.activeForeground": "#000000"
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
## What does this change?
Determins TS version on VSCode from `node_modules`

## Why?
Avoids having the wrong errors on IDE due to mismatch of what TS version is running
