### PR TITLE
Bump @guardian/types to 5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@guardian/src-icons": "^3.3.0",
     "@guardian/src-link": "^3.3.0",
     "@guardian/src-text-input": "^3.3.0",
-    "@guardian/types": "^3.0.0",
+    "@guardian/types": "^5.1.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "typescript": "^4.1.3"
@@ -52,7 +52,7 @@
     "@guardian/src-icons": "^3.3.0",
     "@guardian/src-link": "^3.3.0",
     "@guardian/src-text-input": "^3.3.0",
-    "@guardian/types": "^3.0.0",
+    "@guardian/types": "^5.1.0",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2471,10 +2471,10 @@
     "@guardian/src-helpers" "^3.3.0"
     "@guardian/src-icons" "^3.3.0"
 
-"@guardian/types@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-3.0.0.tgz#bb2cc21f2436fca98143fb18bc58346e43ee9336"
-  integrity sha512-hTrk7EEsqSI/q7fyz2PuKMwKXuXRcwY7Ws+h72bvvimmpayfTwFQgEJfsjABxTSxdTw6bGA8T3F5GV4DJs9zog==
+"@guardian/types@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-5.1.0.tgz#d83e4fe911c0d4d460551855d47d07df0f0af8f2"
+  integrity sha512-8JQFfHqskOyc1ruSwWiJD8W4XuCsGorMpwEMRsBM3/zHykAiizsJu7827UbeFCWJ5FUquO/blXzm7oK8ZO99CQ==
 
 "@hapi/address@2.x.x":
   version "2.1.4"


### PR DESCRIPTION
## What does this change?
Bump `@guardian/types` to v5.1.0

## Why?
We need to support the Letter Design type in editions-rendering which is available from `@guardian/types` v4. The package is already on v5.1.0 so bumping it in one go.
