### PR TITLE
Add googleTagId to UserName types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,7 @@ type UserNameUser = {
 		userEmailValidated: boolean;
 	};
 	privateFields: {
+		googleTagId: string;
 		brazeUuid: string;
 		legacyPackages: string;
 		legacyProducts: string;


### PR DESCRIPTION
## What does this change?

This is now returned from the API, so it should be available.

## Why?

Better, more reliable typing.
