### PR TITLE
Fix Chromatic action

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -10,5 +10,5 @@ jobs:
           yarn && yarn build
       - uses: chromaui/action@v1
         with:
-          appCode: ${{ secrets.CHROMATIC_APP_CODE }}
+          projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this change?

Rename `appCode` to `projectToken`

## Why?

This variable has been renamed in April 2020 https://github.com/chromaui/action/pull/22

## Link to supporting Trello card
