### PR TITLE
Migrate from `@guardian/types` to `@guardian/libs`

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,12 @@
+const nodeModulesExclude = [
+  {
+      test: /node_modules/,
+      exclude: [
+          /@guardian\//,
+      ],
+  },
+]
+
 module.exports = {
   "stories": [
     "../src/**/*.stories.mdx",
@@ -6,12 +15,17 @@ module.exports = {
   webpackFinal: async config => {
       config.module.rules.push({
           test: /\.(ts|tsx)$/,
+          exclude: nodeModulesExclude,
           use: [
               {
                   loader: require.resolve('ts-loader'),
               },
           ],
       });
+
+      // update storybook webpack config to transpile *all* JS
+      config.module.rules.find(rule => String(rule.test) === String(/\.(mjs|tsx?|jsx?)$/))
+      .exclude = nodeModulesExclude;
 
       return config;
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@guardian/src-icons": "^3.6.0",
     "@guardian/src-link": "^3.6.0",
     "@guardian/src-text-input": "^3.6.0",
-    "@guardian/types": "^3.0.0",
+    "@guardian/libs": "^3.1.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "typescript": "^4.1.3"
@@ -52,7 +52,7 @@
     "@guardian/src-icons": "^3.6.0",
     "@guardian/src-link": "^3.6.0",
     "@guardian/src-text-input": "^3.6.0",
-    "@guardian/types": "^3.0.0",
+    "@guardian/libs": "^3.1.0",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
@@ -136,7 +136,7 @@
   "jest": {
     "testEnvironment": "jest-environment-jsdom-sixteen",
     "transformIgnorePatterns": [
-      "node_modules/(?!(@guardian/src-foundations|@guardian/types|@guardian/libs)/)"
+      "node_modules/(?!(@guardian/src-foundations|@guardian/libs)/)"
     ],
     "preset": "ts-jest/presets/js-with-babel",
     "moduleFileExtensions": [

--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { App } from './App';
 import { css } from '@emotion/react';
 
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 
 import { UserProfile } from './types';
 
@@ -33,7 +33,7 @@ export const LoggedOutHiddenPicks = () => (
 		<App
 			shortUrl="p/39f5z"
 			baseUrl="https://discussion.theguardian.com/discussion-api"
-			pillar={Pillar.Culture}
+			pillar={ArticlePillar.Culture}
 			isClosedForComments={false}
 			additionalHeaders={{
 				'D2-X-UID': 'testD2Header',
@@ -63,7 +63,7 @@ export const InitialPage = () => (
 			shortUrl="p/39f5z"
 			initialPage={3}
 			baseUrl="https://discussion.theguardian.com/discussion-api"
-			pillar={Pillar.Lifestyle}
+			pillar={ArticlePillar.Lifestyle}
 			isClosedForComments={false}
 			additionalHeaders={{
 				'D2-X-UID': 'testD2Header',
@@ -90,7 +90,7 @@ export const Overrides = () => (
 			pageSizeOverride={50}
 			orderByOverride="recommendations"
 			baseUrl="https://discussion.theguardian.com/discussion-api"
-			pillar={Pillar.Opinion}
+			pillar={ArticlePillar.Opinion}
 			isClosedForComments={false}
 			additionalHeaders={{
 				'D2-X-UID': 'testD2Header',
@@ -113,7 +113,7 @@ export const LoggedInHiddenNoPicks = () => (
 	>
 		<App
 			shortUrl="p/abc123"
-			pillar={Pillar.News}
+			pillar={ArticlePillar.News}
 			isClosedForComments={false}
 			user={aUser}
 			baseUrl="https://discussion.theguardian.com/discussion-api"
@@ -140,7 +140,7 @@ export const LoggedOutHiddenNoPicks = () => (
 	>
 		<App
 			shortUrl="p/abc123"
-			pillar={Pillar.Sport}
+			pillar={ArticlePillar.Sport}
 			isClosedForComments={false}
 			baseUrl="https://discussion.theguardian.com/discussion-api"
 			additionalHeaders={{
@@ -167,7 +167,7 @@ export const Closed = () => (
 		<App
 			shortUrl="p/39f5z"
 			baseUrl="https://discussion.theguardian.com/discussion-api"
-			pillar={Pillar.Lifestyle}
+			pillar={ArticlePillar.Lifestyle}
 			isClosedForComments={true}
 			user={aUser}
 			additionalHeaders={{
@@ -192,7 +192,7 @@ export const NoComments = () => (
 		<App
 			shortUrl="p/39f5x" // A discussion with zero comments
 			baseUrl="https://discussion.theguardian.com/discussion-api"
-			pillar={Pillar.Culture}
+			pillar={ArticlePillar.Culture}
 			isClosedForComments={false}
 			additionalHeaders={{
 				'D2-X-UID': 'testD2Header',
@@ -218,7 +218,7 @@ export const LegacyDiscussion = () => (
 		<App
 			shortUrl="p/32255" // A 'legacy' discussion that doesn't allow threading
 			baseUrl="https://discussion.theguardian.com/discussion-api"
-			pillar={Pillar.Culture}
+			pillar={ArticlePillar.Culture}
 			isClosedForComments={false}
 			additionalHeaders={{
 				'D2-X-UID': 'testD2Header',

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,7 +7,7 @@ import {
 	screen,
 } from '@testing-library/react';
 
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 
 import { mockFetchCalls } from './lib/mockFetchCalls';
 
@@ -41,7 +41,7 @@ describe('App', () => {
 			<App
 				baseUrl=""
 				shortUrl="p/39f5z"
-				pillar={Pillar.News}
+				pillar={ArticlePillar.News}
 				isClosedForComments={false}
 				expanded={false}
 				additionalHeaders={{
@@ -68,7 +68,7 @@ describe('App', () => {
 			<App
 				shortUrl="p/39f5z"
 				baseUrl="https://discussion.theguardian.com/discussion-api"
-				pillar={Pillar.Culture}
+				pillar={ArticlePillar.Culture}
 				isClosedForComments={false}
 				additionalHeaders={{
 					'D2-X-UID': 'testD2Header',
@@ -94,7 +94,7 @@ describe('App', () => {
 			<App
 				baseUrl=""
 				shortUrl="p/39f5z"
-				pillar={Pillar.News}
+				pillar={ArticlePillar.News}
 				isClosedForComments={false}
 				user={aUser}
 				expanded={true}
@@ -121,7 +121,7 @@ describe('App', () => {
 			<App
 				baseUrl=""
 				shortUrl="p/39f5x" // A discussion with no comments
-				pillar={Pillar.News}
+				pillar={ArticlePillar.News}
 				isClosedForComments={false}
 				expanded={false}
 				additionalHeaders={{
@@ -146,7 +146,7 @@ describe('App', () => {
 			<App
 				baseUrl=""
 				shortUrl="p/39f5a" // A discussion with only two comments
-				pillar={Pillar.News}
+				pillar={ArticlePillar.News}
 				isClosedForComments={false}
 				expanded={false}
 				additionalHeaders={{

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { textSans } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
 import { SvgPlus } from '@guardian/src-icons';
 
-import { Theme } from '@guardian/types';
+import { ArticleTheme } from '@guardian/libs';
 
 import {
 	CommentType,
@@ -29,7 +29,7 @@ import { PillarButton } from './components/PillarButton/PillarButton';
 type Props = {
 	shortUrl: string;
 	baseUrl: string;
-	pillar: Theme;
+	pillar: ArticleTheme;
 	isClosedForComments: boolean;
 	commentToScrollTo?: number;
 	initialPage?: number;

--- a/src/components/AbuseReportForm/AbuseReportForm.stories.tsx
+++ b/src/components/AbuseReportForm/AbuseReportForm.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
 
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 
 import { AbuseReportForm } from './AbuseReportForm';
 
@@ -19,7 +19,7 @@ export const Dialog = () => (
 	<div css={wrapperStyles}>
 		<AbuseReportForm
 			toggleSetShowForm={() => {}}
-			pillar={Pillar.Sport}
+			pillar={ArticlePillar.Sport}
 			commentId={123}
 		/>
 	</div>

--- a/src/components/AbuseReportForm/AbuseReportForm.test.tsx
+++ b/src/components/AbuseReportForm/AbuseReportForm.test.tsx
@@ -8,7 +8,7 @@ import {
 	waitFor,
 } from '@testing-library/react';
 
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 
 import { AbuseReportForm } from './AbuseReportForm';
 
@@ -21,7 +21,7 @@ describe('Dropdown', () => {
 		const { getByText } = render(
 			<AbuseReportForm
 				toggleSetShowForm={() => {}}
-				pillar={Pillar.Sport}
+				pillar={ArticlePillar.Sport}
 				commentId={123}
 			/>,
 		);
@@ -35,7 +35,7 @@ describe('Dropdown', () => {
 		const { getByText } = render(
 			<AbuseReportForm
 				toggleSetShowForm={() => {}}
-				pillar={Pillar.Sport}
+				pillar={ArticlePillar.Sport}
 				commentId={123}
 			/>,
 		);
@@ -50,7 +50,7 @@ describe('Dropdown', () => {
 		const { getByText, getByLabelText, queryByText } = render(
 			<AbuseReportForm
 				toggleSetShowForm={() => {}}
-				pillar={Pillar.Sport}
+				pillar={ArticlePillar.Sport}
 				commentId={123}
 			/>,
 		);

--- a/src/components/AbuseReportForm/AbuseReportForm.tsx
+++ b/src/components/AbuseReportForm/AbuseReportForm.tsx
@@ -7,7 +7,7 @@ import { space, neutral } from '@guardian/src-foundations';
 import { Button } from '@guardian/src-button';
 import { SvgCross } from '@guardian/src-icons';
 
-import { Theme } from '@guardian/types';
+import { ArticleTheme } from '@guardian/libs';
 
 import { reportAbuse } from '../../lib/api';
 import { pillarToString } from '../../lib/pillarToString';
@@ -32,7 +32,7 @@ const formWrapper = css`
 	${textSans.xxsmall()};
 `;
 
-const labelStyles = (pillar: Theme) => css`
+const labelStyles = (pillar: ArticleTheme) => css`
 	color: ${palette[pillarToString(pillar)][400]};
 	${textSans.small({ fontWeight: 'bold' })}
 `;
@@ -62,7 +62,7 @@ const errorMessageStyles = css`
 export const AbuseReportForm: React.FC<{
 	commentId: number;
 	toggleSetShowForm: () => void;
-	pillar: Theme;
+	pillar: ArticleTheme;
 }> = ({ commentId, toggleSetShowForm, pillar }) => {
 	const modalRef = useRef<HTMLDivElement>(null);
 	// TODO: use ref once forwardRef is implemented @guardian/src-button

--- a/src/components/Comment/Comment.stories.tsx
+++ b/src/components/Comment/Comment.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 
 import { Comment } from './Comment';
 import { CommentType, UserProfile } from '../../types';
@@ -129,7 +129,7 @@ const staffUser: UserProfile = {
 export const Root = () => (
 	<Comment
 		comment={commentData}
-		pillar={Pillar.News}
+		pillar={ArticlePillar.News}
 		isClosedForComments={false}
 		setCommentBeingRepliedTo={() => {}}
 		isReply={false}
@@ -149,7 +149,7 @@ Root.story = {
 export const RootMobile = () => (
 	<Comment
 		comment={commentData}
-		pillar={Pillar.Sport}
+		pillar={ArticlePillar.Sport}
 		setCommentBeingRepliedTo={() => {}}
 		isReply={false}
 		isClosedForComments={false}
@@ -169,7 +169,7 @@ RootMobile.story = {
 export const ReplyComment = () => (
 	<Comment
 		comment={replyCommentData}
-		pillar={Pillar.Lifestyle}
+		pillar={ArticlePillar.Lifestyle}
 		isClosedForComments={false}
 		setCommentBeingRepliedTo={() => {}}
 		isReply={true}
@@ -189,7 +189,7 @@ ReplyComment.story = {
 export const MobileReply = () => (
 	<Comment
 		comment={replyCommentData}
-		pillar={Pillar.Culture}
+		pillar={ArticlePillar.Culture}
 		setCommentBeingRepliedTo={() => {}}
 		isReply={true}
 		isClosedForComments={false}
@@ -209,7 +209,7 @@ MobileReply.story = {
 export const LongMobileReply = () => (
 	<Comment
 		comment={longReplyCommentData}
-		pillar={Pillar.Culture}
+		pillar={ArticlePillar.Culture}
 		setCommentBeingRepliedTo={() => {}}
 		isReply={true}
 		isClosedForComments={false}
@@ -229,7 +229,7 @@ LongMobileReply.story = {
 export const LongBothMobileReply = () => (
 	<Comment
 		comment={longBothReplyCommentData}
-		pillar={Pillar.Culture}
+		pillar={ArticlePillar.Culture}
 		setCommentBeingRepliedTo={() => {}}
 		isReply={true}
 		isClosedForComments={false}
@@ -252,7 +252,7 @@ export const PickedComment = () => (
 			...commentData,
 			isHighlighted: true,
 		}}
-		pillar={Pillar.News}
+		pillar={ArticlePillar.News}
 		isClosedForComments={false}
 		setCommentBeingRepliedTo={() => {}}
 		isReply={false}
@@ -266,7 +266,7 @@ PickedComment.story = { name: 'Picked Comment' };
 export const StaffUserComment = () => (
 	<Comment
 		comment={commentStaffData}
-		pillar={Pillar.Opinion}
+		pillar={ArticlePillar.Opinion}
 		isClosedForComments={false}
 		setCommentBeingRepliedTo={() => {}}
 		isReply={false}
@@ -283,7 +283,7 @@ export const PickedStaffUserComment = () => (
 			...commentStaffData,
 			isHighlighted: true,
 		}}
-		pillar={Pillar.News}
+		pillar={ArticlePillar.News}
 		isClosedForComments={false}
 		setCommentBeingRepliedTo={() => {}}
 		isReply={false}
@@ -306,7 +306,7 @@ export const PickedStaffUserCommentMobile = () => (
 			...commentStaffData,
 			isHighlighted: true,
 		}}
-		pillar={Pillar.Sport}
+		pillar={ArticlePillar.Sport}
 		isClosedForComments={false}
 		setCommentBeingRepliedTo={() => {}}
 		isReply={false}
@@ -326,7 +326,7 @@ PickedStaffUserCommentMobile.story = {
 export const LoggedInAsModerator = () => (
 	<Comment
 		comment={commentData}
-		pillar={Pillar.Lifestyle}
+		pillar={ArticlePillar.Lifestyle}
 		isClosedForComments={false}
 		setCommentBeingRepliedTo={() => {}}
 		user={staffUser}
@@ -341,7 +341,7 @@ LoggedInAsModerator.story = { name: 'Logged in as moderator' };
 export const LoggedInAsUser = () => (
 	<Comment
 		comment={commentData}
-		pillar={Pillar.Lifestyle}
+		pillar={ArticlePillar.Lifestyle}
 		isClosedForComments={false}
 		setCommentBeingRepliedTo={() => {}}
 		user={user}
@@ -356,7 +356,7 @@ LoggedInAsUser.story = { name: 'Logged in as normal user' };
 export const BlockedComment = () => (
 	<Comment
 		comment={blockedCommentData}
-		pillar={Pillar.Culture}
+		pillar={ArticlePillar.Culture}
 		isClosedForComments={false}
 		setCommentBeingRepliedTo={() => {}}
 		isReply={false}
@@ -370,7 +370,7 @@ BlockedComment.story = { name: 'Blocked comment' };
 export const MutedComment = () => (
 	<Comment
 		comment={blockedCommentData}
-		pillar={Pillar.Sport}
+		pillar={ArticlePillar.Sport}
 		isClosedForComments={false}
 		setCommentBeingRepliedTo={() => {}}
 		isReply={false}
@@ -384,7 +384,7 @@ MutedComment.story = { name: 'Muted comment' };
 export const ClosedForComments = () => (
 	<Comment
 		comment={commentData}
-		pillar={Pillar.News}
+		pillar={ArticlePillar.News}
 		isClosedForComments={true}
 		setCommentBeingRepliedTo={() => {}}
 		isReply={false}

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -9,7 +9,7 @@ import { Link } from '@guardian/src-link';
 import { SvgIndent } from '@guardian/src-icons';
 import { Button } from '@guardian/src-button';
 
-import { Theme } from '@guardian/types';
+import { ArticleTheme } from '@guardian/libs';
 
 import { GuardianStaff, GuardianPick } from '../Badges/Badges';
 import { RecommendationCount } from '../RecommendationCount/RecommendationCount';
@@ -27,7 +27,7 @@ import { pillarToString } from '../../lib/pillarToString';
 type Props = {
 	user?: UserProfile;
 	comment: CommentType;
-	pillar: Theme;
+	pillar: ArticleTheme;
 	isClosedForComments: boolean;
 	setCommentBeingRepliedTo: (commentBeingRepliedTo?: CommentType) => void;
 	isReply: boolean;
@@ -38,7 +38,7 @@ type Props = {
 	onRecommend?: (commentId: number) => Promise<Boolean>;
 };
 
-const commentControlsLink = (pillar: Theme) => css`
+const commentControlsLink = (pillar: ArticleTheme) => css`
 	margin-top: -2px;
 
 	a {
@@ -140,7 +140,7 @@ const avatarMargin = css`
 	}
 `;
 
-const colourStyles = (pillar: Theme) => css`
+const colourStyles = (pillar: ArticleTheme) => css`
 	a {
 		color: ${palette[pillarToString(pillar)][400]};
 		text-decoration-color: ${palette[pillarToString(pillar)][400]};
@@ -224,7 +224,7 @@ const cssReplyToWrapper = css`
 	}
 `;
 
-const buttonLinkPillarBaseStyles = (pillar: Theme) => css`
+const buttonLinkPillarBaseStyles = (pillar: ArticleTheme) => css`
 	button {
 		color: ${palette[pillarToString(pillar)][400]};
 		background-color: transparent;

--- a/src/components/CommentContainer/CommentContainer.stories.tsx
+++ b/src/components/CommentContainer/CommentContainer.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 
 import { CommentContainer } from './CommentContainer';
 import { CommentType } from '../../types';
@@ -180,7 +180,7 @@ const commentDataThreadedWithLongUserNames: CommentType = {
 export const defaultStory = () => (
 	<CommentContainer
 		comment={commentData}
-		pillar={Pillar.Sport}
+		pillar={ArticlePillar.Sport}
 		isClosedForComments={false}
 		shortUrl="randomShortURL"
 		user={aUser}
@@ -196,7 +196,7 @@ defaultStory.story = { name: 'default' };
 export const threadedComment = () => (
 	<CommentContainer
 		comment={commentDataThreaded}
-		pillar={Pillar.Lifestyle}
+		pillar={ArticlePillar.Lifestyle}
 		isClosedForComments={false}
 		shortUrl="randomShortURL"
 		user={aUser}
@@ -212,7 +212,7 @@ threadedComment.story = { name: 'threaded' };
 export const threadedCommentWithShowMore = () => (
 	<CommentContainer
 		comment={commentDataThreadedWithLongThread}
-		pillar={Pillar.Lifestyle}
+		pillar={ArticlePillar.Lifestyle}
 		isClosedForComments={false}
 		shortUrl="randomShortURL"
 		user={aUser}
@@ -228,7 +228,7 @@ threadedCommentWithShowMore.story = { name: 'threaded with show more button' };
 export const threadedCommentWithLongUsernames = () => (
 	<CommentContainer
 		comment={commentDataThreadedWithLongUserNames}
-		pillar={Pillar.Lifestyle}
+		pillar={ArticlePillar.Lifestyle}
 		isClosedForComments={false}
 		shortUrl="randomShortURL"
 		user={aUser}
@@ -246,7 +246,7 @@ threadedCommentWithLongUsernames.story = {
 export const threadedCommentWithLongUsernamesMobile = () => (
 	<CommentContainer
 		comment={commentDataThreadedWithLongUserNames}
-		pillar={Pillar.Lifestyle}
+		pillar={ArticlePillar.Lifestyle}
 		isClosedForComments={false}
 		shortUrl="randomShortURL"
 		user={aUser}

--- a/src/components/CommentContainer/CommentContainer.test.tsx
+++ b/src/components/CommentContainer/CommentContainer.test.tsx
@@ -7,7 +7,7 @@ import {
 	waitFor,
 } from '@testing-library/react';
 
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 
 import { CommentType } from '../../types';
 import { comment } from '../../fixtures/comment';
@@ -64,7 +64,7 @@ describe('CommentContainer', () => {
 			<CommentContainer
 				shortUrl=""
 				comment={commentWithoutReply} //TODO: should be comments with reponses
-				pillar={Pillar.News}
+				pillar={ArticlePillar.News}
 				user={aUser}
 				threads="collapsed"
 				commentBeingRepliedTo={commentBeingRepliedTo}
@@ -102,7 +102,7 @@ describe('CommentContainer', () => {
 			<CommentContainer
 				shortUrl=""
 				comment={commentWithoutReply} //TODO: should be comments with reponses
-				pillar={Pillar.News}
+				pillar={ArticlePillar.News}
 				user={aUser}
 				threads="collapsed"
 				commentBeingRepliedTo={commentBeingRepliedTo}
@@ -138,7 +138,7 @@ describe('CommentContainer', () => {
 			<CommentContainer
 				shortUrl=""
 				comment={commentWithReply} //TODO: should be comments with reponses
-				pillar={Pillar.News}
+				pillar={ArticlePillar.News}
 				user={aUser}
 				threads="collapsed"
 				commentBeingRepliedTo={commentBeingRepliedTo}
@@ -176,7 +176,7 @@ describe('CommentContainer', () => {
 			<CommentContainer
 				shortUrl=""
 				comment={commentWithoutReply} //TODO: should be comments with reponses
-				pillar={Pillar.News}
+				pillar={ArticlePillar.News}
 				user={aUser}
 				threads="collapsed"
 				commentBeingRepliedTo={commentBeingRepliedTo}

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/react';
 import { space, neutral, border } from '@guardian/src-foundations';
 import { SvgPlus } from '@guardian/src-icons';
 
-import { Theme } from '@guardian/types';
+import { ArticleTheme } from '@guardian/libs';
 
 import {
 	CommentType,
@@ -21,7 +21,7 @@ import { getMoreResponses } from '../../lib/api';
 
 type Props = {
 	comment: CommentType;
-	pillar: Theme;
+	pillar: ArticleTheme;
 	isClosedForComments: boolean;
 	shortUrl: string;
 	user?: UserProfile;

--- a/src/components/CommentForm/CommentForm.stories.tsx
+++ b/src/components/CommentForm/CommentForm.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 
 import { CommentType } from '../../types';
 
@@ -59,7 +59,7 @@ const aComment: CommentType = {
 export const Default = () => (
 	<CommentForm
 		shortUrl={shortUrl}
-		pillar={Pillar.News}
+		pillar={ArticlePillar.News}
 		user={aUser}
 		onAddComment={(comment) => {}}
 	/>
@@ -70,7 +70,7 @@ Default.story = { name: 'default' };
 export const Error = () => (
 	<CommentForm
 		shortUrl={'/p/g8g7v'}
-		pillar={Pillar.News}
+		pillar={ArticlePillar.News}
 		user={aUser}
 		onAddComment={(comment) => {}}
 	/>
@@ -80,7 +80,7 @@ Error.story = { name: 'form with errors' };
 export const Active = () => (
 	<CommentForm
 		shortUrl={shortUrl}
-		pillar={Pillar.Culture}
+		pillar={ArticlePillar.Culture}
 		user={aUser}
 		onAddComment={(comment) => {}}
 		commentBeingRepliedTo={aComment}
@@ -91,7 +91,7 @@ Active.story = { name: 'form is active' };
 export const Premoderated = () => (
 	<CommentForm
 		shortUrl={shortUrl}
-		pillar={Pillar.Opinion}
+		pillar={ArticlePillar.Opinion}
 		user={{
 			...aUser,
 			privateFields: {

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -5,7 +5,7 @@ import { palette, space } from '@guardian/src-foundations';
 import { neutral, text } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 
-import { Theme } from '@guardian/types';
+import { ArticleTheme } from '@guardian/libs';
 
 import { simulateNewComment } from '../../lib/simulateNewComment';
 import {
@@ -23,7 +23,7 @@ import { PillarButton } from '../PillarButton/PillarButton';
 
 type Props = {
 	shortUrl: string;
-	pillar: Theme;
+	pillar: ArticleTheme;
 	user: UserProfile;
 	onAddComment: (response: CommentType) => void;
 	setCommentBeingRepliedTo?: () => void;

--- a/src/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 
 import { CommentReplyPreview, Preview } from './CommentReplyPreview';
 import { CommentType } from '../../types';
@@ -56,7 +56,7 @@ const padding = css`
 
 export const Default = () => (
 	<CommentReplyPreview
-		pillar={Pillar.News}
+		pillar={ArticlePillar.News}
 		commentBeingRepliedTo={commentBeingRepliedTo}
 	/>
 );

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/react';
 import { textSans } from '@guardian/src-foundations/typography';
 import { neutral, space, text, palette } from '@guardian/src-foundations';
 import { SvgIndent } from '@guardian/src-icons';
-import { Theme } from '@guardian/types';
+import { ArticleTheme } from '@guardian/libs';
 import { Button } from '@guardian/src-button';
 
 import { Row } from '../Row/Row';
@@ -13,7 +13,7 @@ import { pillarToString } from '../../lib/pillarToString';
 import { CommentType } from '../../types';
 
 type Props = {
-	pillar: Theme;
+	pillar: ArticleTheme;
 	commentBeingRepliedTo: CommentType;
 };
 
@@ -78,7 +78,7 @@ const blueLink = css`
 	color: ${text.anchorPrimary};
 `;
 
-const buttonLinkPillarBaseStyles = (pillar: Theme) => css`
+const buttonLinkPillarBaseStyles = (pillar: ArticleTheme) => css`
 	button {
 		color: ${palette[pillarToString(pillar)][400]};
 		background-color: transparent;

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { css } from '@emotion/react';
 
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 
 import { DropdownOptionType } from '../../types';
 import { Dropdown } from './Dropdown';
@@ -40,7 +40,7 @@ const DropdownParent = () => {
 		<Dropdown
 			id="d3"
 			label="Page Size"
-			pillar={Pillar.Culture}
+			pillar={ArticlePillar.Culture}
 			options={pageSizeOptions}
 			onSelect={(value: string) => {
 				setSelected(value);
@@ -85,7 +85,7 @@ export const DropdownActive = () => (
 	<Container>
 		<Dropdown
 			id="d1"
-			pillar={Pillar.Lifestyle}
+			pillar={ArticlePillar.Lifestyle}
 			label="Threads"
 			options={threadOptions}
 			onSelect={(value: string) => {
@@ -102,7 +102,7 @@ export const DropdownNoActive = () => (
 		<Dropdown
 			id="d2"
 			label="Threads"
-			pillar={Pillar.News}
+			pillar={ArticlePillar.News}
 			options={optionsWithNoneActive}
 			onSelect={(value: string) => {
 				console.log('clicked: ', value);

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 
 import { render, fireEvent, screen } from '@testing-library/react';
 
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 
 import { DropdownOptionType } from '../../types';
 import { Dropdown } from './Dropdown';
@@ -35,7 +35,7 @@ describe('Dropdown', () => {
 		render(
 			<Dropdown
 				id="abc"
-				pillar={Pillar.News}
+				pillar={ArticlePillar.News}
 				label={label}
 				options={threadOptions}
 				onSelect={() => {}}
@@ -49,7 +49,7 @@ describe('Dropdown', () => {
 		render(
 			<Dropdown
 				id="abc"
-				pillar={Pillar.News}
+				pillar={ArticlePillar.News}
 				label={'The label'}
 				options={noActiveOptions}
 				onSelect={() => {}}
@@ -65,7 +65,7 @@ describe('Dropdown', () => {
 		const { container } = render(
 			<Dropdown
 				id="abc"
-				pillar={Pillar.News}
+				pillar={ArticlePillar.News}
 				label={'The label'}
 				options={threadOptions}
 				onSelect={() => {}}
@@ -80,7 +80,7 @@ describe('Dropdown', () => {
 		const { container } = render(
 			<Dropdown
 				id="abc"
-				pillar={Pillar.News}
+				pillar={ArticlePillar.News}
 				label={'The label'}
 				options={threadOptions}
 				onSelect={() => {}}
@@ -97,7 +97,7 @@ describe('Dropdown', () => {
 		const { container } = render(
 			<Dropdown
 				id="abc"
-				pillar={Pillar.News}
+				pillar={ArticlePillar.News}
 				label={'The label'}
 				options={threadOptions}
 				onSelect={() => {}}
@@ -115,7 +115,7 @@ describe('Dropdown', () => {
 		const { container } = render(
 			<Dropdown
 				id="abc"
-				pillar={Pillar.News}
+				pillar={ArticlePillar.News}
 				label={'The label'}
 				options={threadOptions}
 				onSelect={() => {}}
@@ -135,7 +135,7 @@ it('should trigger the correct onSelect callbacks when an option is clicked', (
 	render(
 		<Dropdown
 			id="abc"
-			pillar={Pillar.News}
+			pillar={ArticlePillar.News}
 			label={'The label'}
 			options={threadOptions}
 			onSelect={mockCallback}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -12,7 +12,7 @@ import {
 } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from, until } from '@guardian/src-foundations/mq';
-import { Theme } from '@guardian/types';
+import { ArticleTheme } from '@guardian/libs';
 
 import { DropdownOptionType } from '../../types';
 
@@ -22,7 +22,7 @@ type Props = {
 	id: string;
 	label: string;
 	options: DropdownOptionType[];
-	pillar: Theme;
+	pillar: ArticleTheme;
 	onSelect: (value: string) => void;
 };
 
@@ -90,7 +90,7 @@ const firstStyles = css`
 	margin-top: 0;
 `;
 
-const activeStyles = (pillar: Theme) => css`
+const activeStyles = (pillar: ArticleTheme) => css`
 	font-weight: bold;
 
 	:after {

--- a/src/components/Filters/Filters.stories.tsx
+++ b/src/components/Filters/Filters.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 
 import { FilterOptions } from '../../types';
 
@@ -16,7 +16,7 @@ export const Default = () => {
 	});
 	return (
 		<Filters
-			pillar={Pillar.Culture}
+			pillar={ArticlePillar.Culture}
 			filters={filters}
 			onFilterChange={setFilters}
 			totalPages={5}

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 
 import { space } from '@guardian/src-foundations';
 import { border } from '@guardian/src-foundations/palette';
-import { Theme } from '@guardian/types';
+import { ArticleTheme } from '@guardian/libs';
 
 import { Dropdown } from '../Dropdown/Dropdown';
 
@@ -16,7 +16,7 @@ import {
 
 type Props = {
 	filters: FilterOptions;
-	pillar: Theme;
+	pillar: ArticleTheme;
 	onFilterChange: (newFilterObject: FilterOptions) => void;
 	totalPages: number;
 	commentCount: number;

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.stories.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 
 import { FirstCommentWelcome } from './FirstCommentWelcome';
 
@@ -9,7 +9,7 @@ export default { title: 'FirstCommentWelcome' };
 export const defaultStory = () => (
 	<FirstCommentWelcome
 		body="My first message ever!!"
-		pillar={Pillar.Lifestyle}
+		pillar={ArticlePillar.Lifestyle}
 		submitForm={() => {}}
 		cancelSubmit={() => {}}
 	/>
@@ -19,7 +19,7 @@ defaultStory.story = { name: 'Welcome message' };
 export const CommentWithError = () => (
 	<FirstCommentWelcome
 		body="My first message ever!!"
-		pillar={Pillar.News}
+		pillar={ArticlePillar.News}
 		error="This is a custom user name error message"
 		submitForm={() => {}}
 		cancelSubmit={() => {}}

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -4,7 +4,7 @@ import { textSans, headline } from '@guardian/src-foundations/typography';
 import { space, neutral } from '@guardian/src-foundations';
 import { TextInput } from '@guardian/src-text-input';
 import { Link } from '@guardian/src-link';
-import { Theme } from '@guardian/types';
+import { ArticleTheme } from '@guardian/libs';
 
 import { Row } from '../Row/Row';
 import { PillarButton } from '../PillarButton/PillarButton';
@@ -13,7 +13,7 @@ import { preview as defaultPreview } from '../../lib/api';
 
 type Props = {
 	body: string;
-	pillar: Theme;
+	pillar: ArticleTheme;
 	error?: string;
 	submitForm: (userName: string) => void;
 	cancelSubmit: () => void;

--- a/src/components/PillarButton/PillarButton.stories.tsx
+++ b/src/components/PillarButton/PillarButton.stories.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 
 import { space } from '@guardian/src-foundations';
 import { SvgCheckmark } from '@guardian/src-icons';
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 
 import { Row } from '../Row/Row';
 
@@ -25,7 +25,7 @@ export const EachPillar = () => (
 			onClick={() => {
 				alert('Clicked!');
 			}}
-			pillar={Pillar.Lifestyle}
+			pillar={ArticlePillar.Lifestyle}
 			linkName=""
 		>
 			Lifestyle
@@ -35,7 +35,7 @@ export const EachPillar = () => (
 			onClick={() => {
 				alert('Clicked!');
 			}}
-			pillar={Pillar.Sport}
+			pillar={ArticlePillar.Sport}
 			linkName=""
 		>
 			Sport
@@ -45,7 +45,7 @@ export const EachPillar = () => (
 			onClick={() => {
 				alert('Clicked!');
 			}}
-			pillar={Pillar.News}
+			pillar={ArticlePillar.News}
 			linkName=""
 		>
 			News
@@ -55,7 +55,7 @@ export const EachPillar = () => (
 			onClick={() => {
 				alert('Clicked!');
 			}}
-			pillar={Pillar.Opinion}
+			pillar={ArticlePillar.Opinion}
 			linkName=""
 		>
 			Opinion
@@ -65,7 +65,7 @@ export const EachPillar = () => (
 			onClick={() => {
 				alert('Clicked!');
 			}}
-			pillar={Pillar.Culture}
+			pillar={ArticlePillar.Culture}
 			linkName=""
 		>
 			Culture
@@ -80,7 +80,7 @@ export const EachSize = () => (
 			onClick={() => {
 				alert('Clicked!');
 			}}
-			pillar={Pillar.News}
+			pillar={ArticlePillar.News}
 			linkName=""
 			size="xsmall"
 		>
@@ -91,7 +91,7 @@ export const EachSize = () => (
 			onClick={() => {
 				alert('Clicked!');
 			}}
-			pillar={Pillar.News}
+			pillar={ArticlePillar.News}
 			linkName=""
 			size="small"
 		>
@@ -102,7 +102,7 @@ export const EachSize = () => (
 			onClick={() => {
 				alert('Clicked!');
 			}}
-			pillar={Pillar.News}
+			pillar={ArticlePillar.News}
 			linkName=""
 			size="default"
 		>
@@ -117,7 +117,7 @@ export const IconLeft = () => (
 		onClick={() => {
 			alert('Clicked!');
 		}}
-		pillar={Pillar.Lifestyle}
+		pillar={ArticlePillar.Lifestyle}
 		icon={<SvgCheckmark />}
 		iconSide="left"
 		linkName="left"
@@ -132,7 +132,7 @@ export const IconRight = () => (
 		onClick={() => {
 			alert('Clicked!');
 		}}
-		pillar={Pillar.Sport}
+		pillar={ArticlePillar.Sport}
 		icon={<SvgCheckmark />}
 		iconSide="right"
 		linkName=""
@@ -147,7 +147,7 @@ export const Secondary = () => (
 			onClick={() => {
 				alert('Clicked!');
 			}}
-			pillar={Pillar.Lifestyle}
+			pillar={ArticlePillar.Lifestyle}
 			priority="secondary"
 			linkName=""
 		>
@@ -158,7 +158,7 @@ export const Secondary = () => (
 			onClick={() => {
 				alert('Clicked!');
 			}}
-			pillar={Pillar.Sport}
+			pillar={ArticlePillar.Sport}
 			priority="secondary"
 			linkName=""
 		>
@@ -169,7 +169,7 @@ export const Secondary = () => (
 			onClick={() => {
 				alert('Clicked!');
 			}}
-			pillar={Pillar.News}
+			pillar={ArticlePillar.News}
 			priority="secondary"
 			linkName=""
 		>
@@ -180,7 +180,7 @@ export const Secondary = () => (
 			onClick={() => {
 				alert('Clicked!');
 			}}
-			pillar={Pillar.Opinion}
+			pillar={ArticlePillar.Opinion}
 			priority="secondary"
 			linkName=""
 		>
@@ -191,7 +191,7 @@ export const Secondary = () => (
 			onClick={() => {
 				alert('Clicked!');
 			}}
-			pillar={Pillar.Culture}
+			pillar={ArticlePillar.Culture}
 			priority="secondary"
 			linkName=""
 		>
@@ -207,7 +207,7 @@ export const Subdued = () => (
 			onClick={() => {
 				alert('Clicked!');
 			}}
-			pillar={Pillar.Lifestyle}
+			pillar={ArticlePillar.Lifestyle}
 			priority="subdued"
 			linkName=""
 		>
@@ -218,7 +218,7 @@ export const Subdued = () => (
 			onClick={() => {
 				alert('Clicked!');
 			}}
-			pillar={Pillar.Sport}
+			pillar={ArticlePillar.Sport}
 			priority="subdued"
 			linkName=""
 		>
@@ -229,7 +229,7 @@ export const Subdued = () => (
 			onClick={() => {
 				alert('Clicked!');
 			}}
-			pillar={Pillar.News}
+			pillar={ArticlePillar.News}
 			priority="subdued"
 			linkName=""
 		>
@@ -240,7 +240,7 @@ export const Subdued = () => (
 			onClick={() => {
 				alert('Clicked!');
 			}}
-			pillar={Pillar.Opinion}
+			pillar={ArticlePillar.Opinion}
 			priority="subdued"
 			linkName=""
 		>
@@ -251,7 +251,7 @@ export const Subdued = () => (
 			onClick={() => {
 				alert('Clicked!');
 			}}
-			pillar={Pillar.Culture}
+			pillar={ArticlePillar.Culture}
 			priority="subdued"
 			linkName=""
 		>

--- a/src/components/PillarButton/PillarButton.tsx
+++ b/src/components/PillarButton/PillarButton.tsx
@@ -4,12 +4,12 @@ import { css } from '@emotion/react';
 import { palette, neutral } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
 import { Button } from '@guardian/src-button';
-import { Pillar, Special, Theme } from '@guardian/types';
+import { ArticlePillar, ArticleSpecial, ArticleTheme } from '@guardian/libs';
 
 import { pillarToString } from '../../lib/pillarToString';
 
 type Props = {
-	pillar: Theme;
+	pillar: ArticleTheme;
 	onClick?: () => void;
 	children: string;
 	type?: 'submit';
@@ -22,26 +22,26 @@ type Props = {
 
 // Why this abstraction? To solve an issue where when we use the 800 key in `palette typescript throws errors. Most
 // likely caused by the fact labs only uses 300 & 400 so the union is restricted
-const dark = (pillar: Theme): string => {
+const dark = (pillar: ArticleTheme): string => {
 	switch (pillar) {
-		case Pillar.Culture:
+		case ArticlePillar.Culture:
 			return '#FBF6EF';
-		case Pillar.Opinion:
+		case ArticlePillar.Opinion:
 			return '#FEF9F5';
-		case Pillar.Lifestyle:
+		case ArticlePillar.Lifestyle:
 			return '#FEEEF7';
-		case Pillar.Sport:
+		case ArticlePillar.Sport:
 			return '#F1F8FC';
-		case Pillar.News:
-		case Special.SpecialReport:
-		case Special.Labs:
+		case ArticlePillar.News:
+		case ArticleSpecial.SpecialReport:
+		case ArticleSpecial.Labs:
 		default:
 			return '#FFF4F2';
 	}
 };
 
 const buttonOverrides = (
-	pillar: Theme,
+	pillar: ArticleTheme,
 	priority: 'primary' | 'secondary' | 'subdued',
 ) => {
 	switch (priority) {

--- a/src/components/TopPick/TopPick.stories.tsx
+++ b/src/components/TopPick/TopPick.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
 
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 
 import { TopPick } from '../TopPick/TopPick';
 import { CommentType } from '../../types';
@@ -58,7 +58,7 @@ export const LongPick = () => (
 		`}
 	>
 		<TopPick
-			pillar={Pillar.News}
+			pillar={ArticlePillar.News}
 			comment={comment}
 			isSignedIn={false}
 			userMadeComment={false}
@@ -76,7 +76,7 @@ export const ShortPick = () => (
 		`}
 	>
 		<TopPick
-			pillar={Pillar.Opinion}
+			pillar={ArticlePillar.Opinion}
 			comment={commentWithShortBody}
 			isSignedIn={true}
 			userMadeComment={false}

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -6,7 +6,7 @@ import { space, neutral, palette } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
 import { Link } from '@guardian/src-link';
 import { brand } from '@guardian/src-foundations/palette';
-import { Theme } from '@guardian/types';
+import { ArticleTheme } from '@guardian/libs';
 
 import { pillarToString } from '../../lib/pillarToString';
 
@@ -19,7 +19,7 @@ import { Row } from '../Row/Row';
 import { Column } from '../Column/Column';
 
 type Props = {
-	pillar: Theme;
+	pillar: ArticleTheme;
 	comment: CommentType;
 	isSignedIn: boolean;
 	userMadeComment: boolean;
@@ -48,7 +48,7 @@ const pickStyles = css`
 const arrowSize = 25;
 const bg = neutral[93];
 
-const userNameStyles = (pillar: Theme) => css`
+const userNameStyles = (pillar: ArticleTheme) => css`
 	margin-top: 3px;
 	margin-bottom: -6px;
 	font-weight: bold;

--- a/src/components/TopPicks/TopPicks.stories.tsx
+++ b/src/components/TopPicks/TopPicks.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Pillar } from '@guardian/types';
+import { ArticlePillar } from '@guardian/libs';
 
 import { CommentType } from '../../types';
 
@@ -58,7 +58,7 @@ const commentWithShortBody: CommentType = {
 
 export const SingleComment = () => (
 	<TopPicks
-		pillar={Pillar.News}
+		pillar={ArticlePillar.News}
 		comments={[commentWithShortBody]}
 		isSignedIn={true}
 		onPermalinkClick={() => {}}
@@ -68,7 +68,7 @@ SingleComment.story = { name: 'Single Comment' };
 
 export const MulitColumn = () => (
 	<TopPicks
-		pillar={Pillar.Culture}
+		pillar={ArticlePillar.Culture}
 		comments={[
 			commentWithLongBody,
 			commentWithShortBody,
@@ -83,7 +83,7 @@ MulitColumn.story = { name: 'Mulitple Columns Comments' };
 
 export const SingleColumn = () => (
 	<TopPicks
-		pillar={Pillar.Sport}
+		pillar={ArticlePillar.Sport}
 		comments={[
 			commentWithLongBody,
 			commentWithShortBody,

--- a/src/components/TopPicks/TopPicks.tsx
+++ b/src/components/TopPicks/TopPicks.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { css } from '@emotion/react';
 
 import { until, from } from '@guardian/src-foundations/mq';
-import { Theme } from '@guardian/types';
+import { ArticleTheme } from '@guardian/libs';
 
 import { CommentType, UserProfile } from '../../types';
 import { TopPick } from '../TopPick/TopPick';
 
 type Props = {
-	pillar: Theme;
+	pillar: ArticleTheme;
 	user?: UserProfile;
 	comments: CommentType[];
 	isSignedIn: boolean;

--- a/src/lib/pillarToEnum.ts
+++ b/src/lib/pillarToEnum.ts
@@ -1,21 +1,21 @@
-import { Pillar, Theme, Special } from '@guardian/types';
+import { ArticlePillar, ArticleTheme, ArticleSpecial } from '@guardian/libs';
 
 import { CAPIPillar } from '../types';
 
-export const pillarToEnum = (pillar: CAPIPillar): Theme => {
+export const pillarToEnum = (pillar: CAPIPillar): ArticleTheme => {
 	switch (pillar) {
 		case 'opinion':
-			return Pillar.Opinion;
+			return ArticlePillar.Opinion;
 		case 'culture':
-			return Pillar.Culture;
+			return ArticlePillar.Culture;
 		case 'sport':
-			return Pillar.Sport;
+			return ArticlePillar.Sport;
 		case 'lifestyle':
-			return Pillar.Lifestyle;
+			return ArticlePillar.Lifestyle;
 		case 'labs':
-			return Special.Labs;
+			return ArticleSpecial.Labs;
 		case 'news':
 		default:
-			return Pillar.News;
+			return ArticlePillar.News;
 	}
 };

--- a/src/lib/pillarToString.ts
+++ b/src/lib/pillarToString.ts
@@ -1,20 +1,20 @@
-import { Pillar, Special, Theme } from '@guardian/types';
+import { ArticlePillar, ArticleSpecial, ArticleTheme } from '@guardian/libs';
 
 import { CAPIPillar } from '../types';
 
-export const pillarToString = (pillar: Theme): CAPIPillar => {
+export const pillarToString = (pillar: ArticleTheme): CAPIPillar => {
 	switch (pillar) {
-		case Pillar.News:
+		case ArticlePillar.News:
 			return 'news';
-		case Pillar.Opinion:
+		case ArticlePillar.Opinion:
 			return 'opinion';
-		case Pillar.Culture:
+		case ArticlePillar.Culture:
 			return 'culture';
-		case Pillar.Sport:
+		case ArticlePillar.Sport:
 			return 'sport';
-		case Pillar.Lifestyle:
+		case ArticlePillar.Lifestyle:
 			return 'lifestyle';
-		case Special.Labs:
+		case ArticleSpecial.Labs:
 			return 'labs';
 		default:
 			return 'news';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2411,6 +2411,11 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@guardian/libs@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.1.0.tgz#44b0291741a0fce588167f4ec8c17fa9a7d41261"
+  integrity sha512-GJk34o9lUmP6FcBKd0FSV2RwvAKKJzcAV5mVdhgq/JmBNj8Ns5eiJlq8LG2ewIJJSzRaWT4h8Fg6n9KI8K0xDQ==
+
 "@guardian/prettier@^0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-0.4.2.tgz#2d08a8a50aad3911a88c9b53f92a37748694d551"
@@ -2471,11 +2476,6 @@
   dependencies:
     "@guardian/src-helpers" "^3.6.0"
     "@guardian/src-icons" "^3.6.0"
-
-"@guardian/types@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-3.0.0.tgz#bb2cc21f2436fca98143fb18bc58346e43ee9336"
-  integrity sha512-hTrk7EEsqSI/q7fyz2PuKMwKXuXRcwY7Ws+h72bvvimmpayfTwFQgEJfsjABxTSxdTw6bGA8T3F5GV4DJs9zog==
 
 "@hapi/address@2.x.x":
   version "2.1.4"


### PR DESCRIPTION
## What does this change?

This PR migrates from the [`@guardian/types`](https://github.com/guardian/types) library to [`@guardian/libs`](https://github.com/guardian/libs) as [`@guardian/types` is now deprecated](https://github.com/guardian/types/pull/140).

## How to test

Run all validation and ensure that everything still runs as expected.