### PR TITLE
feat: Expand by default if comments in hash

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -239,7 +239,9 @@ export const App = ({
 			isClosedForComments,
 		}),
 	);
-	const [isExpanded, setIsExpanded] = useState<boolean>(expanded);
+	const [isExpanded, setIsExpanded] = useState<boolean>(
+		expanded || window.location.hash === '#comments',
+	);
 	const [loading, setLoading] = useState<boolean>(true);
 	const [loadingMore, setLoadingMore] = useState<boolean>(false);
 	const [totalPages, setTotalPages] = useState<number>(0);


### PR DESCRIPTION
## What does this change?
This PR defaults the list of comments to `isExpanded` if the url contains the '#comments' hash

## Why?
If we do this, then when a reader clicks on the count of comments at the top of an article, then we no longer need to use javascript to change a prop and rerender the component. That link click can simply use a href to navigate.
