### PR TITLE
Remove react-app-rewired

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "babel-plugin-emotion": "^10.0.33",
     "customize-cra": "^1.0.0",
-    "react-app-rewired": "^2.1.6",
     "react-focus-lock": "^2.2.1",
     "timeago.js": "^4.0.2"
   },
@@ -93,7 +92,6 @@
     "typescript": "^4.1.3"
   },
   "scripts": {
-    "start": "react-app-rewired start",
     "build": "rollup --config && yarn createTsDec",
     "test": "jest",
     "tsc": "tsc",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16171,13 +16171,6 @@ react-app-polyfill@^1.0.5:
     regenerator-runtime "^0.13.3"
     whatwg-fetch "^3.0.0"
 
-react-app-rewired@^2.1.6:
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/react-app-rewired/-/react-app-rewired-2.1.8.tgz#e192f93b98daf96889418d33d3e86cf863812b56"
-  integrity sha512-wjXPdKPLscA7mn0I1de1NHrbfWdXz4S1ladaGgHVKdn1hTgKK5N6EdGIJM0KrS6bKnJBj7WuqJroDTsPKKr66Q==
-  dependencies:
-    semver "^5.6.0"
-
 react-clientside-effect@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz#6212fb0e07b204e714581dd51992603d1accc837"


### PR DESCRIPTION
## What does this change?
- remove `react-app-rewired`
- remove `yarn start` command

## Why?
We should use storybook instead of `react-app-rewired`

