### PR TITLE
Add Contributor badge to the top picks

### DIFF
--- a/src/components/TopPick/TopPick.stories.tsx
+++ b/src/components/TopPick/TopPick.stories.tsx
@@ -45,8 +45,33 @@ const comment: CommentType = {
 	},
 };
 
+const commentContributor: CommentType = {
+	...comment,
+	userProfile: {
+		...comment.userProfile,
+		badge: [
+			{
+				name: 'Contributor',
+			},
+		],
+	},
+};
+
 const commentWithShortBody: CommentType = {
 	...comment,
+	body: "<p>It's still there FrankDeFord - and thanks, I will pass that on</p>",
+};
+
+const contributorCommentWithShortBody: CommentType = {
+	...comment,
+	userProfile: {
+		...comment.userProfile,
+		badge: [
+			{
+				name: 'Contributor',
+			},
+		],
+	},
 	body: "<p>It's still there FrankDeFord - and thanks, I will pass that on</p>",
 };
 
@@ -66,7 +91,7 @@ export const LongPick = () => (
 		/>
 	</div>
 );
-LongPick.story = { name: 'Long' };
+LongPick.story = { name: 'Long - Staff' };
 
 export const ShortPick = () => (
 	<div
@@ -84,4 +109,40 @@ export const ShortPick = () => (
 		/>
 	</div>
 );
-ShortPick.story = { name: 'Short' };
+ShortPick.story = { name: 'Short - Staff' };
+
+export const LongPickContributor = () => (
+	<div
+		css={css`
+			width: 100%;
+			max-width: 300px;
+		`}
+	>
+		<TopPick
+			pillar={ArticlePillar.News}
+			comment={commentContributor}
+			isSignedIn={false}
+			userMadeComment={false}
+			onPermalinkClick={() => {}}
+		/>
+	</div>
+);
+LongPickContributor.story = { name: 'Long - Contributor' };
+
+export const ShortPickContributor = () => (
+	<div
+		css={css`
+			width: 100%;
+			max-width: 300px;
+		`}
+	>
+		<TopPick
+			pillar={ArticlePillar.Opinion}
+			comment={contributorCommentWithShortBody}
+			isSignedIn={true}
+			userMadeComment={false}
+			onPermalinkClick={() => {}}
+		/>
+	</div>
+);
+ShortPickContributor.story = { name: 'Short - Contributor' };

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -10,7 +10,7 @@ import { ArticleTheme } from '@guardian/libs';
 
 import { pillarToString } from '../../lib/pillarToString';
 
-import { GuardianStaff } from '../Badges/Badges';
+import { GuardianContributor, GuardianStaff } from '../Badges/Badges';
 import { CommentType } from '../../types';
 import { Avatar } from '../Avatar/Avatar';
 import { RecommendationCount } from '../RecommendationCount/RecommendationCount';
@@ -171,76 +171,82 @@ export const TopPick = ({
 	userMadeComment,
 	onPermalinkClick,
 	onRecommend,
-}: Props) => (
-	<div css={pickStyles}>
-		<PickBubble>
-			<Top>
-				<h3 css={titleStyles}>Guardian Pick</h3>
-				<p
-					css={[wrapStyles, inCommentLinkStyling]}
-					dangerouslySetInnerHTML={{
-						__html: truncateText(comment.body, 450),
-					}}
-				></p>
-			</Top>
-			<Bottom>
-				<div css={smallFontSize}>
-					<Link
-						priority="primary"
-						subdued={true}
-						href={comment.webUrl}
-						onClick={(e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-							onPermalinkClick(comment.id);
-							e.preventDefault();
+}: Props) => {
+	const showStaffBadge = comment.userProfile.badge.find(
+		(obj) => obj['name'] === 'Staff',
+	);
+
+	const showContributorBadge = comment.userProfile.badge.find(
+		(obj) => obj['name'] === 'Contributor',
+	);
+
+	return (
+		<div css={pickStyles}>
+			<PickBubble>
+				<Top>
+					<h3 css={titleStyles}>Guardian Pick</h3>
+					<p
+						css={[wrapStyles, inCommentLinkStyling]}
+						dangerouslySetInnerHTML={{
+							__html: truncateText(comment.body, 450),
 						}}
-						rel="nofollow"
-					>
-						Jump to comment
-					</Link>
-				</div>
-			</Bottom>
-		</PickBubble>
-		<PickMeta>
-			<Row>
-				<div css={avatarMargin}>
-					<Avatar
-						imageUrl={comment.userProfile.avatar}
-						displayName={''}
-						size="medium"
-					/>
-				</div>
-				<Column>
-					<span css={userNameStyles(pillar)}>
-						<a
-							href={comment.userProfile.webUrl}
-							css={[linkStyles, inheritColour]}
+					></p>
+				</Top>
+				<Bottom>
+					<div css={smallFontSize}>
+						<Link
+							priority="primary"
+							subdued={true}
+							href={comment.webUrl}
+							onClick={(e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+								onPermalinkClick(comment.id);
+								e.preventDefault();
+							}}
 							rel="nofollow"
 						>
-							{comment.userProfile.displayName}
-						</a>
-					</span>
-					<Timestamp
-						isoDateTime={comment.isoDateTime}
-						webUrl={comment.webUrl}
-						commentId={comment.id}
-						onPermalinkClick={onPermalinkClick}
-					/>
-					{!!comment.userProfile.badge.filter((obj) => obj['name'] === 'Staff')
-						.length ? (
-						<GuardianStaff />
-					) : (
-						<></>
-					)}
-				</Column>
-			</Row>
-			<RecommendationCount
-				commentId={comment.id}
-				initialCount={comment.numRecommends}
-				alreadyRecommended={false}
-				isSignedIn={isSignedIn}
-				userMadeComment={userMadeComment}
-				onRecommend={onRecommend}
-			/>
-		</PickMeta>
-	</div>
-);
+							Jump to comment
+						</Link>
+					</div>
+				</Bottom>
+			</PickBubble>
+			<PickMeta>
+				<Row>
+					<div css={avatarMargin}>
+						<Avatar
+							imageUrl={comment.userProfile.avatar}
+							displayName={''}
+							size="medium"
+						/>
+					</div>
+					<Column>
+						<span css={userNameStyles(pillar)}>
+							<a
+								href={comment.userProfile.webUrl}
+								css={[linkStyles, inheritColour]}
+								rel="nofollow"
+							>
+								{comment.userProfile.displayName}
+							</a>
+						</span>
+						<Timestamp
+							isoDateTime={comment.isoDateTime}
+							webUrl={comment.webUrl}
+							commentId={comment.id}
+							onPermalinkClick={onPermalinkClick}
+						/>
+						{showStaffBadge && <GuardianStaff />}
+						{showContributorBadge && !showStaffBadge && <GuardianContributor />}
+					</Column>
+				</Row>
+				<RecommendationCount
+					commentId={comment.id}
+					initialCount={comment.numRecommends}
+					alreadyRecommended={false}
+					isSignedIn={isSignedIn}
+					userMadeComment={userMadeComment}
+					onRecommend={onRecommend}
+				/>
+			</PickMeta>
+		</div>
+	);
+};


### PR DESCRIPTION
## What does this change?
In #524 we added the Contributor badge to comments but moderators would also like the Contributor badge to appear in any comments that are the top picks.

Before:
<img width="1496" alt="Screenshot 2021-09-27 at 16 14 17" src="https://user-images.githubusercontent.com/45561419/134937354-f000c488-894a-4899-b9e1-87ffeb3ad960.png">

After:
<img width="1512" alt="Screenshot 2021-09-27 at 16 14 03" src="https://user-images.githubusercontent.com/45561419/134937387-389e0aef-5020-4803-abee-f872ff5afd43.png">


## Why?
To achieve parity between frontend and dotcom-rendering

## Link to supporting Trello card
https://trello.com/c/J83m02bt