### PR TITLE
Add onExpanded prop to track expanding time

### DIFF
--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -42,6 +42,9 @@ export const LoggedOutHiddenPicks = () => (
 			expanded={false}
 			onPermalinkClick={() => {}}
 			apiKey=""
+			onExpanded={(expandedTime) => {
+				console.log(expandedTime);
+			}}
 		/>
 	</div>
 );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ type Props = {
 		parentCommentId: number,
 	) => Promise<CommentResponse>;
 	onPreview?: (body: string) => Promise<string>;
+	onExpanded?: (expandedTime: number) => void;
 };
 
 const footerStyles = css`
@@ -211,7 +212,7 @@ const writeMutes = (mutes: string[]) => {
 		// capture these errors
 	}
 };
-
+let expandedStartTime: number;
 export const App = ({
 	baseUrl,
 	shortUrl,
@@ -230,6 +231,7 @@ export const App = ({
 	onComment,
 	onReply,
 	onPreview,
+	onExpanded,
 }: Props) => {
 	const [filters, setFilters] = useState<FilterOptions>(
 		initialiseFilters({
@@ -252,6 +254,16 @@ export const App = ({
 	const [commentCount, setCommentCount] = useState<number>(0);
 	const [mutes, setMutes] = useState<string[]>(readMutes());
 
+	useEffect(() => {
+		if (
+			isExpanded &&
+			onExpanded &&
+			window.performance &&
+			window.performance.now
+		) {
+			onExpanded(window.performance.now() - expandedStartTime);
+		}
+	}, [isExpanded]);
 	useEffect(() => {
 		setLoading(true);
 		getDiscussion(shortUrl, { ...filters, page }).then((json) => {
@@ -335,6 +347,10 @@ export const App = ({
 	};
 
 	const expandView = () => {
+		if (window.performance && window.performance.now) {
+			expandedStartTime = window.performance.now();
+		}
+
 		setIsExpanded(true);
 	};
 


### PR DESCRIPTION
## What does this change?

Adds the `onExpanded` prop to the App.tsx to allow tracking of click -> expand complete timings of the comment list. It was released in https://github.com/guardian/discussion-rendering/releases/tag/v6.1.4-2 to get data for pre-emotion-11 discussion, and needs to be in main for us to capture the data post-7.x version which will contain React and Emotion upgarades.

## Why?

We saw slow downs in rendering times between Emotion 10 and 11. We wanted to see if that equates to RUM.