### PR TITLE
Fix comment preview spacing

### DIFF
--- a/src/components/Preview/Preview.stories.tsx
+++ b/src/components/Preview/Preview.stories.tsx
@@ -1,10 +1,30 @@
 import React from 'react';
+import { css } from '@emotion/react';
 
 import { Preview } from './Preview';
 
 export default { component: Preview, title: 'Preview' };
 
 export const PreviewStory = () => (
-	<Preview previewHtml="<p>This is some preview text</p>" />
+	<div
+		css={css`
+			padding: 20px;
+			width: 700px;
+		`}
+	>
+		<Preview previewHtml="<p>This is some preview text</p>" />
+	</div>
 );
 PreviewStory.story = { name: 'default' };
+
+export const PreviewStoryLinebreaks = () => (
+	<div
+		css={css`
+			padding: 20px;
+			width: 700px;
+		`}
+	>
+		<Preview previewHtml="<p>This is some preview text<br>with a line break in the middle of a paragraph</p><p>This is a new paragraph.</p>" />
+	</div>
+);
+PreviewStoryLinebreaks.story = { name: 'Preview comment with linebreaks' };

--- a/src/components/Preview/Preview.stories.tsx
+++ b/src/components/Preview/Preview.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
 
+import { resets } from '@guardian/source-foundations';
 import { Preview } from './Preview';
 
 export default { component: Preview, title: 'Preview' };
@@ -12,6 +13,7 @@ export const PreviewStory = () => (
 			width: 700px;
 		`}
 	>
+		<style>{resets.resetCSS}</style>
 		<Preview previewHtml="<p>This is some preview text</p>" />
 	</div>
 );
@@ -24,7 +26,8 @@ export const PreviewStoryLinebreaks = () => (
 			width: 700px;
 		`}
 	>
-		<Preview previewHtml="<p>This is some preview text<br>with a line break in the middle of a paragraph</p><p>This is a new paragraph.</p>" />
+		<style>{resets.resetCSS}</style>
+		<Preview previewHtml="<p>Hello world!<br>this is a line break </p> <p>this is two</p> <p><br>this is three</p>" />
 	</div>
 );
 PreviewStoryLinebreaks.story = { name: 'Preview comment with linebreaks' };

--- a/src/components/Preview/Preview.stories.tsx
+++ b/src/components/Preview/Preview.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
 
-import { resets } from '@guardian/source-foundations';
 import { Preview } from './Preview';
 
 export default { component: Preview, title: 'Preview' };
@@ -13,7 +12,6 @@ export const PreviewStory = () => (
 			width: 700px;
 		`}
 	>
-		<style>{resets.resetCSS}</style>
 		<Preview previewHtml="<p>This is some preview text</p>" />
 	</div>
 );
@@ -26,7 +24,6 @@ export const PreviewStoryLinebreaks = () => (
 			width: 700px;
 		`}
 	>
-		<style>{resets.resetCSS}</style>
 		<Preview previewHtml="<p>Hello world!<br>this is a line break </p> <p>this is two</p> <p><br>this is three</p>" />
 	</div>
 );

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -50,22 +50,22 @@ const previewStyle = css`
 `;
 
 const spout = css`
-	&::before {
-		content: '';
-		display: block;
-		left: 0;
-		width: 0;
-		height: 0;
-		border-right: 1rem solid transparent;
-		border-bottom: 1rem solid ${neutral[93]};
-		margin-left: 12.5rem;
-		border-right-style: inset;
-	}
+	display: block;
+	left: 0;
+	width: 0;
+	height: 0;
+	border-right: 1rem solid transparent;
+	border-bottom: 1rem solid ${neutral[93]};
+	margin-left: 12.5rem;
+	border-right-style: inset;
 `;
 
 export const Preview = ({ previewHtml }: Props) => (
-	<div
-		css={[previewStyle, spout]}
-		dangerouslySetInnerHTML={{ __html: previewHtml || '' }}
-	/>
+	<>
+		<div css={spout} />
+		<div
+			css={previewStyle}
+			dangerouslySetInnerHTML={{ __html: previewHtml || '' }}
+		/>
+	</>
 );

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -37,25 +37,30 @@ const previewStyle = css`
 		font-family: monospace;
 		font-size: 1em;
 	}
+
+	p {
+		margin-top: 0;
+		margin-bottom: ${space[3]}px;
+	}
 `;
 
 const spout = css`
-	display: block;
-	left: 0;
-	width: 0;
-	height: 0;
-	border-right: 1rem solid transparent;
-	border-bottom: 1rem solid ${neutral[93]};
-	margin-left: 12.5rem;
-	border-right-style: inset;
+	&::before {
+		content: '';
+		display: block;
+		left: 0;
+		width: 0;
+		height: 0;
+		border-right: 1rem solid transparent;
+		border-bottom: 1rem solid ${neutral[93]};
+		margin-left: 12.5rem;
+		border-right-style: inset;
+	}
 `;
 
 export const Preview = ({ previewHtml }: Props) => (
-	<>
-		<div css={spout} />
-		<p
-			css={previewStyle}
-			dangerouslySetInnerHTML={{ __html: previewHtml || '' }}
-		/>
-	</>
+	<div
+		css={[previewStyle, spout]}
+		dangerouslySetInnerHTML={{ __html: previewHtml || '' }}
+	/>
 );

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -38,6 +38,11 @@ const previewStyle = css`
 		font-size: 1em;
 	}
 
+	/*
+		todo: this spacing is currently repeated here, on regular comments, and
+		on TopPick comments; can we factor out the common styling for these
+		three components?
+	*/
 	p {
 		margin-top: 0;
 		margin-bottom: ${space[3]}px;


### PR DESCRIPTION
## What does this change?
It adds bottom margin to paragraph tags.

## Why?
This makes the styling in comment previews more consistent with the styling of submitted comments. This should address the first part of [this issue](https://github.com/guardian/dotcom-rendering/issues/4741#issuecomment-1118468827).

## Screenshots

(From storybook)

| Before in Prod     | Before in storybook | After in storybook |
|-------------|------------|------------|
| <img width="957" alt="Before in prod" src="https://user-images.githubusercontent.com/37048459/167393694-64b743ae-cbe4-403f-a9b5-611388878957.png"> | <img width="634" alt="Before in storybook" src="https://user-images.githubusercontent.com/37048459/167394877-ab9466e0-182f-493d-972b-9f9e52c42ea7.png"> | <img width="678" alt="After in storybook" src="https://user-images.githubusercontent.com/37048459/167393846-2b8615fb-6087-41cf-9179-61f22e6fd3f2.png"> |

Previously, the storybook rendering of comment previews didn't match the production site, because the dotcom site applies reset styles which weren't being applied in storybook. This PR adds the reset styles (globally, merging #572) and also adds spacing to the preview comments. So there shouldn't be much visual change in the storybook itself, but the storybook should now match dotcom.
