### PR TITLE
Refactor unexpanded state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -356,6 +356,8 @@ export const App = ({
 	};
 
 	const onPageChange = (page: number) => {
+		// Pagination also show when the view is not expanded so we want to expand when clicked
+		setIsExpanded(true);
 		const element = document.getElementById('comment-filters');
 		element && element.scrollIntoView();
 		setPage(page);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -402,17 +402,6 @@ export const App = ({
 	if (!isExpanded) {
 		return (
 			<div css={commentContainerStyles} data-component="discussion">
-				{user && !isClosedForComments && (
-					<CommentForm
-						pillar={pillar}
-						shortUrl={shortUrl}
-						onAddComment={onAddComment}
-						user={user}
-						onComment={onComment}
-						onReply={onReply}
-						onPreview={onPreview}
-					/>
-				)}
 				{picks && picks.length ? (
 					<div css={picksWrapper}>
 						{!!picks.length && (

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -175,10 +175,14 @@ export const CommentForm = ({
 
 	useEffect(() => {
 		if (commentBeingRepliedTo) {
-			const commentElement = document.getElementById(
-				`comment-reply-form-${commentBeingRepliedTo.id}`,
-			);
-			commentElement && commentElement.scrollIntoView();
+			document
+				.getElementById(`comment-${commentBeingRepliedTo.id}`)
+				?.scrollIntoView();
+			document
+				.querySelector<HTMLTextAreaElement>(
+					`#comment-reply-form-${commentBeingRepliedTo.id} textarea`,
+				)
+				?.focus();
 		}
 	}, [commentBeingRepliedTo]);
 


### PR DESCRIPTION
## What does this change?
This PR changes how discussion acts when unexpanded.

- Clicking pagination auto expands the discussion
- You can no longer post a comment when unexpanded  (Fixes https://github.com/guardian/dotcom-rendering/issues/4743)

## Why?
We recently made some changes in DCR to fix the height of the container

### Drive-by 🏎️ 
I also added a cheeky drive-by UX change to focus the textarea when a reader clicks 'Reply' (Fixes https://github.com/guardian/dotcom-rendering/issues/4740)