### PR TITLE
Optimistically render first 10 comments and lazily render remaining comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@guardian/discussion-rendering",
   "description": "This codebase started as a hack day project by @gtrufitt and @nicl. The purpose is parity of the existing discussion application on Frontend using the discussion API (search for Private Repo).",
-  "version": "7.0.0",
+  "version": "7.1.0-0",
   "author": "",
   "homepage": "https://github.com/guardian/discussion-rendering#readme",
   "license": "Apache",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -108,7 +108,7 @@ describe('App', () => {
 		);
 
 		await waitForElementToBeRemoved(() =>
-			screen.getByTestId('loading-comments'),
+			screen.getAllByTestId('loading-comments'),
 		);
 
 		expect(screen.queryAllByPlaceholderText('Join the discussion').length).toBe(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -243,6 +243,7 @@ export const App = ({
 	);
 	const [isExpanded, setIsExpanded] = useState<boolean>(expanded);
 	const [loading, setLoading] = useState<boolean>(true);
+	const [loadingMore, setLoadingMore] = useState<boolean>(false);
 	const [totalPages, setTotalPages] = useState<number>(0);
 	const [page, setPage] = useState<number>(initialPage || 1);
 	const [picks, setPicks] = useState<CommentType[]>([]);
@@ -273,12 +274,14 @@ export const App = ({
 			// to the total comment amount.
 			// This allows a quick render of minimal comments and then immediately begin rendering
 			// the remaining comments.
+			setLoadingMore(true);
 			const timer = setTimeout(() => {
 				setNumberOfCommentsToShow(comments.length);
+				setLoadingMore(false);
 			}, 0);
 			return () => clearTimeout(timer);
 		}
-	}, [isExpanded]);
+	}, [isExpanded, onExpanded, comments.length]);
 
 	useEffect(() => {
 		setLoading(true);
@@ -567,6 +570,7 @@ export const App = ({
 					))}
 				</ul>
 			)}
+			{loadingMore && <LoadingComments />}
 			{showPagination && (
 				<footer css={footerStyles}>
 					<Pagination

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -276,7 +276,6 @@ export const App = ({
 			// to the total comment amount.
 			// This allows a quick render of minimal comments and then immediately begin rendering
 			// the remaining comments.
-			setLoadingMore(true);
 			const timer = setTimeout(() => {
 				setNumberOfCommentsToShow(comments.length);
 				setLoadingMore(false);
@@ -289,6 +288,7 @@ export const App = ({
 		setLoading(true);
 		getDiscussion(shortUrl, { ...filters, page }).then((json) => {
 			setLoading(false);
+			setLoadingMore(true);
 			if (json && json.status !== 'error') {
 				setComments(json && json.discussion && json.discussion.comments);
 				setCommentCount(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -267,7 +267,9 @@ export const App = ({
 		) {
 			onExpanded(window.performance.now() - expandedStartTime);
 		}
+	}, [isExpanded, onExpanded]);
 
+	useEffect(() => {
 		if (isExpanded) {
 			// We want react to complete the current work and render, without trying to batch this update
 			// before resetting the number of comments
@@ -281,7 +283,7 @@ export const App = ({
 			}, 0);
 			return () => clearTimeout(timer);
 		}
-	}, [isExpanded, onExpanded, comments.length]);
+	}, [isExpanded, comments.length]);
 
 	useEffect(() => {
 		setLoading(true);


### PR DESCRIPTION
Initial render of comments would be perceived by the user as 3.4x quicker from 1762ms to 512ms on a 4x slow down of CPU.

![Screen Shot 2021-03-16 at 17 40 52](https://user-images.githubusercontent.com/638051/111355750-94c77400-867f-11eb-9b82-b5c875b19d08.png)

(10 refreshes and clicking on the button, x-axis showing value for each run)

### Before - Full render is slow
![Screen Shot 2021-03-16 at 15 31 35](https://user-images.githubusercontent.com/638051/111355775-9abd5500-867f-11eb-9d7a-8b624bd0c10f.png)

### After - Initial rendering early with full rendering not heavily affected
![Screen Shot 2021-03-16 at 15 46 28](https://user-images.githubusercontent.com/638051/111355766-998c2800-867f-11eb-8ba7-1ed918be6cda.png)

## Part rendered with loading state


|Before |After |
| ----------- |----------- |
|![2021-03-16 17 52 35](https://user-images.githubusercontent.com/638051/111356755-96456c00-8680-11eb-9be8-82d5e3647c4f.gif)| ![2021-03-16 16 10 12](https://user-images.githubusercontent.com/638051/111355784-9c871880-867f-11eb-839b-f874e0a39eb8.gif)    |
