### PR TITLE
Fixes some build issues

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,4 +11,8 @@ module.exports = {
             plugins: ['@babel/plugin-transform-runtime'],
         },
     },
+    "ignore": [
+        "**/*.test.*",
+        "**/*.stories.*"
+      ]
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/guardian/discussion-rendering#readme",
   "license": "Apache",
   "main": "build/App.js",
-  "module": "src/App.tsx",
+  "module": "build/App.esm.js",
   "publishConfig": {
     "access": "public"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,11 +33,11 @@ module.exports = {
         clear({
             targets: ['build/'],
         }),
+        commonjs(),
         babel({ 
             extensions,
         }),
         resolve({ extensions }),
-        commonjs(),
         visualizer({ filename: 'build/stats.html' }),
     ],
 };


### PR DESCRIPTION
## What does this change?

- Ignores test and stories files in babel
- Points at the correctly built esm file
- Moves the `commonjs` plugin before babel as per https://github.com/rollup/plugins/tree/master/packages/babel#using-with-rollupplugin-commonjs

