### PR TITLE
Refactor expansion

### DIFF
--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -42,9 +42,6 @@ export const LoggedOutHiddenPicks = () => (
 			expanded={false}
 			onPermalinkClick={() => {}}
 			apiKey=""
-			onExpanded={(expandedTime) => {
-				console.log(expandedTime);
-			}}
 		/>
 	</div>
 );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -256,7 +256,6 @@ export const App = ({
 	const [commentCount, setCommentCount] = useState<number>(0);
 	const [mutes, setMutes] = useState<string[]>(readMutes());
 
-
 	useEffect(() => {
 		if (isExpanded) {
 			// We want react to complete the current work and render, without trying to batch this update
@@ -271,6 +270,12 @@ export const App = ({
 			return () => clearTimeout(timer);
 		}
 	}, [isExpanded, comments.length]);
+
+	useEffect(() => {
+		// We need this use effect to capture any changes in the expanded prop. This is typicallly
+		// seen when clicking permalinks
+		setIsExpanded(expanded);
+	}, [expanded]);
 
 	useEffect(() => {
 		setLoading(true);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,6 @@ type Props = {
 		parentCommentId: number,
 	) => Promise<CommentResponse>;
 	onPreview?: (body: string) => Promise<string>;
-	onExpanded?: (expandedTime: number) => void;
 };
 
 const footerStyles = css`
@@ -210,7 +209,7 @@ const writeMutes = (mutes: string[]) => {
 		// capture these errors
 	}
 };
-let expandedStartTime: number;
+
 export const App = ({
 	baseUrl,
 	shortUrl,
@@ -229,7 +228,6 @@ export const App = ({
 	onComment,
 	onReply,
 	onPreview,
-	onExpanded,
 }: Props) => {
 	const [filters, setFilters] = useState<FilterOptions>(
 		initialiseFilters({
@@ -258,16 +256,6 @@ export const App = ({
 	const [commentCount, setCommentCount] = useState<number>(0);
 	const [mutes, setMutes] = useState<string[]>(readMutes());
 
-	useEffect(() => {
-		if (
-			isExpanded &&
-			onExpanded &&
-			window.performance &&
-			window.performance.now
-		) {
-			onExpanded(window.performance.now() - expandedStartTime);
-		}
-	}, [isExpanded, onExpanded]);
 
 	useEffect(() => {
 		if (isExpanded) {
@@ -367,14 +355,6 @@ export const App = ({
 		setPage(page);
 	};
 
-	const expandView = () => {
-		if (window.performance && window.performance.now) {
-			expandedStartTime = window.performance.now();
-		}
-
-		setIsExpanded(true);
-	};
-
 	const toggleMuteStatus = (userId: string) => {
 		let updatedMutes;
 		if (mutes.includes(userId)) {
@@ -397,7 +377,7 @@ export const App = ({
 
 		if (!isExpanded) {
 			// It's possible to post a comment without the view being expanded
-			expandView();
+			setIsExpanded(true);
 		}
 
 		const commentElement = document.getElementById(`comment-${comment.id}`);
@@ -490,7 +470,7 @@ export const App = ({
 					>
 						<PillarButton
 							pillar={pillar}
-							onClick={() => expandView()}
+							onClick={() => setIsExpanded(true)}
 							icon={<SvgPlus />}
 							iconSide="left"
 							linkName="more-comments"


### PR DESCRIPTION
## What does this change?
This PR simplifies how expansion is handled.

It removes the callback we were using to track how long it took to expand as this were adding complexity to the code and was no longer needed or used. We previously used this callback as part of the migration to Emotion 11 work.

It adds a step to ensure that the `isExpanded` state is set whenever the `expanded` prop changes. There are use cases where the `Discussion` component in the parent is reloaded with a new value for this prop (permalinks) and we need to respect this.

This PR closes https://github.com/guardian/dotcom-rendering/issues/4297