### PR TITLE
Let snyk run on dev dependencies

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -34,7 +34,7 @@ jobs:
                   sarif_file: snyk-node.sarif
 
             - name: Run Snyk monitor to update snyk.io
-                if: github.ref == 'refs/heads/main'
+              if: github.ref == 'refs/heads/main'
               uses: snyk/actions/node@0.3.0
               continue-on-error: true # To make sure that SARIF upload gets called
               env:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -12,8 +12,6 @@ on:
 jobs:
     security:
         runs-on: ubuntu-latest
-        env:
-            SNYK_COMMAND: test
         steps:
             - name: Checkout branch
               uses: actions/checkout@v2
@@ -28,11 +26,19 @@ jobs:
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
               with:
-                  args: --org=the-guardian --project-name=${{ github.repository }} --sarif-file-output=snyk-node.sarif
-                  command: ${{ env.SNYK_COMMAND }}
+                  args: --org=the-guardian --project-name=${{ github.repository }} --dev=true --prune-repeated-subdependencies --sarif-file-output=snyk-node.sarif
+                  command: test
             - name: Upload result to GitHub Code Scanning
-              if: github.ref != 'refs/heads/main'
               uses: github/codeql-action/upload-sarif@v1
               with:
                   sarif_file: snyk-node.sarif
-                  command: ${{ env.SNYK_COMMAND }}
+
+            - name: Run Snyk monitor to update snyk.io
+                if: github.ref == 'refs/heads/main'
+              uses: snyk/actions/node@0.3.0
+              continue-on-error: true # To make sure that SARIF upload gets called
+              env:
+                  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+              with:
+                  args: --org=the-guardian --project-name=${{ github.repository }} --dev=true --prune-repeated-subdependencies
+                  command: monitor


### PR DESCRIPTION
## What does this change?
Splits the GH Action out to run snyk test and upload SARIF file to code
scanning and then run snyk monitor if on `main`. We can now test dev
dependencies by pruning repeated subdependencies. This was failing prior
to this due to too many vulnerable paths.

## Why?
Code scanning info on `main` and checks `devDependencies`

