### PR TITLE
Discussion-rendering consumes `idApiUrl`

### DIFF
--- a/.changeset/moody-tigers-appear.md
+++ b/.changeset/moody-tigers-appear.md
@@ -1,0 +1,13 @@
+---
+'@guardian/discussion-rendering': major
+---
+
+### What
+Add required prop `idApiUrl` to the discussion App. The url is coming from CAPI and passed via DCR.
+
+### Why
+The previous version of discussion-rendering had the prod identity url hardcoded and was hitting this regardless of environment. This was causing CORS errors when trying to post a comment as `https://m.code.dev-theguardian.com/` is not one of the allowed domains to hit the prod api.
+
+### How to consume
+This change handles the consumption of `idApiUrl` by the application.
+

--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -41,6 +41,7 @@ export const LoggedOutHiddenPicks = () => (
 			expanded={false}
 			onPermalinkClick={() => {}}
 			apiKey=""
+			idApiUrl="https://idapi.theguardian.com"
 		/>
 	</div>
 );
@@ -68,6 +69,7 @@ export const InitialPage = () => (
 			expanded={true}
 			onPermalinkClick={() => {}}
 			apiKey=""
+			idApiUrl="https://idapi.theguardian.com"
 		/>
 	</div>
 );
@@ -95,6 +97,7 @@ export const Overrides = () => (
 			expanded={true}
 			onPermalinkClick={() => {}}
 			apiKey=""
+			idApiUrl="https://idapi.theguardian.com"
 		/>
 	</div>
 );
@@ -120,6 +123,7 @@ export const LoggedInHiddenNoPicks = () => (
 			expanded={false}
 			onPermalinkClick={() => {}}
 			apiKey=""
+			idApiUrl="https://idapi.theguardian.com"
 		/>
 	</div>
 );
@@ -147,6 +151,7 @@ export const LoggedIn = () => (
 			expanded={true}
 			onPermalinkClick={() => {}}
 			apiKey=""
+			idApiUrl="https://idapi.theguardian.com"
 		/>
 	</div>
 );
@@ -174,6 +179,7 @@ export const LoggedInShortDiscussion = () => (
 			expanded={true}
 			onPermalinkClick={() => {}}
 			apiKey=""
+			idApiUrl="https://idapi.theguardian.com"
 		/>
 	</div>
 );
@@ -200,6 +206,7 @@ export const LoggedOutHiddenNoPicks = () => (
 			expanded={false}
 			onPermalinkClick={() => {}}
 			apiKey=""
+			idApiUrl="https://idapi.theguardian.com"
 		/>
 	</div>
 );
@@ -227,6 +234,7 @@ export const Closed = () => (
 			expanded={true}
 			onPermalinkClick={() => {}}
 			apiKey=""
+			idApiUrl="https://idapi.theguardian.com"
 		/>
 	</div>
 );
@@ -251,6 +259,7 @@ export const NoComments = () => (
 			expanded={false}
 			onPermalinkClick={() => {}}
 			apiKey=""
+			idApiUrl="https://idapi.theguardian.com"
 		/>
 	</div>
 );
