### PR TITLE
Bump version to 10.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@guardian/discussion-rendering",
   "description": "This codebase started as a hack day project by @gtrufitt and @nicl. The purpose is parity of the existing discussion application on Frontend using the discussion API (search for Private Repo).",
-  "version": "10.1.1",
+  "version": "10.1.2",
   "author": "",
   "homepage": "https://github.com/guardian/discussion-rendering#readme",
   "license": "Apache",


### PR DESCRIPTION
## What does this change?

- Bumps `package.json` version to `10.1.2` ahead of publishing this package to `npm`

## Why?

- To reflect a8655b3028f654d7ff700903011f2b3e4f537941 - separating hours & minutes with a dot (`.`)