### PR TITLE
Remove yarn tsc command

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "pretty-quick --staged && yarn lint && yarn createTsDec && yarn test --watchAll=false && yarn prettier:check"
+      "pre-push": "pretty-quick --staged && yarn lint && yarn build && yarn test --watchAll=false && yarn prettier:check"
     }
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "start": "react-app-rewired start",
     "build": "rollup --config && yarn createTsDec",
     "test": "jest",
-    "tsc": "tsc",
     "validate": "yarn tsc && yarn test && yarn lint",
     "eject": "react-scripts eject",
     "prettier:check": "prettier . --check",
@@ -134,7 +133,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "pretty-quick --staged && yarn lint && yarn tsc && yarn test --watchAll=false && yarn prettier:check"
+      "pre-push": "pretty-quick --staged && yarn lint && yarn createTsDec && yarn test --watchAll=false && yarn prettier:check"
     }
   },
   "jest": {


### PR DESCRIPTION
## What does this change?
- remove `yarn tsc` command
- `pre-push` uses `yarn build` instead of `yarn tsc`

## Why?
- We want to check that the build works, we should use our command to do that check instead of `yarn tsc` 
- When running `yarn tsc` without options, we would compile `xx.test.tsx` files as well, that in turn would be picked up by Jest

