### PR TITLE
Use `.storyName` To Name Stories

### DIFF
--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -45,9 +45,7 @@ export const LoggedOutHiddenPicks = () => (
 		/>
 	</div>
 );
-LoggedOutHiddenPicks.story = {
-	name: 'when logged out, unexpanded and with picks',
-};
+LoggedOutHiddenPicks.storyName = 'when logged out, unexpanded and with picks';
 
 export const InitialPage = () => (
 	<div
@@ -73,7 +71,7 @@ export const InitialPage = () => (
 		/>
 	</div>
 );
-InitialPage.story = { name: 'with initial page set to 3' };
+InitialPage.storyName = 'with initial page set to 3';
 
 export const Overrides = () => (
 	<div
@@ -101,7 +99,7 @@ export const Overrides = () => (
 		/>
 	</div>
 );
-Overrides.story = { name: 'with page size overridden to 50' };
+Overrides.storyName = 'with page size overridden to 50';
 
 export const LoggedInHiddenNoPicks = () => (
 	<div
@@ -127,9 +125,7 @@ export const LoggedInHiddenNoPicks = () => (
 		/>
 	</div>
 );
-LoggedInHiddenNoPicks.story = {
-	name: 'when logged in, with no picks and not expanded',
-};
+LoggedInHiddenNoPicks.storyName = 'when logged in, with no picks and not expanded';
 
 export const LoggedIn = () => (
 	<div
@@ -155,9 +151,7 @@ export const LoggedIn = () => (
 		/>
 	</div>
 );
-LoggedIn.story = {
-	name: 'when logged in and expanded',
-};
+LoggedIn.storyName = 'when logged in and expanded';
 
 export const LoggedInShortDiscussion = () => (
 	<div
@@ -183,9 +177,7 @@ export const LoggedInShortDiscussion = () => (
 		/>
 	</div>
 );
-LoggedInShortDiscussion.story = {
-	name: 'when logged in but only wo comments made',
-};
+LoggedInShortDiscussion.storyName = 'when logged in but only wo comments made';
 
 export const LoggedOutHiddenNoPicks = () => (
 	<div
@@ -210,9 +202,7 @@ export const LoggedOutHiddenNoPicks = () => (
 		/>
 	</div>
 );
-LoggedOutHiddenNoPicks.story = {
-	name: 'when logged out, with no picks and not expanded',
-};
+LoggedOutHiddenNoPicks.storyName = 'when logged out, with no picks and not expanded';
 
 export const Closed = () => (
 	<div
@@ -238,7 +228,7 @@ export const Closed = () => (
 		/>
 	</div>
 );
-Closed.story = { name: 'Logged in but closed for comments' };
+Closed.storyName = 'Logged in but closed for comments';
 
 export const NoComments = () => (
 	<div
@@ -263,9 +253,7 @@ export const NoComments = () => (
 		/>
 	</div>
 );
-NoComments.story = {
-	name: 'when no comments have been made',
-};
+NoComments.storyName = 'when no comments have been made';
 
 export const LegacyDiscussion = () => (
 	<div
@@ -290,6 +278,4 @@ export const LegacyDiscussion = () => (
 		/>
 	</div>
 );
-LegacyDiscussion.story = {
-	name: "a legacy discussion that doesn't allow threading",
-};
+LegacyDiscussion.storyName = "a legacy discussion that doesn't allow threading";

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -23,7 +23,7 @@ export const Sizes = () => {
 		</>
 	);
 };
-Sizes.story = { name: 'different sizes' };
+Sizes.storyName = 'different sizes';
 
 export const NoImage = () => {
 	return (
@@ -32,4 +32,4 @@ export const NoImage = () => {
 		</>
 	);
 };
-NoImage.story = { name: 'with no image url given' };
+NoImage.storyName = 'with no image url given';

--- a/src/components/Comment/Comment.stories.tsx
+++ b/src/components/Comment/Comment.stories.tsx
@@ -147,8 +147,8 @@ export const Root = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
+Root.storyName = 'A root comment on desktop view';
 Root.story = {
-	name: 'A root comment on desktop view',
 	parameters: {
 		viewport: { defaultViewport: 'desktop' },
 		chromatic: { viewports: [1300] },
@@ -167,8 +167,8 @@ export const RootMobile = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
+RootMobile.storyName = 'A root comment on mobile view';
 RootMobile.story = {
-	name: 'A root comment on mobile view',
 	parameters: {
 		viewport: { defaultViewport: 'mobileMedium' },
 		chromatic: { viewports: [375] },
@@ -187,8 +187,8 @@ export const ReplyComment = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
+ReplyComment.storyName = 'A reply on desktop view';
 ReplyComment.story = {
-	name: 'A reply on desktop view',
 	parameters: {
 		viewport: { defaultViewport: 'desktop' },
 		chromatic: { viewports: [1300] },
@@ -207,8 +207,8 @@ export const MobileReply = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
+MobileReply.storyName = 'A reply on mobile view';
 MobileReply.story = {
-	name: 'A reply on mobile view',
 	parameters: {
 		viewport: { defaultViewport: 'mobileMedium' },
 		chromatic: { viewports: [375] },
@@ -227,8 +227,8 @@ export const LongMobileReply = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
+LongMobileReply.storyName = 'A long username reply on mobile view';
 LongMobileReply.story = {
-	name: 'A long username reply on mobile view',
 	parameters: {
 		viewport: { defaultViewport: 'mobileMedium' },
 		chromatic: { viewports: [375] },
@@ -247,8 +247,8 @@ export const LongBothMobileReply = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
+LongBothMobileReply.storyName = 'Both long usernames replying on mobile view';
 LongBothMobileReply.story = {
-	name: 'Both long usernames replying on mobile view',
 	parameters: {
 		viewport: { defaultViewport: 'mobileMedium' },
 		chromatic: { viewports: [375] },
@@ -270,7 +270,7 @@ export const PickedComment = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
-PickedComment.story = { name: 'Picked Comment' };
+PickedComment.storyName = 'Picked Comment';
 
 export const StaffUserComment = () => (
 	<Comment
@@ -284,7 +284,7 @@ export const StaffUserComment = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
-StaffUserComment.story = { name: 'Staff User Comment' };
+StaffUserComment.storyName = 'Staff User Comment';
 
 export const ContributorUserComment = () => (
 	<Comment
@@ -298,7 +298,7 @@ export const ContributorUserComment = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
-ContributorUserComment.story = { name: 'Contributor User Comment' };
+ContributorUserComment.storyName = 'Contributor User Comment';
 
 export const PickedStaffUserComment = () => (
 	<Comment
@@ -315,8 +315,8 @@ export const PickedStaffUserComment = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
+PickedStaffUserComment.storyName = 'with staff and picked badges on desktop';
 PickedStaffUserComment.story = {
-	name: 'with staff and picked badges on desktop',
 	parameters: {
 		viewport: { defaultViewport: 'desktop' },
 		chromatic: { viewports: [1300] },
@@ -338,8 +338,8 @@ export const PickedStaffUserCommentMobile = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
+PickedStaffUserCommentMobile.storyName = 'with staff and picked badges on mobile';
 PickedStaffUserCommentMobile.story = {
-	name: 'with staff and picked badges on mobile',
 	parameters: {
 		viewport: { defaultViewport: 'mobileMedium' },
 		chromatic: { viewports: [375] },
@@ -361,8 +361,8 @@ export const ContributorUserCommentDesktop = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
+ContributorUserCommentDesktop.storyName = 'with contributor and picked badges on desktop';
 ContributorUserCommentDesktop.story = {
-	name: 'with contributor and picked badges on desktop',
 	parameters: {
 		viewport: { defaultViewport: 'desktop' },
 		chromatic: { viewports: [1300] },
@@ -384,8 +384,8 @@ export const ContributorUserCommentMobile = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
+ContributorUserCommentMobile.storyName = 'with contributor and picked badges on mobile';
 ContributorUserCommentMobile.story = {
-	name: 'with contributor and picked badges on mobile',
 	parameters: {
 		viewport: { defaultViewport: 'mobileMedium' },
 		chromatic: { viewports: [375] },
@@ -405,7 +405,7 @@ export const LoggedInAsModerator = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
-LoggedInAsModerator.story = { name: 'Logged in as moderator' };
+LoggedInAsModerator.storyName = 'Logged in as moderator';
 
 export const LoggedInAsUser = () => (
 	<Comment
@@ -420,7 +420,7 @@ export const LoggedInAsUser = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
-LoggedInAsUser.story = { name: 'Logged in as normal user' };
+LoggedInAsUser.storyName = 'Logged in as normal user';
 
 export const BlockedComment = () => (
 	<Comment
@@ -434,7 +434,7 @@ export const BlockedComment = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
-BlockedComment.story = { name: 'Blocked comment' };
+BlockedComment.storyName = 'Blocked comment';
 
 export const MutedComment = () => (
 	<Comment
@@ -448,7 +448,7 @@ export const MutedComment = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
-MutedComment.story = { name: 'Muted comment' };
+MutedComment.storyName = 'Muted comment';
 
 export const ClosedForComments = () => (
 	<Comment
@@ -462,8 +462,8 @@ export const ClosedForComments = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
+ClosedForComments.storyName = 'A closed comment on desktop view';
 ClosedForComments.story = {
-	name: 'A closed comment on desktop view',
 	parameters: {
 		viewport: { defaultViewport: 'desktop' },
 		chromatic: { viewports: [1300] },

--- a/src/components/CommentContainer/CommentContainer.stories.tsx
+++ b/src/components/CommentContainer/CommentContainer.stories.tsx
@@ -187,7 +187,7 @@ export const defaultStory = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
-defaultStory.story = { name: 'default' };
+defaultStory.storyName = 'default';
 
 export const threadedComment = () => (
 	<CommentContainer
@@ -203,7 +203,7 @@ export const threadedComment = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
-threadedComment.story = { name: 'threaded' };
+threadedComment.storyName = 'threaded';
 
 export const threadedCommentWithShowMore = () => (
 	<CommentContainer
@@ -219,7 +219,7 @@ export const threadedCommentWithShowMore = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
-threadedCommentWithShowMore.story = { name: 'threaded with show more button' };
+threadedCommentWithShowMore.storyName = 'threaded with show more button';
 
 export const threadedCommentWithLongUsernames = () => (
 	<CommentContainer
@@ -235,9 +235,7 @@ export const threadedCommentWithLongUsernames = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
-threadedCommentWithLongUsernames.story = {
-	name: 'threaded with long usernames',
-};
+threadedCommentWithLongUsernames.storyName = 'threaded with long usernames';
 
 export const threadedCommentWithLongUsernamesMobile = () => (
 	<CommentContainer
@@ -253,8 +251,8 @@ export const threadedCommentWithLongUsernamesMobile = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
+threadedCommentWithLongUsernamesMobile.storyName = 'threaded with long usernames on mobile display';
 threadedCommentWithLongUsernamesMobile.story = {
-	name: 'threaded with long usernames on mobile display',
 	parameters: {
 		viewport: { defaultViewport: 'mobileMedium' },
 		chromatic: { viewports: [375] },

--- a/src/components/CommentForm/CommentForm.stories.tsx
+++ b/src/components/CommentForm/CommentForm.stories.tsx
@@ -61,7 +61,7 @@ export const Default = () => (
 		onAddComment={(comment) => {}}
 	/>
 );
-Default.story = { name: 'default' };
+Default.storyName = 'default';
 
 // This story has a mocked post endpoint that returns an error, see 97d6eab4a98917f63bc96a7ac64f7ca7
 export const Error = () => (
@@ -72,7 +72,7 @@ export const Error = () => (
 		onAddComment={(comment) => {}}
 	/>
 );
-Error.story = { name: 'form with errors' };
+Error.storyName = 'form with errors';
 
 export const Active = () => (
 	<CommentForm
@@ -83,7 +83,7 @@ export const Active = () => (
 		commentBeingRepliedTo={aComment}
 	/>
 );
-Active.story = { name: 'form is active' };
+Active.storyName = 'form is active';
 
 export const Premoderated = () => (
 	<CommentForm
@@ -100,4 +100,4 @@ export const Premoderated = () => (
 		commentBeingRepliedTo={aComment}
 	/>
 );
-Premoderated.story = { name: 'user is premoderated' };
+Premoderated.storyName = 'user is premoderated';

--- a/src/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
+++ b/src/components/CommentReplyPreview/CommentReplyPreview.stories.tsx
@@ -58,7 +58,7 @@ export const Default = () => (
 		commentBeingRepliedTo={commentBeingRepliedTo}
 	/>
 );
-Default.story = { name: 'default' };
+Default.storyName = 'default';
 
 export const SingleLinePreview = () => (
 	<div css={padding}>
@@ -72,7 +72,7 @@ export const SingleLinePreview = () => (
 		/>
 	</div>
 );
-SingleLinePreview.story = { name: 'Single line' };
+SingleLinePreview.storyName = 'Single line';
 
 export const SingleBlockPreview = () => (
 	<div css={padding}>
@@ -86,7 +86,7 @@ export const SingleBlockPreview = () => (
 		/>
 	</div>
 );
-SingleBlockPreview.story = { name: 'Single Block' };
+SingleBlockPreview.storyName = 'Single Block';
 
 export const MultiBlockPreview = () => (
 	<div css={padding}>
@@ -100,4 +100,4 @@ export const MultiBlockPreview = () => (
 		/>
 	</div>
 );
-MultiBlockPreview.story = { name: 'Multi Block' };
+MultiBlockPreview.storyName = 'Multi Block';

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -99,7 +99,7 @@ export const DropdownActive = () => (
 		<p>Hi, I'm some other content we want to overlay</p>
 	</Container>
 );
-DropdownActive.story = { name: 'Dropdown with first item active' };
+DropdownActive.storyName = 'Dropdown with first item active';
 
 export const DropdownNoActive = () => (
 	<Container>
@@ -114,11 +114,11 @@ export const DropdownNoActive = () => (
 		/>
 	</Container>
 );
-DropdownNoActive.story = { name: 'Dropdown with nothing active' };
+DropdownNoActive.storyName = 'Dropdown with nothing active';
 
 export const DropdownWithState = () => (
 	<Container>
 		<DropdownParent />
 	</Container>
 );
-DropdownWithState.story = { name: 'Dropdown with working selection' };
+DropdownWithState.storyName = 'Dropdown with working selection';

--- a/src/components/Filters/Filters.stories.tsx
+++ b/src/components/Filters/Filters.stories.tsx
@@ -24,4 +24,4 @@ export const Default = () => {
 		/>
 	);
 };
-Default.story = { name: 'default' };
+Default.storyName = 'default';

--- a/src/components/FirstCommentWelcome/FirstCommentWelcome.stories.tsx
+++ b/src/components/FirstCommentWelcome/FirstCommentWelcome.stories.tsx
@@ -12,7 +12,7 @@ export const defaultStory = () => (
 		cancelSubmit={() => {}}
 	/>
 );
-defaultStory.story = { name: 'Welcome message' };
+defaultStory.storyName = 'Welcome message';
 
 export const CommentWithError = () => (
 	<FirstCommentWelcome
@@ -23,6 +23,4 @@ export const CommentWithError = () => (
 		cancelSubmit={() => {}}
 	/>
 );
-CommentWithError.story = {
-	name: 'Welcome message with error',
-};
+CommentWithError.storyName = 'Welcome message with error';

--- a/src/components/LoadingComments/LoadingComments.stories.tsx
+++ b/src/components/LoadingComments/LoadingComments.stories.tsx
@@ -3,4 +3,4 @@ import { LoadingComments } from './LoadingComments';
 export default { component: LoadingComments, title: 'LoadingComments' };
 
 export const Default = () => <LoadingComments />;
-Default.story = { name: 'default' };
+Default.storyName = 'default';

--- a/src/components/LoadingPicks/LoadingPicks.stories.tsx
+++ b/src/components/LoadingPicks/LoadingPicks.stories.tsx
@@ -3,4 +3,4 @@ import { LoadingPicks } from './LoadingPicks';
 export default { component: LoadingPicks, title: 'LoadingPicks' };
 
 export const Default = () => <LoadingPicks />;
-Default.story = { name: 'default' };
+Default.storyName = 'default';

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -23,7 +23,7 @@ export const Default = () => {
 		/>
 	);
 };
-Default.story = { name: 'default' };
+Default.storyName = 'default';
 
 export const TwoPages = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -37,7 +37,7 @@ export const TwoPages = () => {
 		/>
 	);
 };
-TwoPages.story = { name: 'with two pages' };
+TwoPages.storyName = 'with two pages';
 
 export const WithBackground = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -51,8 +51,8 @@ export const WithBackground = () => {
 		/>
 	);
 };
+WithBackground.storyName = 'with a dark background';
 WithBackground.story = {
-	name: 'with a dark background',
 	parameters: { backgrounds: { default: 'dark' } },
 };
 
@@ -68,7 +68,7 @@ export const ThreePages = () => {
 		/>
 	);
 };
-ThreePages.story = { name: 'with three pages' };
+ThreePages.storyName = 'with three pages';
 
 export const FourPages = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -82,7 +82,7 @@ export const FourPages = () => {
 		/>
 	);
 };
-FourPages.story = { name: 'with four pages' };
+FourPages.storyName = 'with four pages';
 
 export const FivePages = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -96,7 +96,7 @@ export const FivePages = () => {
 		/>
 	);
 };
-FivePages.story = { name: 'with five pages' };
+FivePages.storyName = 'with five pages';
 
 export const SixPages = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -110,7 +110,7 @@ export const SixPages = () => {
 		/>
 	);
 };
-SixPages.story = { name: 'with six pages' };
+SixPages.storyName = 'with six pages';
 
 export const SevenPages = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -124,7 +124,7 @@ export const SevenPages = () => {
 		/>
 	);
 };
-SevenPages.story = { name: 'with seven pages' };
+SevenPages.storyName = 'with seven pages';
 
 export const TwelvePages = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -138,7 +138,7 @@ export const TwelvePages = () => {
 		/>
 	);
 };
-TwelvePages.story = { name: 'with twelve pages' };
+TwelvePages.storyName = 'with twelve pages';
 
 export const LotsOfPages = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -152,7 +152,7 @@ export const LotsOfPages = () => {
 		/>
 	);
 };
-LotsOfPages.story = { name: 'with many pages' };
+LotsOfPages.storyName = 'with many pages';
 
 export const WhenExpanded = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -166,7 +166,7 @@ export const WhenExpanded = () => {
 		/>
 	);
 };
-WhenExpanded.story = { name: 'when expanded' };
+WhenExpanded.storyName = 'when expanded';
 
 export const WhenCollapsed = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -180,7 +180,7 @@ export const WhenCollapsed = () => {
 		/>
 	);
 };
-WhenCollapsed.story = { name: 'when collapsed' };
+WhenCollapsed.storyName = 'when collapsed';
 
 export const WhenUnthreaded = () => {
 	const [page, setCurrentPage] = useState(1);
@@ -194,4 +194,4 @@ export const WhenUnthreaded = () => {
 		/>
 	);
 };
-WhenUnthreaded.story = { name: 'when unthreaded' };
+WhenUnthreaded.storyName = 'when unthreaded';

--- a/src/components/PillarButton/PillarButton.stories.tsx
+++ b/src/components/PillarButton/PillarButton.stories.tsx
@@ -71,7 +71,7 @@ export const EachPillar = () => (
 		</PillarButton>
 	</Row>
 );
-EachPillar.story = { name: 'with each pillar' };
+EachPillar.storyName = 'with each pillar';
 
 export const EachSize = () => (
 	<Row>
@@ -109,7 +109,7 @@ export const EachSize = () => (
 		</PillarButton>
 	</Row>
 );
-EachSize.story = { name: 'with each size' };
+EachSize.storyName = 'with each size';
 
 export const IconLeft = () => (
 	<PillarButton
@@ -124,7 +124,7 @@ export const IconLeft = () => (
 		Left
 	</PillarButton>
 );
-IconLeft.story = { name: 'with an icon on the left' };
+IconLeft.storyName = 'with an icon on the left';
 
 export const IconRight = () => (
 	<PillarButton
@@ -198,7 +198,7 @@ export const Secondary = () => (
 		</PillarButton>
 	</Row>
 );
-Secondary.story = { name: 'with secondary priority' };
+Secondary.storyName = 'with secondary priority';
 
 export const Subdued = () => (
 	<Row>
@@ -258,4 +258,4 @@ export const Subdued = () => (
 		</PillarButton>
 	</Row>
 );
-Subdued.story = { name: 'with subdued priority' };
+Subdued.storyName = 'with subdued priority';

--- a/src/components/Preview/Preview.stories.tsx
+++ b/src/components/Preview/Preview.stories.tsx
@@ -14,7 +14,7 @@ export const PreviewStory = () => (
 		<Preview previewHtml="<p>This is some preview text</p>" />
 	</div>
 );
-PreviewStory.story = { name: 'default' };
+PreviewStory.storyName = 'default';
 
 export const PreviewStoryLinebreaks = () => (
 	<div
@@ -26,4 +26,4 @@ export const PreviewStoryLinebreaks = () => (
 		<Preview previewHtml="<p>Hello world!<br>this is a line break </p> <p>this is two</p> <p><br>this is three</p>" />
 	</div>
 );
-PreviewStoryLinebreaks.story = { name: 'Preview comment with linebreaks' };
+PreviewStoryLinebreaks.storyName = 'Preview comment with linebreaks';

--- a/src/components/Timestamp/Timestamp.stories.tsx
+++ b/src/components/Timestamp/Timestamp.stories.tsx
@@ -12,7 +12,7 @@ export const TwoMonths = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
-TwoMonths.story = { name: 'Two months' };
+TwoMonths.storyName = 'Two months';
 
 export const OneHour = () => (
 	<Timestamp
@@ -22,7 +22,7 @@ export const OneHour = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
-OneHour.story = { name: 'One Hour' };
+OneHour.storyName = 'One Hour';
 
 export const TwentyThreeHours = () => (
 	<Timestamp
@@ -32,7 +32,7 @@ export const TwentyThreeHours = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
-TwentyThreeHours.story = { name: 'Twenty three hours' };
+TwentyThreeHours.storyName = 'Twenty three hours';
 
 export const TwentyFiveHours = () => (
 	<Timestamp
@@ -42,4 +42,4 @@ export const TwentyFiveHours = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
-TwentyFiveHours.story = { name: 'Twenty five hours' };
+TwentyFiveHours.storyName = 'Twenty five hours';

--- a/src/components/TopPick/TopPick.stories.tsx
+++ b/src/components/TopPick/TopPick.stories.tsx
@@ -89,7 +89,7 @@ export const LongPick = () => (
 		/>
 	</div>
 );
-LongPick.story = { name: 'Long - Staff' };
+LongPick.storyName = 'Long - Staff';
 
 export const ShortPick = () => (
 	<div
@@ -107,7 +107,7 @@ export const ShortPick = () => (
 		/>
 	</div>
 );
-ShortPick.story = { name: 'Short - Staff' };
+ShortPick.storyName = 'Short - Staff';
 
 export const LongPickContributor = () => (
 	<div
@@ -125,7 +125,7 @@ export const LongPickContributor = () => (
 		/>
 	</div>
 );
-LongPickContributor.story = { name: 'Long - Contributor' };
+LongPickContributor.storyName = 'Long - Contributor';
 
 export const ShortPickContributor = () => (
 	<div
@@ -143,4 +143,4 @@ export const ShortPickContributor = () => (
 		/>
 	</div>
 );
-ShortPickContributor.story = { name: 'Short - Contributor' };
+ShortPickContributor.storyName = 'Short - Contributor';

--- a/src/components/TopPicks/TopPicks.stories.tsx
+++ b/src/components/TopPicks/TopPicks.stories.tsx
@@ -60,7 +60,7 @@ export const SingleComment = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
-SingleComment.story = { name: 'Single Comment' };
+SingleComment.storyName = 'Single Comment';
 
 export const MulitColumn = () => (
 	<TopPicks
@@ -75,7 +75,7 @@ export const MulitColumn = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
-MulitColumn.story = { name: 'Mulitple Columns Comments' };
+MulitColumn.storyName = 'Mulitple Columns Comments';
 
 export const SingleColumn = () => (
 	<TopPicks
@@ -90,8 +90,8 @@ export const SingleColumn = () => (
 		onPermalinkClick={() => {}}
 	/>
 );
+SingleColumn.storyName = 'Single Column Comments';
 SingleColumn.story = {
-	name: 'Single Column Comments',
 	parameters: {
 		viewport: { defaultViewport: 'phablet' },
 	},


### PR DESCRIPTION
## Why?

This switches from `.story.name` to `.storyName` as the way to name stories. The previous way doesn't match the documentation[^1] and doesn't seem to work in storybook 7; therefore this is a pre-requisite for https://github.com/guardian/dotcom-rendering/issues/7504.

Similar to these DCR PRs: https://github.com/guardian/dotcom-rendering/pull/7560 https://github.com/guardian/dotcom-rendering/pull/7591

## Changes

- Replaced usages of `.story.name` with `.storyName` across most stories

[^1]: https://storybook.js.org/docs/6.5/react/writing-stories/introduction#snippet-button-story-rename-story
