### PR TITLE
refactor(timeAgo): use the @guardian/libs one

### DIFF
--- a/.changeset/calm-eggs-laugh.md
+++ b/.changeset/calm-eggs-laugh.md
@@ -1,0 +1,5 @@
+---
+'@guardian/discussion-rendering': patch
+---
+
+Usage of `timeAgo` from @guardian/libs. The timestamps no longer have hours and minutes if they happened longer than 48h ago.

--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
   "files": [
     "build/**/*"
   ],
-  "dependencies": {
-    "timeago.js": "^4.0.2"
-  },
   "peerDependencies": {
     "@emotion/react": "^11.1.5",
     "@guardian/libs": "^3.1.0",

--- a/src/components/Timestamp/Timestamp.tsx
+++ b/src/components/Timestamp/Timestamp.tsx
@@ -34,7 +34,7 @@ export const Timestamp = ({
 	commentId,
 	onPermalinkClick,
 }: Props) => {
-	let [timeAgo, setTimeAgo] = useState(dateFormatter(isoDateTime));
+	const [timeAgo, setTimeAgo] = useState(dateFormatter(isoDateTime));
 
 	useInterval(() => {
 		setTimeAgo(dateFormatter(isoDateTime));

--- a/src/lib/dateFormatter.ts
+++ b/src/lib/dateFormatter.ts
@@ -1,5 +1,4 @@
-// date.getMonth() gets months from index 0
-import { format } from 'timeago.js';
+import { timeAgo } from '@guardian/libs';
 
 const monthConverter: { [key: number]: string } = {
 	0: 'Jan',
@@ -26,7 +25,7 @@ export const dateFormatter = (dateString: string) => {
 	const date = new Date(dateString);
 
 	if (isLast24Hrs(date)) {
-		return format(date);
+		return timeAgo(date.getTime(), { verbose: true, daysUntilAbsolute: 1 });
 	}
 
 	return `${date.getDate()} ${

--- a/yarn.lock
+++ b/yarn.lock
@@ -19975,11 +19975,6 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
-timeago.js@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/timeago.js/-/timeago.js-4.0.2.tgz#724e8c8833e3490676c7bb0a75f5daf20e558028"
-  integrity sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w==
-
 timers-browserify@^2.0.4:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.11.tgz#800b1f3eee272e5bc53ee465a04d0e804c31211f"


### PR DESCRIPTION
## What does this change?

Remove `timeago.js` in favour of our own `@guardian/libs` one.

## Why?

We have a similar abstraction in [`@guardian/libs/timeAgo`](https://github.com/guardian/csnx/blob/main/libs/%40guardian/libs/src/datetime/timeAgo.ts)

## Screenshots

<img width="1315" alt="image" src="https://user-images.githubusercontent.com/76776/189177565-622ce286-11ac-4cca-b389-579e790565fe.png">

