### PR TITLE
Show the second comment box less

### DIFF
--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -154,6 +154,34 @@ export const LoggedIn = () => (
 LoggedIn.story = {
 	name: 'when logged in and expanded',
 };
+
+export const LoggedInShortDiscussion = () => (
+	<div
+		css={css`
+			width: 100%;
+			max-width: 620px;
+		`}
+	>
+		<App
+			shortUrl="p/39f5a" // Two comments"
+			pillar={ArticlePillar.News}
+			isClosedForComments={false}
+			user={aUser}
+			baseUrl="https://discussion.theguardian.com/discussion-api"
+			additionalHeaders={{
+				'D2-X-UID': 'testD2Header',
+				'GU-Client': 'testClientHeader',
+			}}
+			expanded={true}
+			onPermalinkClick={() => {}}
+			apiKey=""
+		/>
+	</div>
+);
+LoggedInShortDiscussion.story = {
+	name: 'when logged in but only wo comments made',
+};
+
 export const LoggedOutHiddenNoPicks = () => (
 	<div
 		css={css`

--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -128,6 +128,32 @@ LoggedInHiddenNoPicks.story = {
 	name: 'when logged in, with no picks and not expanded',
 };
 
+export const LoggedIn = () => (
+	<div
+		css={css`
+			width: 100%;
+			max-width: 620px;
+		`}
+	>
+		<App
+			shortUrl="p/abc123"
+			pillar={ArticlePillar.News}
+			isClosedForComments={false}
+			user={aUser}
+			baseUrl="https://discussion.theguardian.com/discussion-api"
+			additionalHeaders={{
+				'D2-X-UID': 'testD2Header',
+				'GU-Client': 'testClientHeader',
+			}}
+			expanded={true}
+			onPermalinkClick={() => {}}
+			apiKey=""
+		/>
+	</div>
+);
+LoggedIn.story = {
+	name: 'when logged in and expanded',
+};
 export const LoggedOutHiddenNoPicks = () => (
 	<div
 		css={css`

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -59,27 +59,4 @@ describe('App', () => {
 		expect(screen.queryAllByText('jamesgorrie').length).toBeGreaterThan(0);
 		expect(screen.queryByPlaceholderText('Join the discussion')).toBeNull();
 	});
-
-	it('should render two comment forms when user is logged in', async () => {
-		render(
-			<App
-				baseUrl=""
-				shortUrl="p/39f5z"
-				pillar={ArticlePillar.News}
-				isClosedForComments={false}
-				user={aUser}
-				expanded={true}
-				additionalHeaders={{
-					'D2-X-UID': 'testD2Header',
-					'GU-Client': 'testClientHeader',
-				}}
-				apiKey="discussion-rendering-test"
-				onPermalinkClick={() => {}}
-			/>,
-		);
-
-		expect(screen.queryAllByPlaceholderText('Join the discussion').length).toBe(
-			2,
-		);
-	});
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -548,7 +548,7 @@ export const App = ({
 					/>
 				</footer>
 			)}
-			{user && !isClosedForComments && (
+			{user && !isClosedForComments && comments.length > 10 && (
 				<CommentForm
 					pillar={pillar}
 					shortUrl={shortUrl}


### PR DESCRIPTION
## What does this change?
We now only show the second comment box when there are more than 10 comments. This closes #588 

## Why?
Having two comment boxes so close together on the page makes no sense, we only need to start showing the second one after the discussion starts to get longer

| Before | After |
| -------- | ------- |
| <img width="638" alt="Screenshot 2022-07-29 at 10 10 58" src="https://user-images.githubusercontent.com/1336821/181726744-ff9d1b95-77b0-4955-abb2-021732fbe23e.png"> | <img width="638" alt="Screenshot 2022-07-29 at 10 04 41" src="https://user-images.githubusercontent.com/1336821/181726771-6f122eb2-84db-4a7e-b998-1d37b8183dd4.png"> |
