### PR TITLE
migrate discussion-rendering to source v4

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react"
-import { FocusStyleManager } from "@guardian/src-foundations/utils"
+import { FocusStyleManager } from "@guardian/source-foundations"
 import MockDate from 'mockdate';
 import { mockFetchCalls } from '../src/lib/mockFetchCalls';
 

--- a/package.json
+++ b/package.json
@@ -29,11 +29,8 @@
   "peerDependencies": {
     "@emotion/react": "^11.1.5",
     "@guardian/libs": "^3.1.0",
-    "@guardian/src-button": "^3.6.0",
-    "@guardian/src-foundations": "^3.6.0",
-    "@guardian/src-icons": "^3.6.0",
-    "@guardian/src-link": "^3.6.0",
-    "@guardian/src-text-input": "^3.6.0",
+    "@guardian/source-foundations": "^4.0.0-rc.0",
+    "@guardian/source-react-components": "^4.0.0-rc.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "typescript": "^4.1.3"
@@ -48,11 +45,8 @@
     "@emotion/react": "^11.1.5",
     "@guardian/libs": "^3.1.0",
     "@guardian/prettier": "^0.4.2",
-    "@guardian/src-button": "^3.6.0",
-    "@guardian/src-foundations": "^3.6.0",
-    "@guardian/src-icons": "^3.6.0",
-    "@guardian/src-link": "^3.6.0",
-    "@guardian/src-text-input": "^3.6.0",
+    "@guardian/source-foundations": "^4.0.0-rc.0",
+    "@guardian/source-react-components": "^4.0.0-rc.1",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
@@ -136,7 +130,7 @@
   "jest": {
     "testEnvironment": "jest-environment-jsdom-sixteen",
     "transformIgnorePatterns": [
-      "node_modules/(?!(@guardian/src-foundations|@guardian/libs)/)"
+      "node_modules/(?!(@guardian/libs)/)"
     ],
     "preset": "ts-jest/presets/js-with-babel",
     "moduleFileExtensions": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,11 +23,7 @@ module.exports = {
         // Ignore all dependencies and PeerDependencies in build
         ...Object.keys(pkg.dependencies || {}),
         ...Object.keys(pkg.peerDependencies || {}),
-        'prop-types',
-        // Nested src-foundations
-        '@guardian/src-foundations/mq',
-        '@guardian/src-foundations/palette',
-        '@guardian/src-foundations/typography',
+        'prop-types'
     ],
     plugins: [
         clear({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { css } from '@emotion/react';
 
-import { neutral } from '@guardian/src-foundations/palette';
-import { textSans } from '@guardian/src-foundations/typography';
-import { space } from '@guardian/src-foundations';
-import { SvgPlus } from '@guardian/src-icons';
+import { neutral, textSans, space } from '@guardian/source-foundations';
+import { SvgPlus } from '@guardian/source-react-components';
 
 import { ArticleTheme } from '@guardian/libs';
 

--- a/src/components/AbuseReportForm/AbuseReportForm.tsx
+++ b/src/components/AbuseReportForm/AbuseReportForm.tsx
@@ -1,16 +1,14 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { css } from '@emotion/react';
 
-import { palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/typography';
-import { space, neutral } from '@guardian/src-foundations';
-import { Button } from '@guardian/src-button';
-import { SvgCross } from '@guardian/src-icons';
+import { textSans, space, neutral } from '@guardian/source-foundations';
+import { Button, SvgCross } from '@guardian/source-react-components';
 
 import { ArticleTheme } from '@guardian/libs';
 
 import { reportAbuse } from '../../lib/api';
 import { pillarToString } from '../../lib/pillarToString';
+import { palette } from '../../lib/palette';
 
 type formData = {
 	categoryId: number;
@@ -20,7 +18,7 @@ type formData = {
 
 const formWrapper = css`
 	z-index: 1;
-	border: 1px solid ${palette.neutral[86]};
+	border: 1px solid ${neutral[86]};
 	position: absolute;
 	width: 300px;
 	top: 0;

--- a/src/components/Badges/Badges.tsx
+++ b/src/components/Badges/Badges.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
 
-import { space, neutral, brand } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/typography';
+import { space, neutral, brand, textSans } from '@guardian/source-foundations';
 
 const staffBadge = css`
 	display: flex;

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -1,13 +1,17 @@
 import React, { useState } from 'react';
 import { css } from '@emotion/react';
 
-import { space, palette, remSpace } from '@guardian/src-foundations';
-import { from, until } from '@guardian/src-foundations/mq';
-import { neutral, border } from '@guardian/src-foundations/palette';
-import { textSans } from '@guardian/src-foundations/typography';
-import { Link } from '@guardian/src-link';
-import { SvgIndent } from '@guardian/src-icons';
-import { Button } from '@guardian/src-button';
+import {
+	space,
+	remSpace,
+	from,
+	until,
+	neutral,
+	border,
+	textSans,
+	brand,
+} from '@guardian/source-foundations';
+import { Link, SvgIndent, Button } from '@guardian/source-react-components';
 
 import { ArticleTheme } from '@guardian/libs';
 
@@ -27,6 +31,7 @@ import { CommentType, UserProfile } from '../../types';
 import { pickComment, unPickComment } from '../../lib/api';
 import { createAuthenticationEventParams } from '../../lib/identity-component-event';
 import { pillarToString } from '../../lib/pillarToString';
+import { palette } from '../../lib/palette';
 
 type Props = {
 	user?: UserProfile;
@@ -114,7 +119,7 @@ const blockedCommentStyles = css`
 // to override a tag styles from dangerouslySetInnerHTML
 const commentLinkStyling = css`
 	a {
-		color: ${palette.brand[500]};
+		color: ${brand[500]};
 		text-decoration: none;
 		:hover {
 			text-decoration: underline;

--- a/src/components/CommentContainer/CommentContainer.tsx
+++ b/src/components/CommentContainer/CommentContainer.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { css } from '@emotion/react';
 
-import { space, neutral, border } from '@guardian/src-foundations';
-import { SvgPlus } from '@guardian/src-icons';
+import { space, neutral, border } from '@guardian/source-foundations';
+import { SvgPlus } from '@guardian/source-react-components';
 
 import { ArticleTheme } from '@guardian/libs';
 

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -1,9 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { css } from '@emotion/react';
 
-import { palette, space } from '@guardian/src-foundations';
-import { neutral, text } from '@guardian/src-foundations/palette';
-import { textSans } from '@guardian/src-foundations/typography';
+import { space, neutral, text, textSans } from '@guardian/source-foundations';
 
 import { ArticleTheme } from '@guardian/libs';
 
@@ -58,9 +56,9 @@ const commentTextArea = css`
 	margin-bottom: ${space[3]}px;
 	padding: 8px 10px 10px 8px;
 	${textSans.small()};
-	border-color: ${palette.neutral[86]};
+	border-color: ${neutral[86]};
 	:focus {
-		border-color: ${palette.neutral[46]};
+		border-color: ${neutral[46]};
 		outline: none;
 	}
 `;
@@ -124,7 +122,7 @@ const commentAddOns = css`
 	height: 22px;
 	font-size: 13px;
 	line-height: 17px;
-	border: 1px solid ${palette.neutral[100]};
+	border: 1px solid ${neutral[100]};
 	color: ${neutral[46]};
 	text-align: center;
 	cursor: pointer;

--- a/src/components/CommentReplyPreview/CommentReplyPreview.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.tsx
@@ -1,14 +1,13 @@
 import React, { useState } from 'react';
 import { css } from '@emotion/react';
 
-import { textSans } from '@guardian/src-foundations/typography';
-import { neutral, space, text, palette } from '@guardian/src-foundations';
-import { SvgIndent } from '@guardian/src-icons';
+import { neutral, space, text, textSans } from '@guardian/source-foundations';
+import { Button, SvgIndent } from '@guardian/source-react-components';
 import { ArticleTheme } from '@guardian/libs';
-import { Button } from '@guardian/src-button';
 
 import { Row } from '../Row/Row';
 import { pillarToString } from '../../lib/pillarToString';
+import { palette } from '../../lib/palette';
 
 import { CommentType } from '../../types';
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -3,20 +3,21 @@ import { css } from '@emotion/react';
 
 import FocusLock from 'react-focus-lock';
 
-import { palette } from '@guardian/src-foundations';
 import {
 	neutral,
 	border,
 	brandAlt,
 	background,
-} from '@guardian/src-foundations/palette';
-import { textSans } from '@guardian/src-foundations/typography';
-import { from, until } from '@guardian/src-foundations/mq';
+	textSans,
+	from,
+	until,
+} from '@guardian/source-foundations';
 import { ArticleTheme } from '@guardian/libs';
 
 import { DropdownOptionType } from '../../types';
 
 import { pillarToString } from '../../lib/pillarToString';
+import { palette } from '../../lib/palette';
 
 type Props = {
 	id: string;

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
 
-import { space } from '@guardian/src-foundations';
-import { border } from '@guardian/src-foundations/palette';
+import { space, border } from '@guardian/source-foundations';
 import { ArticleTheme } from '@guardian/libs';
 
 import { Dropdown } from '../Dropdown/Dropdown';

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -1,9 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { css } from '@emotion/react';
-import { textSans, headline } from '@guardian/src-foundations/typography';
-import { space, neutral } from '@guardian/src-foundations';
-import { TextInput } from '@guardian/src-text-input';
-import { Link } from '@guardian/src-link';
+import {
+	textSans,
+	headline,
+	space,
+	neutral,
+} from '@guardian/source-foundations';
+import { Link, TextInput } from '@guardian/source-react-components';
 import { ArticleTheme } from '@guardian/libs';
 
 import { Row } from '../Row/Row';

--- a/src/components/LoadingComments/LoadingComments.tsx
+++ b/src/components/LoadingComments/LoadingComments.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { css, keyframes } from '@emotion/react';
 
-import { space } from '@guardian/src-foundations';
-import { neutral } from '@guardian/src-foundations/palette';
+import { space, neutral } from '@guardian/source-foundations';
 
 import { Row } from '../Row/Row';
 import { Column } from '../Column/Column';

--- a/src/components/LoadingPicks/LoadingPicks.tsx
+++ b/src/components/LoadingPicks/LoadingPicks.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { css, keyframes } from '@emotion/react';
 
-import { space } from '@guardian/src-foundations';
-import { neutral } from '@guardian/src-foundations/palette';
+import { space, neutral } from '@guardian/source-foundations';
 
 import { Row } from '../Row/Row';
 

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
 import { css } from '@emotion/react';
 
-import { textSans } from '@guardian/src-foundations/typography';
-import { neutral, border, space } from '@guardian/src-foundations';
-import { until } from '@guardian/src-foundations/mq';
-import { Button } from '@guardian/src-button';
 import {
+	textSans,
+	neutral,
+	border,
+	space,
+	until,
+} from '@guardian/source-foundations';
+import {
+	Button,
 	SvgChevronLeftSingle,
 	SvgChevronRightSingle,
-} from '@guardian/src-icons';
+} from '@guardian/source-react-components';
 
 import { FilterOptions } from '../../types';
 

--- a/src/components/PillarButton/PillarButton.stories.tsx
+++ b/src/components/PillarButton/PillarButton.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { css } from '@emotion/react';
 
-import { space } from '@guardian/src-foundations';
-import { SvgCheckmark } from '@guardian/src-icons';
+import { space } from '@guardian/source-foundations';
+import { SvgCheckmark } from '@guardian/source-react-components';
 import { ArticlePillar } from '@guardian/libs';
 
 import { Row } from '../Row/Row';

--- a/src/components/PillarButton/PillarButton.tsx
+++ b/src/components/PillarButton/PillarButton.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { css } from '@emotion/react';
 
-import { palette, neutral } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/typography';
-import { Button } from '@guardian/src-button';
+import { neutral, textSans } from '@guardian/source-foundations';
+import { Button } from '@guardian/source-react-components';
 import { ArticlePillar, ArticleSpecial, ArticleTheme } from '@guardian/libs';
 
 import { pillarToString } from '../../lib/pillarToString';
+import { palette } from '../../lib/palette';
 
 type Props = {
 	pillar: ArticleTheme;

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
 
-import { space, neutral } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/typography';
+import { space, neutral, textSans } from '@guardian/source-foundations';
 
 type Props = {
 	previewHtml: string;

--- a/src/components/RecommendationCount/RecommendationCount.tsx
+++ b/src/components/RecommendationCount/RecommendationCount.tsx
@@ -1,10 +1,8 @@
 import React, { useState } from 'react';
 import { css } from '@emotion/react';
 
-import { textSans } from '@guardian/src-foundations/typography';
-import { neutral } from '@guardian/src-foundations/palette';
-import { brand } from '@guardian/src-foundations';
-import { SvgArrowUpStraight } from '@guardian/src-icons';
+import { brand, textSans, neutral } from '@guardian/source-foundations';
+import { SvgArrowUpStraight } from '@guardian/source-react-components';
 import { Row } from '../Row/Row';
 
 import { recommend as recommendDefault } from '../../lib/api';

--- a/src/components/Timestamp/Timestamp.tsx
+++ b/src/components/Timestamp/Timestamp.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
 import { css } from '@emotion/react';
 
-import { textSans } from '@guardian/src-foundations/typography';
-import { palette } from '@guardian/src-foundations';
+import { textSans, neutral } from '@guardian/source-foundations';
 
 import { dateFormatter } from '../../lib/dateFormatter';
 import { useInterval } from '../../lib/useInterval';
@@ -15,7 +14,7 @@ type Props = {
 };
 
 const linkStyles = css`
-	color: ${palette.neutral[46]};
+	color: ${neutral[46]};
 	text-decoration: none;
 	:hover,
 	:focus {

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
 import { css } from '@emotion/react';
 
-import { from } from '@guardian/src-foundations/mq';
-import { space, neutral, palette } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/typography';
-import { Link } from '@guardian/src-link';
-import { brand } from '@guardian/src-foundations/palette';
+import {
+	from,
+	space,
+	neutral,
+	textSans,
+	brand,
+} from '@guardian/source-foundations';
+import { Link } from '@guardian/source-react-components';
 import { ArticleTheme } from '@guardian/libs';
 
 import { pillarToString } from '../../lib/pillarToString';
+import { palette } from '../../lib/palette';
 
 import { GuardianContributor, GuardianStaff } from '../Badges/Badges';
 import { CommentType } from '../../types';

--- a/src/components/TopPicks/TopPicks.tsx
+++ b/src/components/TopPicks/TopPicks.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
 
-import { until, from } from '@guardian/src-foundations/mq';
+import { until, from } from '@guardian/source-foundations';
 import { ArticleTheme } from '@guardian/libs';
 
 import { CommentType, UserProfile } from '../../types';

--- a/src/lib/palette.ts
+++ b/src/lib/palette.ts
@@ -1,0 +1,17 @@
+import {
+	news,
+	opinion,
+	culture,
+	sport,
+	lifestyle,
+	labs,
+} from '@guardian/source-foundations';
+
+export const palette = {
+	news,
+	opinion,
+	culture,
+	sport,
+	lifestyle,
+	labs,
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,17 +86,17 @@ type UserNameUser = {
 		legacyPackages: string;
 		legacyProducts: string;
 		// Optional fields. See scala @ https://git.io/JiKSd
-		brazeUuid?: string,
-		puzzleUuid?: string,
-		googleTagId?: string,
-		firstName?: string,
-		secondName?: string,
-		registrationIp?: string,
-		lastActiveIpAddress?: string,
-		registrationType?: string,
-		registrationPlatform?: string,
-		telephoneNumber?: string,
-		title?: string,
+		brazeUuid?: string;
+		puzzleUuid?: string;
+		googleTagId?: string;
+		firstName?: string;
+		secondName?: string;
+		registrationIp?: string;
+		lastActiveIpAddress?: string;
+		registrationType?: string;
+		registrationPlatform?: string;
+		telephoneNumber?: string;
+		title?: string;
 	};
 	primaryEmailAddress: string;
 	id: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2421,61 +2421,15 @@
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-0.4.2.tgz#2d08a8a50aad3911a88c9b53f92a37748694d551"
   integrity sha512-f8MCY/s3rLNonqxITsqnqrPRt0r6hEyW6rGKqDexTt88fEQnA3BMtAlN2hqjuNfrOa9EQexEknZugRVdIpbijQ==
 
-"@guardian/src-button@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-button/-/src-button-3.6.0.tgz#b620c4512f6069e97ca61380a9cf20a30108b3e2"
-  integrity sha512-7YOAp8MHwm4UGRylAKlctM34bVoyICk2OP83nYchf9U4+b+ih3W2fdTwikQdlMhdA49XV/8zl2XSe+4WFcCuLw==
-  dependencies:
-    "@guardian/src-helpers" "^3.6.0"
+"@guardian/source-foundations@^4.0.0-rc.0":
+  version "4.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-4.0.0-rc.1.tgz#981c0ec19a3d7b59ca6d604bf1cbcf9f8db8257f"
+  integrity sha512-I7Tb4xpjhOnjd4sCJ1YstkxMpYLxNMwdR0YZFatTGUWsWRGCUDk4vIwDbrzX2/SE/okSwOQ/UPc0bYqvdCOzzg==
 
-"@guardian/src-foundations@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-3.6.0.tgz#7bf7d4a7c28f9f4812494fdb22b8019c1c466ef5"
-  integrity sha512-KjcBwR334dhWWB6l1/j6kUcUncDgyIEE0M+ifwHPoVB/n/OVcB0LJl/a7qTCUPBYpxeZ3wukaTcMVr2zz+VL1Q==
-
-"@guardian/src-helpers@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-helpers/-/src-helpers-3.6.0.tgz#85c5c4bd73ccf9d6a768f228f664671ecadc3982"
-  integrity sha512-Y3mrvH1qaXoMkM2/U/7dfDO5ZUiyfSi9iRrioVMabS4CnrRVELVJkt0aTk5FAG2A966z6mYkHzbTOTWaESLCmw==
-  dependencies:
-    "@guardian/src-foundations" "^3.6.0"
-    mini-svg-data-uri "^1.2.3"
-
-"@guardian/src-icons@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-3.6.0.tgz#f093cd554f928e189e4d6ac069c6c7b5e65558ff"
-  integrity sha512-2j8TrRFyFbFBYGBdfL6ExCh0Bqgga0coi7H40tb3flV4UazyQqAGYuUb2r8Z38MJfTpotcPLxkA0uU6LY7VP7w==
-
-"@guardian/src-label@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-label/-/src-label-3.6.0.tgz#0d65a7a07875d0b705392ee76157c54d24104cfc"
-  integrity sha512-NyxLj8/xcZOvMj0qJ1EpNpVrcfdO44TR9NLvNnud1gcksEWur4EcWUeGgcrbJdOdK0LS7fbDUbYj5GnBWhN0aw==
-  dependencies:
-    "@guardian/src-helpers" "^3.6.0"
-
-"@guardian/src-link@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-link/-/src-link-3.6.0.tgz#c3295b0e986efefcace176cafeaacc898c335c70"
-  integrity sha512-4fZVLFs9AM0Bn5OOQEsHn9MiNB7wwWlT1Deze7DQkB1qP+R0kpPEs5AVsDMmubNbthrNZz9mxOYQF5IcLujxVA==
-  dependencies:
-    "@guardian/src-helpers" "^3.6.0"
-
-"@guardian/src-text-input@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-text-input/-/src-text-input-3.6.0.tgz#73e0e0b10b8a35abf79b9da970517ca8587c76a3"
-  integrity sha512-ej9mUte7LhKpVcytMtylgz0bosybzm7Wmm31yK3h+y/Le81ZC7T63qs56CkR9cgy32jP8z0XbdwDg3YTu/mOWA==
-  dependencies:
-    "@guardian/src-helpers" "^3.6.0"
-    "@guardian/src-label" "^3.6.0"
-    "@guardian/src-user-feedback" "^3.6.0"
-
-"@guardian/src-user-feedback@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-user-feedback/-/src-user-feedback-3.6.0.tgz#574cfd66528d2a509b5473a506fe0924773f604f"
-  integrity sha512-tCg/XJynB+xygJhuxoz6nDHmAXEqxesiKcYXFYVwKCDObdaCpO17TX623AFrpxra9jEdazqzrojy0Xpr7y2BMg==
-  dependencies:
-    "@guardian/src-helpers" "^3.6.0"
-    "@guardian/src-icons" "^3.6.0"
+"@guardian/source-react-components@^4.0.0-rc.1":
+  version "4.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@guardian/source-react-components/-/source-react-components-4.0.0-rc.1.tgz#cd6f372471f8cc09d868ab0c8afd9d2dd7e428d7"
+  integrity sha512-C0hZuTpeJSv+GV9r4G8OTQRZt8SKjvFjtbYeXVCxccseDVq3tjT9eOKQg08X809PvYWtFOVgZR+ySHnqJVyiAg==
 
 "@hapi/address@2.x.x":
   version "2.1.4"
@@ -14128,11 +14082,6 @@ mini-css-extract-plugin@0.8.0:
     normalize-url "1.9.1"
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
-
-mini-svg-data-uri@^1.2.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.3.3.tgz#91d2c09f45e056e5e1043340b8b37ba7b50f4fac"
-  integrity sha512-+fA2oRcR1dJI/7ITmeQJDrYWks0wodlOz0pAEhKYJ2IVc1z0AnwJUsKY2fzFmPAM3Jo9J0rBx8JAA9QQSJ5PuA==
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Why?

We have published a Source v4 release candidate, and are keen for dotcom-rendering and apps-rendering to be first benefit from the improved developer ergonomics 🎉   In order to do this, we must update packages that they depend on, so as to avoid bundling both v3 and v4 of Source.

We have written an eslint plugin that has automated the majority of the upgrade. 

## What has changed?

Source now comprises 3 packages:

- `@guardian/source-foundations`: equivalent to `@guardian/src-foundations`
- `@guardian/source-react-components`: contains all components from packages that were prefixed `@guardian/src-*`
- `@guardian/source-react-components-development-kitchen`: New and experimental components

## Workarounds

There are a few places that use the old `palette` object to do `palette[pillarToString(pillar)][400]`.

As `palette` has now been deprecated in favour of importing the component parts directly, this is no longer possible. To replicate the existing behaviour in a type safe way, whilst making minimal changes, the required `palette` object (containing only the parts required here, rather than the full object available previously) has been created in `src/lib/palette.ts`. In a future PR, this pattern could well be refactored to provide a nicer solution, potentially combining it with the `pillarToString` function.