### PR TITLE
toString the data we POST to fix Chrome 49 bug

### DIFF
--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -104,7 +104,7 @@ export const preview = (body: string): Promise<string> => {
 
 	return fetch(url, {
 		method: 'POST',
-		body: data,
+		body: data.toString(),
 		headers: {
 			'Content-Type': 'application/x-www-form-urlencoded',
 			...options.headers,
@@ -141,7 +141,7 @@ export const comment = (
 
 	return fetch(url, {
 		method: 'POST',
-		body: data,
+		body: data.toString(),
 		headers: {
 			'Content-Type': 'application/x-www-form-urlencoded',
 			...options.headers,
@@ -169,7 +169,7 @@ export const reply = (
 
 	return fetch(url, {
 		method: 'POST',
-		body: data,
+		body: data.toString(),
 		headers: {
 			'Content-Type': 'application/x-www-form-urlencoded',
 			...options.headers,
@@ -215,7 +215,7 @@ export const reportAbuse = ({
 
 	return fetch(url, {
 		method: 'POST',
-		body: data,
+		body: data.toString(),
 		headers: {
 			'Content-Type': 'application/x-www-form-urlencoded',
 			...options.headers,


### PR DESCRIPTION
## What does this change?
Post requests from discussion were failing because they were not sending a body with the request, this meant that users are not able to post, preview or report comments on Chrome 49.

- We can only replicate this in Chrome 49 (Though older Chrome browsers have different issues)
- URLSearchParams was only added in Chrome 49

We were able to replicate the issue in the console with the following:

```js
const body = new URLSearchParams();
body.append('body', 'this is a comment')
fetch(anyUrl, {
  method: 'POST',
  body: searchParams
})
```

This sends a request with *no body*.

We were able to prove that the issue was within Guardian JS, by replicating this request on google.com and ft.com in the console, where we saw a request sent with a body as expected.

We *did* see this on both DCR and Frontend platforms.

Fetch requests are routed through several interceptors in the JS:
- Sourcepoint
- Polyfill
- Raven (from the commercial bundle)

To try and identify the culprit:

- We changed our locale so that the sourcepoint JS did not capture the fetch
- We removed the commercial bundle and tested on CODE to see the request without raven
- We updated our Polyfill request to explicitly include `URLSearchParams' and `es5`. 

None of the above seem to make a difference and the fetch request.

We were unable to further identify what was capturing the request and causing this issue.

Finally, we came to the conclusion that we could either manually build up the request as per the [comment here](https://github.com/github/fetch/issues/263#issuecomment-209548790) or simply `toString` the `URLSearchParams`, essentially ensuring that our body is a string and not confusing whatever is intercepting this request.

We decided on the simpler approach of `toString`.

## Link to supporting Trello card
https://trello.com/c/UEN8nirg/2477-commenting-on-chrome-49-not-working