### PR TITLE
fix: Re-add anchor icon to comment permalink.

### DIFF
--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -131,6 +131,10 @@ const commentWrapper = css`
 	border-top: 1px solid ${border.secondary};
 	display: flex;
 	padding: ${space[2]}px 0;
+
+	:hover .comment-permalink-icon {
+		display: inline-block;
+	}
 `;
 
 const selectedStyles = css`

--- a/src/components/Timestamp/Timestamp.tsx
+++ b/src/components/Timestamp/Timestamp.tsx
@@ -28,6 +28,16 @@ const timeStyles = css`
 	white-space: nowrap;
 `;
 
+const anchorStyles = css`
+	display: none;
+	width: 15px;
+	height: 15px;
+	vertical-align: middle;
+	margin-left: 0.125rem;
+	max-height: 0.9375rem;
+	fill: #ffffff;
+`;
+
 export const Timestamp = ({
 	isoDateTime,
 	webUrl,
@@ -54,6 +64,15 @@ export const Timestamp = ({
 			<time dateTime={isoDateTime.toString()} css={timeStyles}>
 				{timeAgo}
 			</time>
+
+			<span css={anchorStyles} className="comment-permalink-icon">
+				<svg viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg">
+					<path
+						fill="#898989"
+						d="M5.725,13.348c-0.979,1.021-2.6,1.055-3.623,0.076c-1.02-0.979-1.055-2.602-0.076-3.623l8.424-8.79 c0.732-0.766,1.95-0.792,2.717-0.057c0.768,0.734,0.791,1.949,0.059,2.715l-6.894,7.193C5.84,11.375,5.03,11.393,4.52,10.9 c-0.511-0.488-0.528-1.299-0.04-1.81l5.324-5.553l0.337,0.321L4.816,9.413c-0.311,0.325-0.3,0.84,0.025,1.152 c0.326,0.312,0.841,0.301,1.15-0.024l6.896-7.193c0.557-0.581,0.536-1.501-0.043-2.058c-0.581-0.557-1.504-0.537-2.058,0.043 l-8.427,8.79c-0.798,0.837-0.771,2.163,0.063,2.965c0.836,0.802,2.164,0.772,2.965-0.062l6.853-7.152l0.338,0.323L5.725,13.348z"
+					/>
+				</svg>
+			</span>
 		</a>
 	);
 };

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -156,6 +156,10 @@ const PickMeta = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
 			display: flex;
 			justify-content: space-between;
 			padding-top: ${space[1]}px;
+
+			:hover .comment-permalink-icon {
+				display: inline-block;
+			}
 		`}
 	>
 		{children}


### PR DESCRIPTION
## What does this change?

Shows the permalink icon when the comment is hovered over by the user. This used to be the old behaviour that was used by Frontend

## Frontend version
![image](https://user-images.githubusercontent.com/21217225/150557579-c0e4f0df-77de-4b1c-8d53-ae3ae66976e5.png)
![image](https://user-images.githubusercontent.com/21217225/150557705-f14ae536-24d3-49b3-98d5-cc6837ff8480.png)


|                                                      Before                                                     |                                                      After                                                      |
|:---------------------------------------------------------------------------------------------------------------:|:---------------------------------------------------------------------------------------------------------------:|
| ![image](https://user-images.githubusercontent.com/21217225/150558588-1c1b91c5-4b04-4a8f-9281-0227c94e6bbc.png) | ![image](https://user-images.githubusercontent.com/21217225/150557899-5105808f-3007-43c1-8987-fdabd409dae4.png) |
| ![image](https://user-images.githubusercontent.com/21217225/150558291-7416e7e6-03b7-45ea-a02b-4d49ddf047a4.png) | ![image](https://user-images.githubusercontent.com/21217225/150557957-67c437d5-aadf-4909-be64-217b9f713cc8.png) |

