### PR TITLE
fix: drop source maps from build

### DIFF
--- a/.changeset/fresh-crabs-bake.md
+++ b/.changeset/fresh-crabs-bake.md
@@ -1,0 +1,5 @@
+---
+'@guardian/discussion-rendering': patch
+---
+
+Drop sourcemaps from build

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@guardian/discussion-rendering",
   "description": "This codebase started as a hack day project by @gtrufitt and @nicl. The purpose is parity of the existing discussion application on Frontend using the discussion API (search for Private Repo).",
-  "version": "11.0.2",
+  "version": "11.0.3-0",
   "author": "",
   "homepage": "https://github.com/guardian/discussion-rendering#readme",
   "license": "Apache",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,14 @@ export default defineConfig({
 			jsxRuntime: 'classic',
 			babel: {
 				// https://emotion.sh/docs/install#babelrc
-				plugins: ['@emotion'],
+				plugins: [
+					[
+						'@emotion',
+						{
+							sourceMap: false,
+						},
+					],
+				],
 			},
 		}),
 	],


### PR DESCRIPTION
## What does this change?

Stop bundling the sourcemaps in the built package.

This branch has been tested via a pre-release of [11.0.3-0](https://github.com/guardian/discussion-rendering/releases/tag/v11.0.3-0) in DCR.

## Why?

This seems to crash dotcom-rendering: https://github.com/guardian/dotcom-rendering/pull/6329
