### PR TITLE
Remove expand button

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -56,7 +56,6 @@ describe('App', () => {
 			screen.getByTestId('loading-comments'),
 		);
 
-		expect(screen.getByText('View more comments')).toBeInTheDocument();
 		expect(screen.queryAllByText('jamesgorrie').length).toBeGreaterThan(0);
 		expect(screen.queryByPlaceholderText('Join the discussion')).toBeNull();
 	});
@@ -77,10 +76,6 @@ describe('App', () => {
 				apiKey="discussion-rendering-test"
 				onPermalinkClick={() => {}}
 			/>,
-		);
-
-		await waitForElementToBeRemoved(() =>
-			screen.getAllByTestId('loading-comments'),
 		);
 
 		expect(screen.queryAllByPlaceholderText('Join the discussion').length).toBe(

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import {
 	render,
-	fireEvent,
 	waitForElementToBeRemoved,
 	screen,
 } from '@testing-library/react';
@@ -36,33 +35,6 @@ const aUser = {
 jest.setTimeout(20000);
 
 describe('App', () => {
-	it('should expand when view more button is clicked', async () => {
-		render(
-			<App
-				baseUrl=""
-				shortUrl="p/39f5z"
-				pillar={ArticlePillar.News}
-				isClosedForComments={false}
-				expanded={false}
-				additionalHeaders={{
-					'D2-X-UID': 'testD2Header',
-					'GU-Client': 'testClientHeader',
-				}}
-				apiKey="discussion-rendering-test"
-				onPermalinkClick={() => {}}
-			/>,
-		);
-
-		await waitForElementToBeRemoved(() =>
-			screen.getByTestId('loading-comments'),
-		);
-
-		expect(screen.queryByText('View more comments')).toBeInTheDocument();
-		fireEvent.click(screen.getByText('View more comments'));
-		expect(screen.queryByText('View more comments')).not.toBeInTheDocument();
-		expect(screen.getByText('Display threads')).toBeInTheDocument();
-	});
-
 	it('should not render the comment form if user is logged out', async () => {
 		render(
 			<App
@@ -114,55 +86,5 @@ describe('App', () => {
 		expect(screen.queryAllByPlaceholderText('Join the discussion').length).toBe(
 			2,
 		);
-	});
-
-	it('should not render the view more button if there are zero comments', async () => {
-		render(
-			<App
-				baseUrl=""
-				shortUrl="p/39f5x" // A discussion with no comments
-				pillar={ArticlePillar.News}
-				isClosedForComments={false}
-				expanded={false}
-				additionalHeaders={{
-					'D2-X-UID': 'testD2Header',
-					'GU-Client': 'testClientHeader',
-				}}
-				apiKey="discussion-rendering-test"
-				onPermalinkClick={() => {}}
-			/>,
-		);
-
-		await waitForElementToBeRemoved(() =>
-			screen.getByTestId('loading-comments'),
-		);
-
-		expect(screen.getByText('Display threads')).toBeInTheDocument();
-		expect(screen.queryByText('View more comments')).not.toBeInTheDocument();
-	});
-
-	it('should not render the view more button if there are only two comments', async () => {
-		render(
-			<App
-				baseUrl=""
-				shortUrl="p/39f5a" // A discussion with only two comments
-				pillar={ArticlePillar.News}
-				isClosedForComments={false}
-				expanded={false}
-				additionalHeaders={{
-					'D2-X-UID': 'testD2Header',
-					'GU-Client': 'testClientHeader',
-				}}
-				apiKey="discussion-rendering-test"
-				onPermalinkClick={() => {}}
-			/>,
-		);
-
-		await waitForElementToBeRemoved(() =>
-			screen.getByTestId('loading-comments'),
-		);
-
-		expect(screen.getByText('Display threads')).toBeInTheDocument();
-		expect(screen.queryByText('View more comments')).not.toBeInTheDocument();
 	});
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -395,7 +395,9 @@ export const App = ({
 
 	const showPagination = totalPages > 1;
 
-	if (!isExpanded && loading) return <></>;
+	if (!isExpanded && loading) {
+		return <span data-testid="loading-comments"></span>;
+	}
 
 	if (!isExpanded) {
 		return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -391,6 +391,8 @@ export const App = ({
 
 	const showPagination = totalPages > 1;
 
+	if (!isExpanded && loading) return <></>;
+
 	if (!isExpanded) {
 		return (
 			<div css={commentContainerStyles} data-component="discussion">
@@ -437,9 +439,7 @@ export const App = ({
 								filters={filters}
 							/>
 						)}
-						{loading ? (
-							<LoadingComments />
-						) : !comments.length ? (
+						{!comments.length ? (
 							<NoComments />
 						) : (
 							<ul css={commentContainerStyles}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { css } from '@emotion/react';
 
 import { neutral, textSans, space } from '@guardian/source-foundations';
-import { SvgPlus } from '@guardian/source-react-components';
 
 import { ArticleTheme } from '@guardian/libs';
 
@@ -22,7 +21,6 @@ import { CommentForm } from './components/CommentForm/CommentForm';
 import { Filters } from './components/Filters/Filters';
 import { Pagination } from './components/Pagination/Pagination';
 import { LoadingComments } from './components/LoadingComments/LoadingComments';
-import { PillarButton } from './components/PillarButton/PillarButton';
 
 type Props = {
 	shortUrl: string;
@@ -466,24 +464,6 @@ export const App = ({
 							</ul>
 						)}
 					</>
-				)}
-				{commentCount > 2 && (
-					<div
-						css={css`
-							width: 250px;
-						`}
-					>
-						<PillarButton
-							pillar={pillar}
-							onClick={() => setIsExpanded(true)}
-							icon={<SvgPlus />}
-							iconSide="left"
-							linkName="more-comments"
-							size="small"
-						>
-							View more comments
-						</PillarButton>
-					</div>
 				)}
 			</div>
 		);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ type Props = {
 		parentCommentId: number,
 	) => Promise<CommentResponse>;
 	onPreview?: (body: string) => Promise<string>;
+	onExpand?: () => void;
 };
 
 const footerStyles = css`
@@ -226,6 +227,7 @@ export const App = ({
 	onComment,
 	onReply,
 	onPreview,
+	onExpand,
 }: Props) => {
 	const [filters, setFilters] = useState<FilterOptions>(
 		initialiseFilters({
@@ -349,6 +351,7 @@ export const App = ({
 		rememberFilters(newFilterObject);
 		// Filters also show when the view is not expanded but we want to expand when they're changed
 		setIsExpanded(true);
+		if (typeof onExpand === 'function') onExpand();
 		setFilters(newFilterObject);
 	};
 
@@ -381,6 +384,7 @@ export const App = ({
 		if (!isExpanded) {
 			// It's possible to post a comment without the view being expanded
 			setIsExpanded(true);
+			if (typeof onExpand === 'function') onExpand();
 		}
 
 		const commentElement = document.getElementById(`comment-${comment.id}`);


### PR DESCRIPTION
## What does this change?
This removes the `View more comment` expand button and associated tests

## Why?
We're going to move this button to the calling container so that we can fix its height and reduce layout shifts