### PR TITLE
Use classic JSX runtime

### DIFF
--- a/.changeset/rude-mayflies-count.md
+++ b/.changeset/rude-mayflies-count.md
@@ -1,0 +1,5 @@
+---
+'@guardian/discussion-rendering': patch
+---
+
+Externalise react-is and react/jsx-runtime

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,10 +11,12 @@ export default defineConfig({
   plugins: [
     react({
         jsxImportSource: "@emotion/react",
+        jsxRuntime: 'classic',
     }),
   ],
   build: {
     outDir,
+    minify: false,
     lib: {
       entry: "./src/App.tsx",
       formats: ["cjs","es"],


### PR DESCRIPTION
## What does this change?

Use the classic JSX runtime and [opt out of the automatic one](https://github.com/vitejs/vite/tree/main/packages/plugin-react#opting-out-of-the-automatic-jsx-runtime).

## Why?

So this version can work with `preact/compat`.
Tested locally with `yarn link` in `dotcom-rendering`

