### PR TITLE
Bump @guardian packages

### DIFF
--- a/.changeset/silly-pots-protect.md
+++ b/.changeset/silly-pots-protect.md
@@ -1,0 +1,9 @@
+---
+'@guardian/discussion-rendering': major
+---
+
+Bring in the latest Source packages, which bring major visual changes to:
+- Line height, which is now a little bit tighter
+- `Link` & `LinkButton`, which no longer have a subdued setting and come with
+  an underline for accessibility
+- Pillar colours, which have been tweaked to provide higher contrast

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "peerDependencies": {
     "@emotion/react": "^11.1.5",
     "@guardian/libs": "^3.1.0",
-    "@guardian/source-foundations": "^4.2.1",
-    "@guardian/source-react-components": "^4.4.0",
+    "@guardian/source-foundations": "^7.0.1",
+    "@guardian/source-react-components": "^9.0.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },
@@ -43,8 +43,8 @@
     "@emotion/react": "^11.1.5",
     "@guardian/libs": "^3.1.0",
     "@guardian/prettier": "^0.4.2",
-    "@guardian/source-foundations": "^4.2.1",
-    "@guardian/source-react-components": "^4.4.0",
+    "@guardian/source-foundations": "^7.0.1",
+    "@guardian/source-react-components": "^9.0.1",
     "@storybook/addon-actions": "^6.5.13",
     "@storybook/addon-essentials": "^6.5.13",
     "@storybook/addon-links": "^6.5.13",
@@ -105,7 +105,9 @@
     },
     "overrides": [
       {
-        "files": ["src/**/*.stories.tsx"],
+        "files": [
+          "src/**/*.stories.tsx"
+        ],
         "rules": {
           "import/no-anonymous-default-export": "off"
         }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "peerDependencies": {
     "@emotion/react": "^11.1.5",
-    "@guardian/libs": "^3.1.0",
+    "@guardian/libs": "^9.0.1",
     "@guardian/source-foundations": "^7.0.1",
     "@guardian/source-react-components": "^9.0.1",
     "react": "^17.0.1",
@@ -41,7 +41,7 @@
     "@changesets/cli": "^2.24.1",
     "@emotion/babel-preset-css-prop": "^11.10.0",
     "@emotion/react": "^11.1.5",
-    "@guardian/libs": "^3.1.0",
+    "@guardian/libs": "^9.0.1",
     "@guardian/prettier": "^0.4.2",
     "@guardian/source-foundations": "^7.0.1",
     "@guardian/source-react-components": "^9.0.1",
@@ -80,7 +80,8 @@
     "storybook-chromatic": "^4.0.2",
     "ts-jest": "^26.5.0",
     "typescript": "^4.8.4",
-    "vite": "^3.1.8"
+    "vite": "^3.1.8",
+    "web-vitals": "^3.0.4"
   },
   "scripts": {
     "build": "vite build && yarn createTsDec",

--- a/src/components/TopPick/TopPick.tsx
+++ b/src/components/TopPick/TopPick.tsx
@@ -200,7 +200,6 @@ export const TopPick = ({
 					<div css={smallFontSize}>
 						<Link
 							priority="primary"
-							subdued={true}
 							href={comment.webUrl}
 							onClick={(e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
 								onPermalinkClick(comment.id);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2684,17 +2684,17 @@
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-0.4.2.tgz#2d08a8a50aad3911a88c9b53f92a37748694d551"
   integrity sha512-f8MCY/s3rLNonqxITsqnqrPRt0r6hEyW6rGKqDexTt88fEQnA3BMtAlN2hqjuNfrOa9EQexEknZugRVdIpbijQ==
 
-"@guardian/source-foundations@^4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-4.2.1.tgz#26bbc0976ccca9d2f57c87467945fd965166888e"
-  integrity sha512-9enZ10Tpe9ZCnY1rL1NdiFT1UFPoFWdo0CsKL7Fz1v0UDqvCsNk4OA/ppJkNF07tDSffPFDuQWi8EJaxGLy2Ow==
+"@guardian/source-foundations@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-7.0.1.tgz#b838ab2cf0e2d7b93a617552730eec5b86f6292c"
+  integrity sha512-23dyR0Z/dmly9H2H+6Z0YLOP3vpThE979k9b+jDND6TExcSxo6GTFllvUYNRJb7KZ3pJPqG0wYMGg1q+2o9ogQ==
   dependencies:
     mini-svg-data-uri "^1.3.3"
 
-"@guardian/source-react-components@^4.4.0":
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/source-react-components/-/source-react-components-4.4.0.tgz#69cf404b56db3ca507702d29dae6a40eeb145cf4"
-  integrity sha512-5Q4Vl8ek0UV0Y9ob5y3Smq5xHs1d3lEzLynv5qqlYqVBlhze5Ypg5IzrPcEpKtcUaCIQeI9d5FevHM9fmm18sQ==
+"@guardian/source-react-components@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/source-react-components/-/source-react-components-9.0.1.tgz#468fd1739dbb53363be5a4e9d0ed552013e74f0d"
+  integrity sha512-d6go5ySn1rynKcg/NZjIBVZtefJNgreA06u8MNh1o6jdNGNug+NCGG8ztAL6aq8IdKtJw5vRvbeSGjh6bAAViQ==
 
 "@humanwhocodes/config-array@^0.11.6":
   version "0.11.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2674,10 +2674,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@guardian/libs@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.1.0.tgz#44b0291741a0fce588167f4ec8c17fa9a7d41261"
-  integrity sha512-GJk34o9lUmP6FcBKd0FSV2RwvAKKJzcAV5mVdhgq/JmBNj8Ns5eiJlq8LG2ewIJJSzRaWT4h8Fg6n9KI8K0xDQ==
+"@guardian/libs@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-9.0.1.tgz#0cae687b733d8ab34af6482edb5da07e815eb58f"
+  integrity sha512-3nDfG/wRjhAXejQH4MCc0C0fpl5aSDQhuyOYqi5lb+nfrpw5uldH89xVIB/fcIK+OcrrCeCEndbPvpP41298vw==
 
 "@guardian/prettier@^0.4.2":
   version "0.4.2"
@@ -17787,6 +17787,11 @@ web-namespaces@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
+
+web-vitals@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-3.0.4.tgz#a78ea93e95f7d7961dd151e0a76ac132c5dee2c9"
+  integrity sha512-Yau8qf1AJ/dm6MY180Bi0qpCIuWmAfKAnOqmxLecGfIHn0+ND3H4JOhXeY73Pyi9zjSF5J4SNUewHLNUzU7mmA==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
## What does this change?

Bump @guardian packages:
- [@guardian/source-foundations](https://www.npmjs.com/package/@guardian/source-foundations) v7
- [@guardian/source-react-components](https://www.npmjs.com/package/@guardian/source-react-components) v9
- [@guardian/libs](https://www.npmjs.com/package/@guardian/libs) v9

Bump this package to the next major version, due to the flurry of visual changes. [See chromatic diff](https://www.chromatic.com/test?appId=5e80d53adc9c280022406eae&id=6357e091736422fae1b8cf56).

## Why?

These have received major updates, which include a change in the way underlines of `Link` and `LinkButton` are handled. It is no longer possible to set their styles as `subdued`.

We need to capture this change via Chromatic. See alos https://github.com/guardian/dotcom-rendering/issues/6255

