### PR TITLE
Use a dot to separate hours and minutes

### DIFF
--- a/src/lib/dateFormatter.ts
+++ b/src/lib/dateFormatter.ts
@@ -31,7 +31,7 @@ export const dateFormatter = (dateString: string) => {
 
 	return `${date.getDate()} ${
 		monthConverter[date.getMonth()]
-	} ${date.getFullYear()} ${date.getHours()}:${
+	} ${date.getFullYear()} ${date.getHours()}.${
 		(date.getMinutes() < 10 ? '0' : '') + date.getMinutes()
 	}`;
 };

--- a/src/lib/dateFormatter.ts
+++ b/src/lib/dateFormatter.ts
@@ -31,7 +31,7 @@ export const dateFormatter = (dateString: string) => {
 
 	return `${date.getDate()} ${
 		monthConverter[date.getMonth()]
-	} ${date.getFullYear()} ${date.getHours()}.${
-		(date.getMinutes() < 10 ? '0' : '') + date.getMinutes()
-	}`;
+	} ${date.getFullYear()} ${date.getHours()}.${String(
+		date.getMinutes(),
+	).padStart(2, '0')}`;
 };


### PR DESCRIPTION
## What does this change?

- Changes the separator between hours and minutes from a colon `:` (`hh:mm`) to a dot `.` (`hh.mm`)

## Why?

- For consistency with the [Guardian style guide](https://www.theguardian.com/guardian-observer-style-guide-t#:~:text=timebomb%2C%20timescale%2C%20timeshare-,times,-1am%2C%206.30pm%2C%20etc) and other parts of the website which display timestamps like live/dead blogs

## Screenshots

| Before | After |
| - | - |
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/705427/180019804-26c5c137-f746-45b3-9ba7-1a2a2f956147.png
[after]: https://user-images.githubusercontent.com/705427/180019915-c90ef0d0-420c-4446-ac4e-06c8ee181bc0.png