### PR TITLE
refactor: resolve git.io link

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -85,7 +85,7 @@ type UserNameUser = {
 	privateFields: {
 		legacyPackages: string;
 		legacyProducts: string;
-		// Optional fields. See scala @ https://git.io/JiKSd
+		// Optional fields. See scala @ https://github.com/guardian/identity/blob/d72ff3ed1f6d69800f0e3fee81cf49839d903f16/identity-model-play/src/main/scala/com/gu/identity/model/play/PrivateFields.scala#L6-L18
 		brazeUuid?: string;
 		puzzleUuid?: string;
 		googleTagId?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,7 +85,7 @@ type UserNameUser = {
 	privateFields: {
 		legacyPackages: string;
 		legacyProducts: string;
-		// Optional fields. See scala @ https://github.com/guardian/identity/blob/d72ff3ed1f6d69800f0e3fee81cf49839d903f16/identity-model-play/src/main/scala/com/gu/identity/model/play/PrivateFields.scala#L6-L18
+		// Optional fields. See scala @ https://github.com/guardian/identity/blob/07142212b1571d5f8e0a60585c6511abb3620f8c/identity-model-play/src/main/scala/com/gu/identity/model/play/PrivateFields.scala#L5-L18
 		brazeUuid?: string;
 		puzzleUuid?: string;
 		googleTagId?: string;


### PR DESCRIPTION
## What does this change?

Resolve the `git.io` links.

## Why?

https://github.blog/changelog/2022-04-25-git-io-deprecation/
