### PR TITLE
Upload snyk results as SARIF to code scanning

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -24,8 +24,15 @@ jobs:
 
             - name: Run Snyk to check for vulnerabilities
               uses: snyk/actions/node@0.3.0
+              continue-on-error: true # To make sure that SARIF upload gets called
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
               with:
-                  args: --org=the-guardian --project-name=${{ github.repository }}
+                  args: --org=the-guardian --project-name=${{ github.repository }} --sarif-file-output=snyk-node.sarif
+                  command: ${{ env.SNYK_COMMAND }}
+            - name: Upload result to GitHub Code Scanning
+              if: github.ref != 'refs/heads/main'
+              uses: github/codeql-action/upload-sarif@v1
+              with:
+                  sarif_file: snyk-node.sarif
                   command: ${{ env.SNYK_COMMAND }}

--- a/README.md
+++ b/README.md
@@ -29,3 +29,6 @@ While you are linked, you will need to run `yarn build` after making changes to 
 ### `yarn build`
 
 Builds the app for production to the `build` folder.
+
+## Snyk Code Scanning
+There's a Github action set up on the repository to scan for vulnerabilities. This is set to "continue on error" and so will show a green tick regardless. In order to check the vulnerabilities we can use the Github code scanning feature in the security tab and this will list all vulnerabilities for a given branch etc. You should use this if adding/removing/updating packages to see if there are any vulnerabilities.


### PR DESCRIPTION
## What does this change?
Upload results from the Snyk Github action as a SARIF file to Github's code scanning. This should make it easier to parse and read errors.
