### PR TITLE
Update chromatic secret

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -10,5 +10,5 @@ jobs:
           yarn && yarn build
       - uses: chromaui/action@v1
         with:
-          projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this change?

[The secret](https://www.chromatic.com/manage?appId=5e80d53adc9c280022406eae&view=configure) has been added to both actions and dependabot workflows in the admin panel:

- https://github.com/guardian/dotcom-rendering/settings/secrets/actions
- https://github.com/guardian/dotcom-rendering/settings/secrets/dependabot

## Why?

Dependabot PRs cannot successfully run the Chromatic action

Follow-up on #612 
