### PR TITLE
fix(np): run np from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "build-storybook": "build-storybook",
     "lint": "eslint . --ext .ts,.tsx",
     "createTsDec": "tsc --emitDeclarationOnly true --declaration true --declarationDir build/ --noEmit false",
-    "release": "yarn validate && yarn build && np"
+    "release": "yarn validate && yarn build && yarn np"
   },
   "eslintConfig": {
     "extends": "react-app",


### PR DESCRIPTION
## What does this change?

Allow releasing without having installed `np` globally.

## Why?

It’s already in the package deps. We tested it locally with @bryophyta 
