### PR TITLE
Add prop & styles for full width styling

### DIFF
--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -233,3 +233,29 @@ export const LegacyDiscussion = () => (
 LegacyDiscussion.story = {
 	name: "a legacy discussion that doesn't allow threading",
 };
+
+export const FullWidthLegacyDiscussion = () => (
+	<div
+		css={css`
+			width: 1000px;
+		`}
+	>
+		<App
+			shortUrl="p/4v8kk"
+			baseUrl="https://discussion.theguardian.com/discussion-api"
+			pillar={Pillar.Culture}
+			isClosedForComments={false}
+			additionalHeaders={{
+				'D2-X-UID': 'testD2Header',
+				'GU-Client': 'testClientHeader',
+			}}
+			isFullWidth={true}
+			expanded={false}
+			onPermalinkClick={() => {}}
+			apiKey=""
+		/>
+	</div>
+);
+FullWidthLegacyDiscussion.story = {
+	name: 'a full width legacy discussion',
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ type Props = {
 	baseUrl: string;
 	pillar: Theme;
 	isClosedForComments: boolean;
+	isFullWidth?: boolean;
 	commentToScrollTo?: number;
 	initialPage?: number;
 	pageSizeOverride?: PageSizeType;
@@ -68,6 +69,10 @@ const commentContainerStyles = css`
 	list-style-type: none;
 	padding-left: 0;
 	margin: 0;
+`;
+
+const fullWidthStyles = css`
+	width: 100%;
 `;
 
 const picksWrapper = css`
@@ -218,6 +223,7 @@ export const App = ({
 	shortUrl,
 	pillar,
 	isClosedForComments,
+	isFullWidth,
 	initialPage,
 	commentToScrollTo,
 	pageSizeOverride,
@@ -410,7 +416,10 @@ export const App = ({
 
 	if (!isExpanded) {
 		return (
-			<div css={commentContainerStyles} data-component="discussion">
+			<div
+				css={[commentContainerStyles, isFullWidth && fullWidthStyles]}
+				data-component="discussion"
+			>
 				{user && !isClosedForComments && (
 					<CommentForm
 						pillar={pillar}
@@ -505,7 +514,10 @@ export const App = ({
 	}
 
 	return (
-		<div data-component="discussion" css={commentColumnWrapperStyles}>
+		<div
+			data-component="discussion"
+			css={[commentColumnWrapperStyles, isFullWidth && fullWidthStyles]}
+		>
 			{user && !isClosedForComments && (
 				<CommentForm
 					pillar={pillar}

--- a/src/fixtures/legacyDiscussionWithoutFullWidthComment.ts
+++ b/src/fixtures/legacyDiscussionWithoutFullWidthComment.ts
@@ -1,0 +1,63 @@
+import { DiscussionResponse } from '../types';
+
+export const legacyDiscussionWithoutFullWidthComment: DiscussionResponse = {
+    status: 'ok',
+	page: 1,
+	pages: 0,
+	pageSize: 100,
+	orderBy: 'oldest',
+	discussion: {
+        apiUrl: "https://discussion.guardianapis.com/discussion-api/discussion//p/4v8kk",
+        commentCount: 7,
+        comments: [
+            {
+                apiUrl: "https://discussion.guardianapis.com/discussion-api/comment/38591122",
+                body: "<p>someone's run out of ideas..!</p>",
+                date: "25 July 2014 9:07am",
+                id: 38591122,
+                isHighlighted: false,
+                isoDateTime: "2014-07-25T08:07:54Z",
+                numRecommends: 0,
+                status: "visible",
+                userProfile: {
+                    apiUrl: "https://discussion.guardianapis.com/discussion-api/profile/12173512",
+                    avatar: "https://avatar.guim.co.uk/user/12173512",
+                    badge: [],
+                    displayName: "bellyofcassano",
+                    secureAvatarUrl: "https://avatar.guim.co.uk/user/12173512",
+                    userId: "12173512",
+                    webUrl: "https://profile.theguardian.com/user/id/12173512"
+                },
+                webUrl: "https://discussion.theguardian.com/comment-permalink/38591122"
+            },
+            {
+                apiUrl: "https://discussion.guardianapis.com/discussion-api/comment/38649787",
+                body: "<p>Edge of seventeen.</p>",
+                date: "26 July 2014 6:37pm",
+                id: 38649787,
+                isHighlighted: false,
+                isoDateTime: "2014-07-26T17:37:07Z",
+                numRecommends: 0,
+                status: "visible",
+                userProfile: {
+                    apiUrl: "https://discussion.guardianapis.com/discussion-api/profile/4431346",
+                    avatar: "https://avatar.guim.co.uk/user/4431346",
+                    badge: [],
+                    displayName: "halfienoakes",
+                    secureAvatarUrl: "https://avatar.guim.co.uk/user/4431346",
+                    userId: "4431346",
+                    webUrl: "https://profile.theguardian.com/user/id/4431346"
+                },
+                webUrl: "https://discussion.theguardian.com/comment-permalink/38649787"
+            }
+        ],
+        isClosedForComments: true,
+        isClosedForRecommendation: true,
+        isThreaded: true,
+        key: "/p/4v8kk",
+        title: "Stevie Nicks to release double album of songs from her past",
+        topLevelCommentCount: 6,
+        webUrl: "https://www.theguardian.com/music/2014/jul/25/stevie-nicks-ro-release-double-album-of-songs-from-her-past"
+    }
+}
+

--- a/src/fixtures/legacyDiscussionWithoutFullWidthComment.ts
+++ b/src/fixtures/legacyDiscussionWithoutFullWidthComment.ts
@@ -1,63 +1,68 @@
 import { DiscussionResponse } from '../types';
 
 export const legacyDiscussionWithoutFullWidthComment: DiscussionResponse = {
-    status: 'ok',
+	status: 'ok',
 	page: 1,
 	pages: 0,
 	pageSize: 100,
 	orderBy: 'oldest',
 	discussion: {
-        apiUrl: "https://discussion.guardianapis.com/discussion-api/discussion//p/4v8kk",
-        commentCount: 7,
-        comments: [
-            {
-                apiUrl: "https://discussion.guardianapis.com/discussion-api/comment/38591122",
-                body: "<p>someone's run out of ideas..!</p>",
-                date: "25 July 2014 9:07am",
-                id: 38591122,
-                isHighlighted: false,
-                isoDateTime: "2014-07-25T08:07:54Z",
-                numRecommends: 0,
-                status: "visible",
-                userProfile: {
-                    apiUrl: "https://discussion.guardianapis.com/discussion-api/profile/12173512",
-                    avatar: "https://avatar.guim.co.uk/user/12173512",
-                    badge: [],
-                    displayName: "bellyofcassano",
-                    secureAvatarUrl: "https://avatar.guim.co.uk/user/12173512",
-                    userId: "12173512",
-                    webUrl: "https://profile.theguardian.com/user/id/12173512"
-                },
-                webUrl: "https://discussion.theguardian.com/comment-permalink/38591122"
-            },
-            {
-                apiUrl: "https://discussion.guardianapis.com/discussion-api/comment/38649787",
-                body: "<p>Edge of seventeen.</p>",
-                date: "26 July 2014 6:37pm",
-                id: 38649787,
-                isHighlighted: false,
-                isoDateTime: "2014-07-26T17:37:07Z",
-                numRecommends: 0,
-                status: "visible",
-                userProfile: {
-                    apiUrl: "https://discussion.guardianapis.com/discussion-api/profile/4431346",
-                    avatar: "https://avatar.guim.co.uk/user/4431346",
-                    badge: [],
-                    displayName: "halfienoakes",
-                    secureAvatarUrl: "https://avatar.guim.co.uk/user/4431346",
-                    userId: "4431346",
-                    webUrl: "https://profile.theguardian.com/user/id/4431346"
-                },
-                webUrl: "https://discussion.theguardian.com/comment-permalink/38649787"
-            }
-        ],
-        isClosedForComments: true,
-        isClosedForRecommendation: true,
-        isThreaded: true,
-        key: "/p/4v8kk",
-        title: "Stevie Nicks to release double album of songs from her past",
-        topLevelCommentCount: 6,
-        webUrl: "https://www.theguardian.com/music/2014/jul/25/stevie-nicks-ro-release-double-album-of-songs-from-her-past"
-    }
-}
-
+		apiUrl:
+			'https://discussion.guardianapis.com/discussion-api/discussion//p/4v8kk',
+		commentCount: 7,
+		comments: [
+			{
+				apiUrl:
+					'https://discussion.guardianapis.com/discussion-api/comment/38591122',
+				body: "<p>someone's run out of ideas..!</p>",
+				date: '25 July 2014 9:07am',
+				id: 38591122,
+				isHighlighted: false,
+				isoDateTime: '2014-07-25T08:07:54Z',
+				numRecommends: 0,
+				status: 'visible',
+				userProfile: {
+					apiUrl:
+						'https://discussion.guardianapis.com/discussion-api/profile/12173512',
+					avatar: 'https://avatar.guim.co.uk/user/12173512',
+					badge: [],
+					displayName: 'bellyofcassano',
+					secureAvatarUrl: 'https://avatar.guim.co.uk/user/12173512',
+					userId: '12173512',
+					webUrl: 'https://profile.theguardian.com/user/id/12173512',
+				},
+				webUrl: 'https://discussion.theguardian.com/comment-permalink/38591122',
+			},
+			{
+				apiUrl:
+					'https://discussion.guardianapis.com/discussion-api/comment/38649787',
+				body: '<p>Edge of seventeen.</p>',
+				date: '26 July 2014 6:37pm',
+				id: 38649787,
+				isHighlighted: false,
+				isoDateTime: '2014-07-26T17:37:07Z',
+				numRecommends: 0,
+				status: 'visible',
+				userProfile: {
+					apiUrl:
+						'https://discussion.guardianapis.com/discussion-api/profile/4431346',
+					avatar: 'https://avatar.guim.co.uk/user/4431346',
+					badge: [],
+					displayName: 'halfienoakes',
+					secureAvatarUrl: 'https://avatar.guim.co.uk/user/4431346',
+					userId: '4431346',
+					webUrl: 'https://profile.theguardian.com/user/id/4431346',
+				},
+				webUrl: 'https://discussion.theguardian.com/comment-permalink/38649787',
+			},
+		],
+		isClosedForComments: true,
+		isClosedForRecommendation: true,
+		isThreaded: true,
+		key: '/p/4v8kk',
+		title: 'Stevie Nicks to release double album of songs from her past',
+		topLevelCommentCount: 6,
+		webUrl:
+			'https://www.theguardian.com/music/2014/jul/25/stevie-nicks-ro-release-double-album-of-songs-from-her-past',
+	},
+};

--- a/src/lib/mockFetchCalls.ts
+++ b/src/lib/mockFetchCalls.ts
@@ -7,6 +7,7 @@ import { noTopPicks } from '../fixtures/noTopPicks';
 import { discussionWithNoComments } from '../fixtures/discussionWithNoComments';
 import { discussionWithTwoComments } from '../fixtures/discussionWithTwoComments';
 import { legacyDiscussionWithoutThreading } from '../fixtures/legacyDiscussionWithoutThreading';
+import { legacyDiscussionWithoutFullWidthComment } from '../fixtures/legacyDiscussionWithoutFullWidthComment';
 
 export const mockedMessageID = '123456';
 
@@ -84,6 +85,19 @@ export const mockFetchCalls = () => {
 			},
 		)
 		.get(/.*\/discussion\/p\/32255\/topcomments.*/, {
+			status: 200,
+			body: noTopPicks,
+		})
+
+		// Get discussion 4v8kk
+		.get(
+			/.*\/discussion.theguardian.com\/discussion-api\/discussion\/p\/4v8kk\?.*/,
+			{
+				status: 200,
+				body: legacyDiscussionWithoutFullWidthComment,
+			},
+		)
+		.get(/.*\/discussion\/p\/4v8kk\/topcomments.*/, {
 			status: 200,
 			body: noTopPicks,
 		})


### PR DESCRIPTION
## What does this change?

Creates an optional prop which adds `width: 100%` to the comments container.

## Why?

On articles where no comments span the full width on the available container, the comments section shrinks to the size of the largest comment

![image](https://user-images.githubusercontent.com/9575458/120350304-c7841e80-c2f6-11eb-9478-cba2b16618d1.png)

## Link to supporting Trello card

https://trello.com/c/xurRBeNp/235-comment-section-width-not-correct