### PR TITLE
Cache `npm` dependencies

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -15,8 +15,10 @@ jobs:
               with:
                   # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
                   fetch-depth: 0
-            - name: Install Node
-              uses: guardian/actions-setup-node@main
+            - uses: actions/setup-node@v3
+                with:
+                  node-version-file: ".nvmrc"
+                  cache: yarn
 
             - name: Install Dependencies
               run: yarn install --frozen-lockfile

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -14,7 +14,8 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: yarn
-      - run: yarn && yarn build
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
       - uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -10,8 +10,11 @@ jobs:
           # This fetches all Git history, which is required for Chromatic
           # https://www.chromatic.com/docs/github-actions#support-for-codeactionscheckoutv2code-and-above
           fetch-depth: 0
-      - run: |
-          yarn && yarn build
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          cache: yarn
+      - run: yarn && yarn build
       - uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -12,6 +12,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version-file: ".nvmrc"
+                  cache: yarn
             - uses: preactjs/compressed-size-action@v2
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -9,5 +9,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
+          cache: yarn
       - run: yarn
       - run: CI=true yarn test

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -10,5 +10,5 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: yarn
-      - run: yarn
+      - run: yarn install --frozen-lockfile
       - run: CI=true yarn test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,5 +10,5 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: yarn
-      - run: yarn
+      - run: yarn install --frozen-lockfile
       - run: yarn lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,5 +9,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
+          cache: yarn
       - run: yarn
       - run: yarn lint

--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -9,5 +9,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
+          cache: yarn
       - run: yarn
       - run: yarn tsc

--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -10,5 +10,5 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: yarn
-      - run: yarn
+      - run: yarn install --frozen-lockfile
       - run: yarn tsc

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>discussion-rendering</title>
+    <title>@guardian/discussion-rendering</title>
 
     <style>
         body {


### PR DESCRIPTION
## What does this change?

Cache the npm dependencies using the standard GH action

## Why?

faster continuous integration workflows

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/233999982-97b4cd5c-5781-4dd9-a686-38c0390911fa.png
[after]: https://user-images.githubusercontent.com/76776/234000460-72219321-bc75-4eb4-ad72-c66765b4402c.png