@@ -277,6 +286,7 @@ export const LegacyDiscussion = () => (
 			expanded={false}
 			onPermalinkClick={() => {}}
 			apiKey=""
+			idApiUrl="https://idapi.theguardian.com"
 		/>
 	</div>
 );

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -33,6 +33,7 @@ describe('App', () => {
 				expanded={false}
 				onPermalinkClick={() => {}}
 				apiKey=""
+				idApiUrl="https://idapi.theguardian.com"
 			/>,
 		);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ type Props = {
 	) => Promise<CommentResponse>;
 	onPreview?: (body: string) => Promise<string>;
 	onExpand?: () => void;
+	idApiUrl: string;
 };
 
 const footerStyles = css`
@@ -228,6 +229,7 @@ export const App = ({
 	onReply,
 	onPreview,
 	onExpand,
+	idApiUrl,
 }: Props) => {
 	const [filters, setFilters] = useState<FilterOptions>(
 		initialiseFilters({
@@ -390,7 +392,7 @@ export const App = ({
 		commentElement && commentElement.scrollIntoView();
 	};
 
-	initialiseApi({ additionalHeaders, baseUrl, apiKey });
+	initialiseApi({ additionalHeaders, baseUrl, apiKey, idApiUrl });
 
 	const showPagination = totalPages > 1;
 

--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -17,6 +17,7 @@ let options = {
 	baseUrl: 'https://discussion.theguardian.com/discussion-api',
 	apiKey: 'discussion-rendering',
 	headers: {},
+	idApiUrl: 'https://idapi.theguardian.com',
 };
 
 let defaultParams = {
@@ -27,14 +28,17 @@ export const initialiseApi = ({
 	baseUrl,
 	additionalHeaders,
 	apiKey,
+	idApiUrl,
 }: {
 	baseUrl: string;
 	additionalHeaders: AdditionalHeadersType;
 	apiKey: string;
+	idApiUrl: string;
 }) => {
 	options.baseUrl = baseUrl || options.baseUrl;
 	options.headers = additionalHeaders || options.headers;
 	options.apiKey = apiKey || options.apiKey;
+	options.idApiUrl = idApiUrl || options.idApiUrl;
 
 	defaultParams['api-key'] = options.apiKey;
 };
@@ -238,8 +242,8 @@ export const recommend = (commentId: number): Promise<boolean> => {
 };
 
 export const addUserName = (userName: string): Promise<UserNameResponse> => {
-	const url =
-		`https://idapi.theguardian.com/user/me` + objAsParams(defaultParams);
+	const url = options.idApiUrl + `/user/me` + objAsParams(defaultParams);
+
 	return fetch(url, {
 		method: 'POST',
 		credentials: 'include',

--- a/src/test-page.tsx
+++ b/src/test-page.tsx
@@ -104,6 +104,7 @@ const IndexPageWrapper = () => {
 					onPermalinkClick={() => {}}
 					apiKey="discussion-rendering"
 					initialPage={1}
+					idApiUrl="https://idapi.theguardian.com"
 					// page={page}
 					// onPageChange={setPage}
 				/>


### PR DESCRIPTION
Co-authored-by: Georges Lebreton <georges.lebreton@guardian.co.uk>

## Context
In order to support the identity's team work on migration we need to make sure they can use the CODE environment for testing. Currently, the flow below is broken:

1. A user who does not have a discussion username set
2. Tries to make a comment
3. They're taken to the 'set username' flow
4. When they hit submit, nothing happens on the page, and the POST call to `https://idapi.theguardian.com/user/me?api-key=dotcom-rendering` fails with a CORS error

![image](https://user-images.githubusercontent.com/19683595/212668424-acd3d5d8-1796-4328-aecf-77b3e29d8c7d.png)

![image](https://user-images.githubusercontent.com/19683595/212669785-749822d3-804b-4c7a-9ec0-608d70456d47.png)

5. The payload of that call is the setting of the new username, which means the call to set a new username doesn't work 

![image](https://user-images.githubusercontent.com/19683595/212668611-00b0bd05-5645-4f7f-9893-04330c09be45.png)

## What does this change?
Adds `idApiUrl` prop to discussion-rendering `App`. Its value will be coming from CAPI and passed to discussion-rendering [via DCR](https://github.com/guardian/dotcom-rendering/pull/6968).

## Why?
CAPI knows the correct url

| CODE | PROD |
|------|------|
| ![image](https://user-images.githubusercontent.com/19683595/212706867-53f58657-5cf0-4e13-95e3-84f806eb79df.png) | ![image](https://user-images.githubusercontent.com/19683595/212707368-576dbb72-70d8-466c-bb72-01c0f13e60eb.png) |


## Link to supporting GH issue
#677 