### PR TITLE
fix: add CSS resets

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,9 +1,15 @@
 import React, { useEffect } from "react"
-import { FocusStyleManager } from "@guardian/source-foundations"
+import { FocusStyleManager, resets } from "@guardian/source-foundations"
 import MockDate from 'mockdate';
 import { mockFetchCalls } from '../src/lib/mockFetchCalls';
 
 MockDate.set('Fri March 27 2020 12:00:00 GMT+0000 (Greenwich Mean Time)');
+
+// Add global CSS styles
+let head = document.querySelector('head');
+let style = document.createElement('style');
+head.appendChild(style);
+style.appendChild(document.createTextNode(resets.resetCSS));
 
 mockFetchCalls();
 
@@ -74,6 +80,7 @@ const FocusManagerDecorator = storyFn => {
 	})
 
 	return <div>{storyFn()}</div>
+	
 }
 
 export const decorators = [FocusManagerDecorator];


### PR DESCRIPTION
## What does this change?

Adds [Source’s reset CSS](https://github.com/guardian/source/blob/main/packages/@guardian/source-foundations/src/utils/resets.stories.mdx)

## Why?

These are currently missing from Storybook, which prevents us from having Chromatic screenshots that look like production

## Screenshots

<img width="702" alt="First comment" src="https://user-images.githubusercontent.com/76776/167398666-0158da2b-bef3-49e5-ba16-92e4b3f594c8.png">
