### PR TITLE
Soft-code the identity url

### DIFF
--- a/.changeset/hungry-pears-behave.md
+++ b/.changeset/hungry-pears-behave.md
@@ -1,0 +1,5 @@
+---
+'@guardian/discussion-rendering': patch
+---
+
+Soft-code identity url in set username flow

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ type Props = {
 	) => Promise<CommentResponse>;
 	onPreview?: (body: string) => Promise<string>;
 	onExpand?: () => void;
+	stage?: string;
 };
 
 const footerStyles = css`
@@ -228,6 +229,7 @@ export const App = ({
 	onReply,
 	onPreview,
 	onExpand,
+	stage,
 }: Props) => {
 	const [filters, setFilters] = useState<FilterOptions>(
 		initialiseFilters({
@@ -474,6 +476,7 @@ export const App = ({
 					onComment={onComment}
 					onReply={onReply}
 					onPreview={onPreview}
+					stage={stage}
 				/>
 			)}
 			{!!picks.length && (
@@ -554,6 +557,7 @@ export const App = ({
 					onComment={onComment}
 					onReply={onReply}
 					onPreview={onPreview}
+					stage={stage}
 				/>
 			)}
 		</div>

--- a/src/components/CommentForm/CommentForm.tsx
+++ b/src/components/CommentForm/CommentForm.tsx
@@ -33,6 +33,7 @@ type Props = {
 		parentCommentId: number,
 	) => Promise<CommentResponse>;
 	onPreview?: (body: string) => Promise<string>;
+	stage?: string;
 };
 
 const boldString = (text: string) => `<b>${text}</b>`;
@@ -161,6 +162,7 @@ export const CommentForm = ({
 	onComment,
 	onReply,
 	onPreview,
+	stage,
 }: Props) => {
 	const [isActive, setIsActive] = useState<boolean>(
 		commentBeingRepliedTo ? true : false,
@@ -339,14 +341,14 @@ export const CommentForm = ({
 		}
 	};
 
-	const submitUserName = async (userName: string) => {
+	const submitUserName = async (userName: string, stage?: string) => {
 		setError('');
 		if (!userName) {
 			setError('Username field cannot be empty');
 			return;
 		}
 
-		const response = await addUserName(userName);
+		const response = await addUserName(userName, stage);
 		if (response.status === 'ok') {
 			// If we are able to submit userName we should continue with submitting comment
 			submitForm();

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.tsx
@@ -18,7 +18,7 @@ type Props = {
 	body: string;
 	pillar: ArticleTheme;
 	error?: string;
-	submitForm: (userName: string) => void;
+	submitForm: (userName: string, stage?: string) => void;
 	cancelSubmit: () => void;
 	onPreview?: (body: string) => Promise<string>;
 };

--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -12,11 +12,21 @@ import {
 	AdditionalHeadersType,
 } from '../types';
 
-let options = {
+const options = {
 	// Defaults
 	baseUrl: 'https://discussion.theguardian.com/discussion-api',
 	apiKey: 'discussion-rendering',
 	headers: {},
+	idApiUrl: (stage?: string) => {
+		switch (stage) {
+			case 'DEV':
+				return `https://idapi.code.dev-theguardian.com/user/me`;
+			case 'CODE':
+				return `https://idapi.code.dev-theguardian.com/user/me`;
+			default:
+				return `https://idapi.theguardian.com/user/me`;
+		}
+	},
 };
 
 let defaultParams = {
@@ -237,22 +247,11 @@ export const recommend = (commentId: number): Promise<boolean> => {
 	}).then((resp) => resp.ok);
 };
 
-const decideIdentityApiUrl = (stage?: string): string => {
-	switch (stage) {
-		case 'DEV':
-			return `https://idapi.code.dev-theguardian.com/user/me`;
-		case 'CODE':
-			return `https://idapi.code.dev-theguardian.com/user/me`;
-		default:
-			return `https://idapi.theguardian.com/user/me`;
-	}
-};
-
 export const addUserName = (
 	userName: string,
 	stage?: string,
 ): Promise<UserNameResponse> => {
-	const url = decideIdentityApiUrl(stage) + objAsParams(defaultParams);
+	const url = options.idApiUrl(stage) + objAsParams(defaultParams);
 
 	return fetch(url, {
 		method: 'POST',

--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -237,9 +237,23 @@ export const recommend = (commentId: number): Promise<boolean> => {
 	}).then((resp) => resp.ok);
 };
 
-export const addUserName = (userName: string): Promise<UserNameResponse> => {
-	const url =
-		`https://idapi.theguardian.com/user/me` + objAsParams(defaultParams);
+const decideIdentityApiUrl = (stage?: string): string => {
+	switch (stage) {
+		case 'DEV':
+			return `https://idapi.code.dev-theguardian.com/user/me`;
+		case 'CODE':
+			return `https://idapi.code.dev-theguardian.com/user/me`;
+		default:
+			return `https://idapi.theguardian.com/user/me`;
+	}
+};
+
+export const addUserName = (
+	userName: string,
+	stage?: string,
+): Promise<UserNameResponse> => {
+	const url = decideIdentityApiUrl(stage) + objAsParams(defaultParams);
+
 	return fetch(url, {
 		method: 'POST',
 		credentials: 'include',


### PR DESCRIPTION
Co-authored-by: Georges Lebreton <georges.lebreton@guardian.co.uk>

## Context
In order to support the identity's team work on migration we need to make sure they can use the CODE environment for testing. Currently, the flow below is broken:

1. A user who does not have a discussion username set
2. Tries to make a comment
3. They're taken to the 'set username' flow
4. When they hit submit, nothing happens on the page, and the POST call to `https://idapi.theguardian.com/user/me?api-key=dotcom-rendering` fails with a CORS error

![image](https://user-images.githubusercontent.com/19683595/212668424-acd3d5d8-1796-4328-aecf-77b3e29d8c7d.png)

![image](https://user-images.githubusercontent.com/19683595/212669785-749822d3-804b-4c7a-9ec0-608d70456d47.png)

5. The payload of that call is the setting of the new username, which means the call to set a new username doesn't work 

![image](https://user-images.githubusercontent.com/19683595/212668611-00b0bd05-5645-4f7f-9893-04330c09be45.png)

## What does this change?
It decides the identity url based on the stage.

## Why?
Until now the https://idapi.theguardian.com/user/me was hard-coded and was being hit regardless of environment.
For example, currently COSE (https://m.code.dev-theguardian.com/) is hitting the PROD identity API endpoint but it is not one of the allowed domains listed [in the PROD configuration](https://github.com/guardian/identity/blob/main/identity-api/src/main/resources/PROD.conf#L11). [CODE identity api configuration](https://github.com/guardian/identity/blob/main/identity-api/src/main/resources/CODE.conf#L11) includes https://m.code.dev-theguardian.com/ in the valid guardian domains.


## Link to supporting GH issue
#677  https://github.com/guardian/dotcom-rendering/issues/6665