### PR TITLE
Remove `devDependencies` check from Snyk Action

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -27,5 +27,5 @@ jobs:
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
               with:
-                  args: --org=the-guardian --project-name=${{ github.repository }} --dev=true
+                  args: --org=the-guardian --project-name=${{ github.repository }}
                   command: ${{ env.SNYK_COMMAND }}


### PR DESCRIPTION
The `devDependencies` check is crashing `snyk monitor`. I've raised a [bug report](https://github.com/snyk/snyk/issues/2011) with them, but given that production dependencies are the real issue here, I'm gonna remove the development stage check until the bug is fixed.