### PR TITLE
chore: remove vscode workbench colour settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,9 +15,5 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "workbench.colorCustomizations": {
-    "titleBar.activeBackground": "#DC267F",
-    "titleBar.activeForeground": "#000000"
-  },
   "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
## What does this change?

- Removes workbench colour definitions from VSCode settings

## Why?

- I'm not sure these should be configured by the repository