### PR TITLE
fix(deps): keep devDependencies together

### DIFF
--- a/.changeset/ten-coats-judge.md
+++ b/.changeset/ten-coats-judge.md
@@ -1,0 +1,5 @@
+---
+'@guardian/discussion-rendering': patch
+---
+
+Keep `devDependencies` where they should be

--- a/package.json
+++ b/package.json
@@ -21,13 +21,6 @@
     "build/**/*"
   ],
   "dependencies": {
-    "@rollup/plugin-html": "^0.2.4",
-    "@rollup/plugin-replace": "^4.0.0",
-    "babel-plugin-emotion": "^10.0.33",
-    "customize-cra": "^1.0.0",
-    "rollup-plugin-livereload": "^2.0.5",
-    "rollup-plugin-serve": "^1.1.0",
-    "rollup-plugin-terser": "^7.0.2",
     "timeago.js": "^4.0.2"
   },
   "peerDependencies": {
@@ -54,7 +47,9 @@
     "@guardian/source-react-components": "^4.4.0",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^17.1.0",
+    "@rollup/plugin-html": "^0.2.4",
     "@rollup/plugin-node-resolve": "^11.2.0",
+    "@rollup/plugin-replace": "^4.0.0",
     "@storybook/addon-actions": "^6.1.18",
     "@storybook/addon-essentials": "^6.1.18",
     "@storybook/addon-links": "^6.1.18",
@@ -68,6 +63,8 @@
     "@types/react-dom": "^17.0.1",
     "babel-loader": "^8.2.2",
     "babel-plugin-const-enum": "^1.0.1",
+    "babel-plugin-emotion": "^10.0.33",
+    "customize-cra": "^1.0.0",
     "eslint-plugin-react-hooks": "^4.0.4",
     "fetch-mock": "^9.3.1",
     "husky": "^4.2.3",
@@ -82,6 +79,9 @@
     "react-scripts": "3.3.0",
     "rollup": "^2.40.0",
     "rollup-plugin-clear": "^2.0.7",
+    "rollup-plugin-livereload": "^2.0.5",
+    "rollup-plugin-serve": "^1.1.0",
+    "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-visualizer": "^4.2.0",
     "storybook-chromatic": "^4.0.2",
     "ts-jest": "^26.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6184,7 +6184,7 @@ babel-plugin-dynamic-import-node@^2.3.3:
   dependencies:
     object.assign "^4.1.0"
 
-babel-plugin-emotion@^10.0.20, babel-plugin-emotion@^10.0.33:
+babel-plugin-emotion@^10.0.20:
   version "10.0.33"
   resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz#ce1155dcd1783bbb9286051efee53f4e2be63e03"
   integrity sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==
@@ -6209,6 +6209,22 @@ babel-plugin-emotion@^10.0.27:
     "@emotion/hash" "0.7.4"
     "@emotion/memoize" "0.7.4"
     "@emotion/serialize" "^0.11.15"
+    babel-plugin-macros "^2.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^1.0.5"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+
+babel-plugin-emotion@^10.0.33:
+  version "10.2.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz#a1fe3503cff80abfd0bdda14abd2e8e57a79d17d"
+  integrity sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/hash" "0.8.0"
+    "@emotion/memoize" "0.7.4"
+    "@emotion/serialize" "^0.11.16"
     babel-plugin-macros "^2.0.0"
     babel-plugin-syntax-jsx "^6.18.0"
     convert-source-map "^1.5.0"


### PR DESCRIPTION
## What does this change?

Keeps `devDependencies` together

## Why?

So consumers stop downloading them unnecessarily.

Flagged by @georgeblahblah in https://github.com/guardian/dotcom-rendering/pull/5949#discussion_r963852620
