### PR TITLE
Fix yarn start

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "typescript": "^4.1.3"
   },
   "scripts": {
-    "start": "react-app-rewired start",
+    "start": "SKIP_PREFLIGHT_CHECK=true react-app-rewired start",
     "build": "rollup --config && yarn createTsDec",
     "test": "jest",
     "tsc": "tsc",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,33 @@
 {
-    "compilerOptions": {
-        "target": "esnext",
-        "module": "esnext",
-        "lib": ["es2017", "es7", "es6", "dom", "DOM.Iterable"],
-        "outDir": "build",
-        "strict": true,
-        "esModuleInterop": true,
-        "jsx": "react-jsx",
-        "jsxImportSource": "@emotion/react",
-        "moduleResolution": "node",
-        "allowJs": true,
-        "skipLibCheck": true,
-        "allowSyntheticDefaultImports": true,
-        "forceConsistentCasingInFileNames": true,
-        "resolveJsonModule": true,
-        "isolatedModules": false,
-        "noEmit": false,
-    },
-    "files": ["src/types.ts"],
-    "include": ["src/"],
-    "exclude": []
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "lib": [
+      "es2017",
+      "es7",
+      "es6",
+      "dom",
+      "DOM.Iterable"
+    ],
+    "outDir": "build",
+    "strict": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "@emotion/react",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "files": [
+    "src/types.ts"
+  ],
+  "include": [
+    "src/"
+  ],
+  "exclude": []
 }


### PR DESCRIPTION
## What does this change?
Add `SKIP_PREFLIGHT_CHECK= true` before `react-app-rewired start`

## Why?
`react-app-rewired` isnt actively maintained, and since we have updated other packages, it complains that the dependencies are not the versions it expects. Although this isnt ideal, `babel-loader` has not had a major version jump, and we do not use `react-app-rewired` for jest, so the incompatability is minor. Plus `react-app-rewired` seems to work fine
